### PR TITLE
fix(mirror): warn on JSONL parse errors instead of silently swallowing them

### DIFF
--- a/apps/mirror/src/advice.rs
+++ b/apps/mirror/src/advice.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 use refine_core::infra::LlmClient;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::warn;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CachedAdvice {
@@ -16,8 +17,21 @@ pub struct CachedAdvice {
 
 pub fn load_cached() -> Option<CachedAdvice> {
     let path = crate::config::mirror_dir().join("advice.json");
-    let content = std::fs::read_to_string(&path).ok()?;
-    let cached: CachedAdvice = serde_json::from_str(&content).ok()?;
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            warn!("failed to read advice.json: {}", e);
+            return None;
+        }
+    };
+    let cached: CachedAdvice = match serde_json::from_str(&content) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("failed to parse advice.json: {}", e);
+            return None;
+        }
+    };
     let age = Utc::now() - cached.generated_at;
     if age.num_hours() < 72 {
         Some(cached)
@@ -124,10 +138,7 @@ fn system_prompt() -> &'static str {
 }
 
 /// Generate advice via LLM (single attempt, best-effort) and cache result
-pub async fn generate_and_cache(
-    score: &ScoreResult,
-    llm: &Arc<dyn LlmClient>,
-) -> Result<String> {
+pub async fn generate_and_cache(score: &ScoreResult, llm: &Arc<dyn LlmClient>) -> Result<String> {
     let prompt = build_prompt(score);
     let response = llm
         .complete(&prompt, Some(system_prompt()))
@@ -137,8 +148,16 @@ pub async fn generate_and_cache(
 
     // Parse JSON response: {"short": "...", "full": "..."}
     let (short, full) = if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&raw) {
-        let s = parsed.get("short").and_then(|v| v.as_str()).unwrap_or("").to_string();
-        let f = parsed.get("full").and_then(|v| v.as_str()).unwrap_or(&raw).to_string();
+        let s = parsed
+            .get("short")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let f = parsed
+            .get("full")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&raw)
+            .to_string();
         (s, f)
     } else {
         // Fallback: LLM didn't return JSON, use first 15 chars as short

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -7,6 +7,7 @@ use refine_core::session::{cluster_observations, ClusterResult, GlobalStats};
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, Write};
 use std::sync::Arc;
+use tracing::warn;
 
 /// Filter items to only those created since the given date string (YYYY-MM-DD).
 /// If `since` is None, returns all items unchanged.
@@ -565,13 +566,23 @@ pub fn load_recent_scores(n: usize) -> Result<Vec<ScoreResult>> {
     let path = mirror_dir().join("scores.jsonl");
     let file = match std::fs::File::open(&path) {
         Ok(f) => f,
-        Err(_) => return Ok(Vec::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            warn!("failed to open scores.jsonl: {}", e);
+            return Ok(Vec::new());
+        }
     };
     let reader = std::io::BufReader::new(file);
     let all: Vec<ScoreResult> = reader
         .lines()
         .map_while(|line| line.ok())
-        .filter_map(|line| serde_json::from_str(&line).ok())
+        .filter_map(|line| match serde_json::from_str(&line) {
+            Ok(r) => Some(r),
+            Err(e) => {
+                warn!("failed to parse score record: {}", e);
+                None
+            }
+        })
         .collect();
     let start = all.len().saturating_sub(n);
     Ok(all[start..].to_vec())

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -9,6 +9,7 @@ use refine_core::session::cluster_observations;
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, Write};
 use std::sync::Arc;
+use tracing::warn;
 
 const MAX_RETRIES: usize = 5;
 const RETRY_BASE_DELAY_SECS: u64 = 10;
@@ -147,11 +148,7 @@ pub fn build_weekly_prompt(
         parts.push(format!("- {}", format_layer(layer)));
     }
     if let Some(tension) = &this.tension {
-        parts.push(format!(
-            "\n{}: {}",
-            t!("Tension", "张力"),
-            tension
-        ));
+        parts.push(format!("\n{}: {}", t!("Tension", "张力"), tension));
     }
 
     if let Some(last) = last {
@@ -203,12 +200,25 @@ pub fn build_weekly_prompt(
 
 fn load_last_weekly_record() -> Option<WeeklyRecord> {
     let path = mirror_dir().join("weekly-history.jsonl");
-    let file = std::fs::File::open(&path).ok()?;
+    let file = match std::fs::File::open(&path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            warn!("failed to open weekly-history.jsonl: {}", e);
+            return None;
+        }
+    };
     let reader = std::io::BufReader::new(file);
     reader
         .lines()
         .map_while(|l| l.ok())
-        .filter_map(|l| serde_json::from_str::<WeeklyRecord>(&l).ok())
+        .filter_map(|l| match serde_json::from_str::<WeeklyRecord>(&l) {
+            Ok(record) => Some(record),
+            Err(e) => {
+                warn!("failed to parse weekly record: {}", e);
+                None
+            }
+        })
         .last()
 }
 
@@ -246,7 +256,9 @@ fn extract_suggestions(report: &str) -> Vec<String> {
             if is_list_item {
                 // Strip leading bullet/number markers
                 let content = trimmed
-                    .trim_start_matches(|c: char| c == '-' || c == '*' || c.is_ascii_digit() || c == '.' || c == ')')
+                    .trim_start_matches(|c: char| {
+                        c == '-' || c == '*' || c.is_ascii_digit() || c == '.' || c == ')'
+                    })
                     .trim();
                 if !content.is_empty() {
                     suggestions.push(content.to_string());
@@ -309,11 +321,7 @@ async fn save_to_document(doc_repo: &Arc<dyn DocumentRepository>, report: &str) 
     Ok(())
 }
 
-async fn llm_with_retry(
-    client: &Arc<dyn LlmClient>,
-    prompt: &str,
-    system: &str,
-) -> Result<String> {
+async fn llm_with_retry(client: &Arc<dyn LlmClient>, prompt: &str, system: &str) -> Result<String> {
     let mut last_err = String::new();
     for attempt in 0..MAX_RETRIES {
         match client.complete(prompt, Some(system)).await {
@@ -334,7 +342,12 @@ async fn llm_with_retry(
                 eprintln!(
                     "  {}",
                     t!(
-                        format!("Retry ({}/{}) waiting {}s...", attempt + 1, MAX_RETRIES, delay),
+                        format!(
+                            "Retry ({}/{}) waiting {}s...",
+                            attempt + 1,
+                            MAX_RETRIES,
+                            delay
+                        ),
                         format!("重试 ({}/{}) 等待 {}s...", attempt + 1, MAX_RETRIES, delay)
                     )
                 );


### PR DESCRIPTION
## Summary
- Add `tracing::warn!` for JSON parse failures in `load_recent_scores`, `load_last_weekly_record`, and `load_cached`
- Distinguish `NotFound` from other file I/O errors so unexpected failures are visible
- Corrupted/malformed JSONL lines now emit a warning instead of being silently dropped

Fixes #2