### PR TITLE
fix(mirror): divide personal baseline avg by match count not total entries

### DIFF
--- a/apps/cli/src/insights.rs
+++ b/apps/cli/src/insights.rs
@@ -4,8 +4,8 @@ use anyhow::{Context, Result};
 use refine_core::infra::LlmClient;
 use refine_core::knowledge::{Document, DocumentRepository, ItemRepository, ItemType};
 use refine_core::session::{
-    build_final_prompt, cluster_observations, merge_route_results, plan_routes,
-    RouteResult, INSIGHTS_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT,
+    build_final_prompt, cluster_observations, merge_route_results, plan_routes, RouteResult,
+    INSIGHTS_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT,
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -16,6 +16,7 @@ const MAX_RETRIES: usize = 5;
 const RETRY_BASE_DELAY_SECS: u64 = 10;
 
 pub struct InsightsOptions {
+    #[allow(dead_code)]
     pub period: Option<usize>,
     pub with_prescription: bool,
 }
@@ -93,7 +94,10 @@ pub async fn handle_insights(
         }
     }
 
-    println!("\n{} 路分析完成，合并生成最终报告...\n", route_results.len());
+    println!(
+        "\n{} 路分析完成，合并生成最终报告...\n",
+        route_results.len()
+    );
 
     // Step 4: 合并 + 最终报告
     let combined = merge_route_results(&route_results);
@@ -120,11 +124,7 @@ pub async fn handle_insights(
     Ok(())
 }
 
-async fn llm_with_retry(
-    client: &Arc<dyn LlmClient>,
-    prompt: &str,
-    system: &str,
-) -> Result<String> {
+async fn llm_with_retry(client: &Arc<dyn LlmClient>, prompt: &str, system: &str) -> Result<String> {
     let mut last_err = String::new();
     for attempt in 0..MAX_RETRIES {
         match client.complete(prompt, Some(system)).await {
@@ -153,5 +153,9 @@ async fn llm_with_retry(
             }
         }
     }
-    Err(anyhow::anyhow!("LLM 调用失败 ({}次重试): {}", MAX_RETRIES, last_err))
+    Err(anyhow::anyhow!(
+        "LLM 调用失败 ({}次重试): {}",
+        MAX_RETRIES,
+        last_err
+    ))
 }

--- a/apps/mirror/src/advice.rs
+++ b/apps/mirror/src/advice.rs
@@ -16,8 +16,21 @@ pub struct CachedAdvice {
 
 pub fn load_cached() -> Option<CachedAdvice> {
     let path = crate::config::mirror_dir().join("advice.json");
-    let content = std::fs::read_to_string(&path).ok()?;
-    let cached: CachedAdvice = serde_json::from_str(&content).ok()?;
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!("load_cached: failed to read {:?}: {}", path, e);
+            return None;
+        }
+    };
+    let cached: CachedAdvice = match serde_json::from_str(&content) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("load_cached: JSON parse error in {:?}: {}", path, e);
+            return None;
+        }
+    };
     let age = Utc::now() - cached.generated_at;
     if age.num_hours() < 72 {
         Some(cached)
@@ -124,10 +137,7 @@ fn system_prompt() -> &'static str {
 }
 
 /// Generate advice via LLM (single attempt, best-effort) and cache result
-pub async fn generate_and_cache(
-    score: &ScoreResult,
-    llm: &Arc<dyn LlmClient>,
-) -> Result<String> {
+pub async fn generate_and_cache(score: &ScoreResult, llm: &Arc<dyn LlmClient>) -> Result<String> {
     let prompt = build_prompt(score);
     let response = llm
         .complete(&prompt, Some(system_prompt()))
@@ -137,8 +147,16 @@ pub async fn generate_and_cache(
 
     // Parse JSON response: {"short": "...", "full": "..."}
     let (short, full) = if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&raw) {
-        let s = parsed.get("short").and_then(|v| v.as_str()).unwrap_or("").to_string();
-        let f = parsed.get("full").and_then(|v| v.as_str()).unwrap_or(&raw).to_string();
+        let s = parsed
+            .get("short")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let f = parsed
+            .get("full")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&raw)
+            .to_string();
         (s, f)
     } else {
         // Fallback: LLM didn't return JSON, use first 15 chars as short

--- a/apps/mirror/src/config.rs
+++ b/apps/mirror/src/config.rs
@@ -87,11 +87,21 @@ pub fn ensure_mirror_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// 加载配置，不存在则用默认值
+/// 加载配置，不存在则用默认值；解析失败时警告并使用默认值
 pub fn load() -> MirrorConfig {
     let path = mirror_dir().join("config.toml");
     match std::fs::read_to_string(&path) {
-        Ok(content) => toml::from_str(&content).unwrap_or_default(),
+        Ok(content) => match toml::from_str(&content) {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!(
+                    "[mirror] 警告: {} 解析失败，使用默认配置。错误: {}",
+                    path.display(),
+                    e
+                );
+                MirrorConfig::default()
+            }
+        },
         Err(_) => MirrorConfig::default(),
     }
 }
@@ -113,6 +123,14 @@ mod tests {
     fn load_missing_file_returns_default() {
         let config = load();
         assert!((config.targets.dreyfus_green - 3.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn invalid_toml_falls_back_to_default() {
+        let bad_toml = "[targets]\ndreyfus_green = \"not_a_number\"";
+        let result: Result<MirrorConfig, _> = toml::from_str(bad_toml);
+        assert!(result.is_err(), "invalid TOML should produce a parse error");
+        // load() would warn + return default in this case
     }
 
     #[test]

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -733,14 +733,29 @@ pub fn load_recent_scores(n: usize) -> Result<Vec<ScoreResult>> {
     let path = mirror_dir().join("scores.jsonl");
     let file = match std::fs::File::open(&path) {
         Ok(f) => f,
-        Err(_) => return Ok(Vec::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            tracing::warn!("load_recent_scores: failed to open {:?}: {}", path, e);
+            return Ok(Vec::new());
+        }
     };
     let reader = std::io::BufReader::new(file);
-    let all: Vec<ScoreResult> = reader
-        .lines()
-        .map_while(|line| line.ok())
-        .filter_map(|line| serde_json::from_str(&line).ok())
-        .collect();
+    let mut all: Vec<ScoreResult> = Vec::new();
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!("load_recent_scores: IO error reading line: {}", e);
+                break;
+            }
+        };
+        match serde_json::from_str::<ScoreResult>(&line) {
+            Ok(score) => all.push(score),
+            Err(e) => {
+                tracing::warn!("load_recent_scores: JSON parse error: {}", e);
+            }
+        }
+    }
     let start = all.len().saturating_sub(n);
     Ok(all[start..].to_vec())
 }

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -138,14 +138,13 @@ pub fn compute_personal_baseline(history: &[ScoreResult]) -> Option<PersonalBase
         return None;
     }
 
-    let n = recent.len() as f64;
-
     let avg = |name: &str| -> f64 {
-        let sum: f64 = recent
-            .iter()
-            .filter_map(|s| extract_indicator(s, name))
-            .sum();
-        sum / n
+        let values: Vec<f64> = recent.iter().filter_map(|s| extract_indicator(s, name)).collect();
+        let count = values.len() as f64;
+        if count == 0.0 {
+            return 0.0;
+        }
+        values.iter().sum::<f64>() / count
     };
 
     Some(PersonalBaseline {
@@ -1044,6 +1043,68 @@ mod tests {
 
         let baseline = compute_personal_baseline(&history);
         assert!(baseline.is_none(), "should return None when all data is outside 28-day window");
+    }
+
+    #[test]
+    fn test_personal_baseline_mixed_schema() {
+        // Regression: old schema entries lack knowledge_rate/friction_density.
+        // avg must divide by match count, not total entry count.
+        let now = Utc::now();
+
+        // 7 new-schema entries: knowledge_rate=0.6, friction_density=1.2
+        let new_schema: Vec<ScoreResult> = (0..7)
+            .map(|i| {
+                make_score_result(3.0, 50.0, 10.0, 0.6, 20.0, 25.0, 15.0, 30.0, 4.0, 0.20, 1.2, now - Duration::days(i))
+            })
+            .collect();
+
+        // 3 old-schema entries: no knowledge_rate or friction_density
+        let old_schema: Vec<ScoreResult> = (7..10)
+            .map(|i| ScoreResult {
+                layers: [
+                    LayerScore {
+                        name: "depth".into(),
+                        signal: Signal::Yellow,
+                        indicators: vec![
+                            Indicator { name: "dreyfus".into(), actual: 3.0, target: String::new(), signal: Signal::Yellow },
+                            Indicator { name: "decision_quality".into(), actual: 50.0, target: String::new(), signal: Signal::Yellow },
+                            Indicator { name: "depth_output".into(), actual: 10.0, target: String::new(), signal: Signal::Yellow },
+                        ],
+                    },
+                    LayerScore {
+                        name: "breadth".into(),
+                        signal: Signal::Yellow,
+                        indicators: vec![
+                            Indicator { name: "exploration".into(), actual: 20.0, target: String::new(), signal: Signal::Yellow },
+                            Indicator { name: "deep_invest".into(), actual: 25.0, target: String::new(), signal: Signal::Yellow },
+                            Indicator { name: "fragmentation".into(), actual: 15.0, target: String::new(), signal: Signal::Yellow },
+                        ],
+                    },
+                    LayerScore {
+                        name: "collaboration".into(),
+                        signal: Signal::Yellow,
+                        indicators: vec![
+                            Indicator { name: "delegation".into(), actual: 30.0, target: String::new(), signal: Signal::Yellow },
+                            Indicator { name: "mode_diversity".into(), actual: 4.0, target: String::new(), signal: Signal::Yellow },
+                            Indicator { name: "bug_decision".into(), actual: 0.20, target: String::new(), signal: Signal::Yellow },
+                        ],
+                    },
+                ],
+                tension: None,
+                timestamp: now - Duration::days(i),
+            })
+            .collect();
+
+        let history: Vec<ScoreResult> = new_schema.into_iter().chain(old_schema).collect();
+        let baseline = compute_personal_baseline(&history);
+        assert!(baseline.is_some(), "should produce baseline with 10 mixed-schema entries");
+        let Some(baseline) = baseline else { return; };
+
+        // Must be 0.6 (avg of 7 matches), not 0.42 (0.6*7/10 with old divisor bug)
+        assert!((baseline.knowledge_rate_avg - 0.6).abs() < f64::EPSILON,
+            "knowledge_rate_avg should be 0.6, got {}", baseline.knowledge_rate_avg);
+        assert!((baseline.friction_density_avg - 1.2).abs() < f64::EPSILON,
+            "friction_density_avg should be 1.2, got {}", baseline.friction_density_avg);
     }
 
     #[test]

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -20,12 +20,15 @@ pub fn filter_since(items: Vec<Item>, since: &Option<String>) -> Result<Vec<Item
         .and_hms_opt(0, 0, 0)
         .ok_or_else(|| anyhow::anyhow!("invalid date"))?
         .and_utc();
-    Ok(items.into_iter().filter(|i| i.created_at() >= cutoff).collect())
+    Ok(items
+        .into_iter()
+        .filter(|i| i.created_at() >= cutoff)
+        .collect())
 }
 
 const DECISION_KEYWORDS: &[&str] = &[
-    "因为", "因", "原因", "选择", "采用",
-    "because", "reason", "chose", "chosen", "adopted", "selected",
+    "因为", "因", "原因", "选择", "采用", "because", "reason", "chose", "chosen", "adopted",
+    "selected",
 ];
 
 /// Minimum number of historical scores to activate personal baseline
@@ -129,17 +132,17 @@ fn extract_indicator(result: &ScoreResult, name: &str) -> Option<f64> {
 /// Returns None if fewer than BASELINE_MIN_ENTRIES scores exist in that window.
 pub fn compute_personal_baseline(history: &[ScoreResult]) -> Option<PersonalBaseline> {
     let cutoff = Utc::now() - Duration::days(BASELINE_WINDOW_DAYS);
-    let recent: Vec<&ScoreResult> = history
-        .iter()
-        .filter(|s| s.timestamp >= cutoff)
-        .collect();
+    let recent: Vec<&ScoreResult> = history.iter().filter(|s| s.timestamp >= cutoff).collect();
 
     if recent.len() < BASELINE_MIN_ENTRIES {
         return None;
     }
 
     let avg = |name: &str| -> f64 {
-        let values: Vec<f64> = recent.iter().filter_map(|s| extract_indicator(s, name)).collect();
+        let values: Vec<f64> = recent
+            .iter()
+            .filter_map(|s| extract_indicator(s, name))
+            .collect();
         let count = values.len() as f64;
         if count == 0.0 {
             return 0.0;
@@ -200,24 +203,71 @@ struct IndicatorMeta {
 /// Apply personal baseline to override signals on a ScoreResult (in-place).
 fn apply_personal_baseline(result: &mut ScoreResult, baseline: &PersonalBaseline) {
     let metas = [
-        IndicatorMeta { name: "dreyfus", baseline_value: baseline.dreyfus_avg, higher_is_better: true },
-        IndicatorMeta { name: "decision_quality", baseline_value: baseline.decision_quality_avg, higher_is_better: true },
-        IndicatorMeta { name: "depth_output", baseline_value: baseline.depth_output_avg, higher_is_better: true },
-        IndicatorMeta { name: "exploration", baseline_value: baseline.exploration_avg, higher_is_better: true },
-        IndicatorMeta { name: "deep_invest", baseline_value: baseline.deep_invest_avg, higher_is_better: true },
-        IndicatorMeta { name: "fragmentation", baseline_value: baseline.fragmentation_avg, higher_is_better: false },
-        IndicatorMeta { name: "delegation", baseline_value: baseline.delegation_avg, higher_is_better: false },
-        IndicatorMeta { name: "mode_diversity", baseline_value: baseline.mode_diversity_avg, higher_is_better: true },
-        IndicatorMeta { name: "bug_decision", baseline_value: baseline.bug_decision_avg, higher_is_better: false },
-        IndicatorMeta { name: "knowledge_rate", baseline_value: baseline.knowledge_rate_avg, higher_is_better: true },
-        IndicatorMeta { name: "friction_density", baseline_value: baseline.friction_density_avg, higher_is_better: false },
+        IndicatorMeta {
+            name: "dreyfus",
+            baseline_value: baseline.dreyfus_avg,
+            higher_is_better: true,
+        },
+        IndicatorMeta {
+            name: "decision_quality",
+            baseline_value: baseline.decision_quality_avg,
+            higher_is_better: true,
+        },
+        IndicatorMeta {
+            name: "depth_output",
+            baseline_value: baseline.depth_output_avg,
+            higher_is_better: true,
+        },
+        IndicatorMeta {
+            name: "exploration",
+            baseline_value: baseline.exploration_avg,
+            higher_is_better: true,
+        },
+        IndicatorMeta {
+            name: "deep_invest",
+            baseline_value: baseline.deep_invest_avg,
+            higher_is_better: true,
+        },
+        IndicatorMeta {
+            name: "fragmentation",
+            baseline_value: baseline.fragmentation_avg,
+            higher_is_better: false,
+        },
+        IndicatorMeta {
+            name: "delegation",
+            baseline_value: baseline.delegation_avg,
+            higher_is_better: false,
+        },
+        IndicatorMeta {
+            name: "mode_diversity",
+            baseline_value: baseline.mode_diversity_avg,
+            higher_is_better: true,
+        },
+        IndicatorMeta {
+            name: "bug_decision",
+            baseline_value: baseline.bug_decision_avg,
+            higher_is_better: false,
+        },
+        IndicatorMeta {
+            name: "knowledge_rate",
+            baseline_value: baseline.knowledge_rate_avg,
+            higher_is_better: true,
+        },
+        IndicatorMeta {
+            name: "friction_density",
+            baseline_value: baseline.friction_density_avg,
+            higher_is_better: false,
+        },
     ];
 
     for layer in &mut result.layers {
         for indicator in &mut layer.indicators {
             if let Some(meta) = metas.iter().find(|m| m.name == indicator.name) {
-                indicator.signal =
-                    signal_from_personal(indicator.actual, meta.baseline_value, meta.higher_is_better);
+                indicator.signal = signal_from_personal(
+                    indicator.actual,
+                    meta.baseline_value,
+                    meta.higher_is_better,
+                );
             }
         }
         // Recalculate layer signal as worst of its indicators
@@ -246,7 +296,11 @@ fn dreyfus_weighted(stats: &GlobalStats) -> f64 {
         sum += n as f64 * w;
         count += n;
     }
-    if count == 0 { 0.0 } else { sum / count as f64 }
+    if count == 0 {
+        0.0
+    } else {
+        sum / count as f64
+    }
 }
 
 fn decision_quality_rate(cluster: &ClusterResult) -> f64 {
@@ -294,7 +348,11 @@ fn knowledge_rate(cluster: &ClusterResult) -> f64 {
         .map(|p| p.knowledge_gained.len())
         .sum();
     let total_sessions = cluster.global_stats.total_sessions;
-    if total_sessions == 0 { 0.0 } else { total_knowledge as f64 / total_sessions as f64 }
+    if total_sessions == 0 {
+        0.0
+    } else {
+        total_knowledge as f64 / total_sessions as f64
+    }
 }
 
 fn layer1(cluster: &ClusterResult, t: &Targets) -> LayerScore {
@@ -333,10 +391,30 @@ fn layer1(cluster: &ClusterResult, t: &Targets) -> LayerScore {
     };
 
     let indicators = vec![
-        Indicator { name: "dreyfus".into(), actual: dw, target: format!(">{}", t.dreyfus_green), signal: sig_dw },
-        Indicator { name: "decision_quality".into(), actual: dq * 100.0, target: format!(">{}%", (t.decision_quality_green * 100.0) as u32), signal: sig_dq },
-        Indicator { name: "depth_output".into(), actual: dor * 100.0, target: format!(">{}%", (t.depth_output_green * 100.0) as u32), signal: sig_dor },
-        Indicator { name: "knowledge_rate".into(), actual: kr, target: format!(">{:.1}", t.knowledge_green), signal: sig_kr },
+        Indicator {
+            name: "dreyfus".into(),
+            actual: dw,
+            target: format!(">{}", t.dreyfus_green),
+            signal: sig_dw,
+        },
+        Indicator {
+            name: "decision_quality".into(),
+            actual: dq * 100.0,
+            target: format!(">{}%", (t.decision_quality_green * 100.0) as u32),
+            signal: sig_dq,
+        },
+        Indicator {
+            name: "depth_output".into(),
+            actual: dor * 100.0,
+            target: format!(">{}%", (t.depth_output_green * 100.0) as u32),
+            signal: sig_dor,
+        },
+        Indicator {
+            name: "knowledge_rate".into(),
+            actual: kr,
+            target: format!(">{:.1}", t.knowledge_green),
+            signal: sig_kr,
+        },
     ];
 
     LayerScore {
@@ -350,14 +428,38 @@ fn layer1(cluster: &ClusterResult, t: &Targets) -> LayerScore {
 
 fn layer2(cluster: &ClusterResult, t: &Targets) -> LayerScore {
     let collab_total: usize = cluster.global_stats.collaboration_modes.values().sum();
-    let exploration = *cluster.global_stats.collaboration_modes.get("exploration").unwrap_or(&0);
-    let exploration_rate = if collab_total == 0 { 0.0 } else { exploration as f64 / collab_total as f64 };
+    let exploration = *cluster
+        .global_stats
+        .collaboration_modes
+        .get("exploration")
+        .unwrap_or(&0);
+    let exploration_rate = if collab_total == 0 {
+        0.0
+    } else {
+        exploration as f64 / collab_total as f64
+    };
 
     let total_projects = cluster.projects.len();
-    let deep_projects = cluster.projects.values().filter(|p| p.session_count >= 20).count();
-    let frag_projects = cluster.projects.values().filter(|p| p.session_count == 1).count();
-    let deep_rate = if total_projects == 0 { 0.0 } else { deep_projects as f64 / total_projects as f64 };
-    let frag_rate = if total_projects == 0 { 0.0 } else { frag_projects as f64 / total_projects as f64 };
+    let deep_projects = cluster
+        .projects
+        .values()
+        .filter(|p| p.session_count >= 20)
+        .count();
+    let frag_projects = cluster
+        .projects
+        .values()
+        .filter(|p| p.session_count == 1)
+        .count();
+    let deep_rate = if total_projects == 0 {
+        0.0
+    } else {
+        deep_projects as f64 / total_projects as f64
+    };
+    let frag_rate = if total_projects == 0 {
+        0.0
+    } else {
+        frag_projects as f64 / total_projects as f64
+    };
 
     let sig_exp = if exploration_rate > t.exploration_green {
         Signal::Green
@@ -382,9 +484,28 @@ fn layer2(cluster: &ClusterResult, t: &Targets) -> LayerScore {
     };
 
     let indicators = vec![
-        Indicator { name: "exploration".into(), actual: exploration_rate * 100.0, target: format!(">{}%", (t.exploration_green * 100.0) as u32), signal: sig_exp },
-        Indicator { name: "deep_invest".into(), actual: deep_rate * 100.0, target: format!("{}-{}%", (t.deep_invest_green_lo * 100.0) as u32, (t.deep_invest_green_hi * 100.0) as u32), signal: sig_deep },
-        Indicator { name: "fragmentation".into(), actual: frag_rate * 100.0, target: format!("<{}%", (t.fragmentation_green * 100.0) as u32), signal: sig_frag },
+        Indicator {
+            name: "exploration".into(),
+            actual: exploration_rate * 100.0,
+            target: format!(">{}%", (t.exploration_green * 100.0) as u32),
+            signal: sig_exp,
+        },
+        Indicator {
+            name: "deep_invest".into(),
+            actual: deep_rate * 100.0,
+            target: format!(
+                "{}-{}%",
+                (t.deep_invest_green_lo * 100.0) as u32,
+                (t.deep_invest_green_hi * 100.0) as u32
+            ),
+            signal: sig_deep,
+        },
+        Indicator {
+            name: "fragmentation".into(),
+            actual: frag_rate * 100.0,
+            target: format!("<{}%", (t.fragmentation_green * 100.0) as u32),
+            signal: sig_frag,
+        },
     ];
 
     LayerScore {
@@ -397,21 +518,34 @@ fn layer2(cluster: &ClusterResult, t: &Targets) -> LayerScore {
 // ── Layer 3: Collaboration ──
 
 fn friction_density(cluster: &ClusterResult) -> f64 {
-    let total_frictions: usize = cluster
-        .projects
-        .values()
-        .map(|p| p.frictions.len())
-        .sum();
+    let total_frictions: usize = cluster.projects.values().map(|p| p.frictions.len()).sum();
     let total_sessions = cluster.global_stats.total_sessions;
-    if total_sessions == 0 { 0.0 } else { total_frictions as f64 / total_sessions as f64 }
+    if total_sessions == 0 {
+        0.0
+    } else {
+        total_frictions as f64 / total_sessions as f64
+    }
 }
 
 fn layer3(cluster: &ClusterResult, t: &Targets) -> LayerScore {
     let collab_total: usize = cluster.global_stats.collaboration_modes.values().sum();
-    let delegation = *cluster.global_stats.collaboration_modes.get("delegation").unwrap_or(&0);
-    let delegation_rate = if collab_total == 0 { 0.0 } else { delegation as f64 / collab_total as f64 };
+    let delegation = *cluster
+        .global_stats
+        .collaboration_modes
+        .get("delegation")
+        .unwrap_or(&0);
+    let delegation_rate = if collab_total == 0 {
+        0.0
+    } else {
+        delegation as f64 / collab_total as f64
+    };
 
-    let mode_count = cluster.global_stats.collaboration_modes.values().filter(|&&v| v > 0).count();
+    let mode_count = cluster
+        .global_stats
+        .collaboration_modes
+        .values()
+        .filter(|&&v| v > 0)
+        .count();
 
     let bug_dec_ratio = if cluster.global_stats.total_decisions == 0 {
         0.0
@@ -452,10 +586,30 @@ fn layer3(cluster: &ClusterResult, t: &Targets) -> LayerScore {
     };
 
     let indicators = vec![
-        Indicator { name: "delegation".into(), actual: delegation_rate * 100.0, target: format!("<{}%", (t.delegation_green * 100.0) as u32), signal: sig_del },
-        Indicator { name: "mode_diversity".into(), actual: mode_count as f64, target: format!(">={}", t.mode_diversity_green), signal: sig_div },
-        Indicator { name: "bug_decision".into(), actual: bug_dec_ratio, target: format!("<{}", t.bug_decision_green), signal: sig_bug },
-        Indicator { name: "friction_density".into(), actual: fd, target: format!("<{:.1}", t.friction_green), signal: sig_fd },
+        Indicator {
+            name: "delegation".into(),
+            actual: delegation_rate * 100.0,
+            target: format!("<{}%", (t.delegation_green * 100.0) as u32),
+            signal: sig_del,
+        },
+        Indicator {
+            name: "mode_diversity".into(),
+            actual: mode_count as f64,
+            target: format!(">={}", t.mode_diversity_green),
+            signal: sig_div,
+        },
+        Indicator {
+            name: "bug_decision".into(),
+            actual: bug_dec_ratio,
+            target: format!("<{}", t.bug_decision_green),
+            signal: sig_bug,
+        },
+        Indicator {
+            name: "friction_density".into(),
+            actual: fd,
+            target: format!("<{:.1}", t.friction_green),
+            signal: sig_fd,
+        },
     ];
 
     LayerScore {
@@ -470,26 +624,41 @@ fn layer3(cluster: &ClusterResult, t: &Targets) -> LayerScore {
 fn analyze_tension(layers: &[LayerScore; 3]) -> Option<String> {
     let s = [layers[0].signal, layers[1].signal, layers[2].signal];
     match s {
-        [Signal::Green, Signal::Red, _] => Some(t!(
-            "L1+L2 tension: deep but narrowing — try an exploration session in a new direction",
-            "层1绿+层2红 → 深耕但视野收窄，开一个新方向的探索 session"
-        ).into()),
-        [_, Signal::Green, Signal::Red] => Some(t!(
-            "L2+L3 tension: exploring but over-delegating — try pair mode instead",
-            "层2绿+层3红 → 探索多但 delegation 过高，探索时用 pair 模式而非委托"
-        ).into()),
-        [Signal::Red, _, Signal::Green] => Some(t!(
-            "L1+L3 tension: smooth collaboration but no cognitive growth — challenge yourself",
-            "层1红+层3绿 → 协作顺畅但认知没提升，你在舒适区，挑战更难的问题"
-        ).into()),
-        [Signal::Green, Signal::Green, Signal::Green] => Some(t!(
-            "All green — healthy growth, consider raising your baseline",
-            "全绿 → 健康成长，考虑提升基线标准"
-        ).into()),
-        [Signal::Red, Signal::Red, Signal::Red] => Some(t!(
-            "All red — time to replan, run refine insights --prescription",
-            "全红 → 需要重新规划，建议运行 refine insights --prescription"
-        ).into()),
+        [Signal::Green, Signal::Red, _] => Some(
+            t!(
+                "L1+L2 tension: deep but narrowing — try an exploration session in a new direction",
+                "层1绿+层2红 → 深耕但视野收窄，开一个新方向的探索 session"
+            )
+            .into(),
+        ),
+        [_, Signal::Green, Signal::Red] => Some(
+            t!(
+                "L2+L3 tension: exploring but over-delegating — try pair mode instead",
+                "层2绿+层3红 → 探索多但 delegation 过高，探索时用 pair 模式而非委托"
+            )
+            .into(),
+        ),
+        [Signal::Red, _, Signal::Green] => Some(
+            t!(
+                "L1+L3 tension: smooth collaboration but no cognitive growth — challenge yourself",
+                "层1红+层3绿 → 协作顺畅但认知没提升，你在舒适区，挑战更难的问题"
+            )
+            .into(),
+        ),
+        [Signal::Green, Signal::Green, Signal::Green] => Some(
+            t!(
+                "All green — healthy growth, consider raising your baseline",
+                "全绿 → 健康成长，考虑提升基线标准"
+            )
+            .into(),
+        ),
+        [Signal::Red, Signal::Red, Signal::Red] => Some(
+            t!(
+                "All red — time to replan, run refine insights --prescription",
+                "全红 → 需要重新规划，建议运行 refine insights --prescription"
+            )
+            .into(),
+        ),
         _ => None,
     }
 }
@@ -585,8 +754,17 @@ fn print_score(result: &ScoreResult, using_personal: bool) {
             .indicators
             .iter()
             .map(|i| {
-                let mark = if i.signal == Signal::Green { "✓" } else { "✗" };
-                format!("{} {} {}", indicator_display(&i.name), i.display_value(), mark)
+                let mark = if i.signal == Signal::Green {
+                    "✓"
+                } else {
+                    "✗"
+                };
+                format!(
+                    "{} {} {}",
+                    indicator_display(&i.name),
+                    i.display_value(),
+                    mark
+                )
             })
             .collect();
         println!(
@@ -600,15 +778,21 @@ fn print_score(result: &ScoreResult, using_personal: bool) {
         println!("\n  {}{}", t!("Tension: ", "张力: "), tension);
     }
     if using_personal {
-        println!("  {}", t!(
-            "Baseline: personal (4-week rolling avg)",
-            "基线: 个人(4周均值)"
-        ));
+        println!(
+            "  {}",
+            t!(
+                "Baseline: personal (4-week rolling avg)",
+                "基线: 个人(4周均值)"
+            )
+        );
     } else {
-        println!("  {}", t!(
-            "Baseline: default thresholds (insufficient data for personal baseline)",
-            "基线: 默认阈值(数据不足4周)"
-        ));
+        println!(
+            "  {}",
+            t!(
+                "Baseline: default thresholds (insufficient data for personal baseline)",
+                "基线: 默认阈值(数据不足4周)"
+            )
+        );
     }
 }
 
@@ -619,7 +803,10 @@ pub async fn handle_score(
     llm: Option<Arc<dyn refine_core::infra::LlmClient>>,
     since: Option<String>,
 ) -> Result<()> {
-    let all_items = repo.find_all().await.map_err(|e| anyhow::anyhow!("{}", e))?;
+    let all_items = repo
+        .find_all()
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
     let items = filter_since(all_items, &since)?;
     let cluster = cluster_observations(&items);
     let config = crate::config::load();
@@ -661,7 +848,10 @@ pub async fn handle_score(
         .join("growth-tracker.json");
     if let Ok(content) = std::fs::read_to_string(&tracker_path) {
         if let Ok(tracker) = serde_json::from_str::<serde_json::Value>(&content) {
-            let pending = tracker.get("pending_ingest").and_then(|v| v.as_u64()).unwrap_or(0);
+            let pending = tracker
+                .get("pending_ingest")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
             if pending > 3 {
                 println!(
                     "  ⚠️ {} {} {}",
@@ -678,11 +868,7 @@ pub async fn handle_score(
 
     if let Some(llm) = llm {
         match crate::advice::generate_and_cache(&result, &llm).await {
-            Ok(advice) => println!(
-                "\n  {} {}",
-                t!("Advice:", "建议:"),
-                advice
-            ),
+            Ok(advice) => println!("\n  {} {}", t!("Advice:", "建议:"), advice),
             Err(e) => tracing::debug!("advice generation skipped: {}", e),
         }
     }
@@ -738,6 +924,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     fn make_cluster_with_data(
         cognitive: HashMap<String, usize>,
         collab: HashMap<String, usize>,
@@ -783,6 +970,7 @@ mod tests {
     }
 
     /// Build a ScoreResult with known indicator values for baseline testing.
+    #[allow(clippy::too_many_arguments)]
     fn make_score_result(
         dreyfus: f64,
         decision_quality: f64,
@@ -803,29 +991,84 @@ mod tests {
                     name: "depth".into(),
                     signal: Signal::Yellow,
                     indicators: vec![
-                        Indicator { name: "dreyfus".into(), actual: dreyfus, target: String::new(), signal: Signal::Yellow },
-                        Indicator { name: "decision_quality".into(), actual: decision_quality, target: String::new(), signal: Signal::Yellow },
-                        Indicator { name: "depth_output".into(), actual: depth_output, target: String::new(), signal: Signal::Yellow },
-                        Indicator { name: "knowledge_rate".into(), actual: knowledge_rate_val, target: String::new(), signal: Signal::Yellow },
+                        Indicator {
+                            name: "dreyfus".into(),
+                            actual: dreyfus,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
+                        Indicator {
+                            name: "decision_quality".into(),
+                            actual: decision_quality,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
+                        Indicator {
+                            name: "depth_output".into(),
+                            actual: depth_output,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
+                        Indicator {
+                            name: "knowledge_rate".into(),
+                            actual: knowledge_rate_val,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
                     ],
                 },
                 LayerScore {
                     name: "breadth".into(),
                     signal: Signal::Yellow,
                     indicators: vec![
-                        Indicator { name: "exploration".into(), actual: exploration, target: String::new(), signal: Signal::Yellow },
-                        Indicator { name: "deep_invest".into(), actual: deep_invest, target: String::new(), signal: Signal::Yellow },
-                        Indicator { name: "fragmentation".into(), actual: fragmentation, target: String::new(), signal: Signal::Yellow },
+                        Indicator {
+                            name: "exploration".into(),
+                            actual: exploration,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
+                        Indicator {
+                            name: "deep_invest".into(),
+                            actual: deep_invest,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
+                        Indicator {
+                            name: "fragmentation".into(),
+                            actual: fragmentation,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
                     ],
                 },
                 LayerScore {
                     name: "collaboration".into(),
                     signal: Signal::Yellow,
                     indicators: vec![
-                        Indicator { name: "delegation".into(), actual: delegation, target: String::new(), signal: Signal::Yellow },
-                        Indicator { name: "mode_diversity".into(), actual: mode_diversity, target: String::new(), signal: Signal::Yellow },
-                        Indicator { name: "bug_decision".into(), actual: bug_decision, target: String::new(), signal: Signal::Yellow },
-                        Indicator { name: "friction_density".into(), actual: friction_density_val, target: String::new(), signal: Signal::Yellow },
+                        Indicator {
+                            name: "delegation".into(),
+                            actual: delegation,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
+                        Indicator {
+                            name: "mode_diversity".into(),
+                            actual: mode_diversity,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
+                        Indicator {
+                            name: "bug_decision".into(),
+                            actual: bug_decision,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
+                        Indicator {
+                            name: "friction_density".into(),
+                            actual: friction_density_val,
+                            target: String::new(),
+                            signal: Signal::Yellow,
+                        },
                     ],
                 },
             ],
@@ -921,12 +1164,17 @@ mod tests {
             indicators: Vec::new(),
         };
         // L1 green + L2 red
-        let tension = analyze_tension(&[green_layer.clone(), red_layer.clone(), green_layer.clone()]);
+        let tension =
+            analyze_tension(&[green_layer.clone(), red_layer.clone(), green_layer.clone()]);
         assert!(tension.is_some());
         assert!(tension.unwrap_or_default().contains("narrowing"));
 
         // All green
-        let tension = analyze_tension(&[green_layer.clone(), green_layer.clone(), green_layer.clone()]);
+        let tension = analyze_tension(&[
+            green_layer.clone(),
+            green_layer.clone(),
+            green_layer.clone(),
+        ]);
         assert!(tension.unwrap_or_default().contains("healthy"));
 
         // All red
@@ -941,9 +1189,21 @@ mod tests {
 
         let result = ScoreResult {
             layers: [
-                LayerScore { name: "L1".into(), signal: Signal::Green, indicators: Vec::new() },
-                LayerScore { name: "L2".into(), signal: Signal::Yellow, indicators: Vec::new() },
-                LayerScore { name: "L3".into(), signal: Signal::Red, indicators: Vec::new() },
+                LayerScore {
+                    name: "L1".into(),
+                    signal: Signal::Green,
+                    indicators: Vec::new(),
+                },
+                LayerScore {
+                    name: "L2".into(),
+                    signal: Signal::Yellow,
+                    indicators: Vec::new(),
+                },
+                LayerScore {
+                    name: "L3".into(),
+                    signal: Signal::Red,
+                    indicators: Vec::new(),
+                },
             ],
             tension: Some("test tension".into()),
             timestamp: Utc::now(),
@@ -963,7 +1223,7 @@ mod tests {
         let reader = std::io::BufReader::new(std::fs::File::open(&path).unwrap());
         let loaded: Vec<ScoreResult> = reader
             .lines()
-            .filter_map(|l| l.ok())
+            .map_while(Result::ok)
             .filter_map(|l| serde_json::from_str(&l).ok())
             .collect();
         assert_eq!(loaded.len(), 1);
@@ -995,7 +1255,10 @@ mod tests {
             .collect();
 
         let baseline = compute_personal_baseline(&history);
-        assert!(baseline.is_some(), "should produce baseline with 10 entries");
+        assert!(
+            baseline.is_some(),
+            "should produce baseline with 10 entries"
+        );
 
         let bl = baseline.unwrap();
         assert!((bl.dreyfus_avg - 3.5).abs() < f64::EPSILON);
@@ -1018,14 +1281,27 @@ mod tests {
         let history: Vec<ScoreResult> = (0..5)
             .map(|i| {
                 make_score_result(
-                    3.5, 60.0, 10.0, 0.5, 20.0, 25.0, 15.0, 30.0, 4.0, 0.20, 0.8,
+                    3.5,
+                    60.0,
+                    10.0,
+                    0.5,
+                    20.0,
+                    25.0,
+                    15.0,
+                    30.0,
+                    4.0,
+                    0.20,
+                    0.8,
                     now - Duration::days(i),
                 )
             })
             .collect();
 
         let baseline = compute_personal_baseline(&history);
-        assert!(baseline.is_none(), "should return None with fewer than 7 entries");
+        assert!(
+            baseline.is_none(),
+            "should return None with fewer than 7 entries"
+        );
     }
 
     #[test]
@@ -1035,14 +1311,27 @@ mod tests {
         let history: Vec<ScoreResult> = (0..10)
             .map(|i| {
                 make_score_result(
-                    3.5, 60.0, 10.0, 0.5, 20.0, 25.0, 15.0, 30.0, 4.0, 0.20, 0.8,
+                    3.5,
+                    60.0,
+                    10.0,
+                    0.5,
+                    20.0,
+                    25.0,
+                    15.0,
+                    30.0,
+                    4.0,
+                    0.20,
+                    0.8,
                     now - Duration::days(30 + i),
                 )
             })
             .collect();
 
         let baseline = compute_personal_baseline(&history);
-        assert!(baseline.is_none(), "should return None when all data is outside 28-day window");
+        assert!(
+            baseline.is_none(),
+            "should return None when all data is outside 28-day window"
+        );
     }
 
     #[test]
@@ -1054,7 +1343,20 @@ mod tests {
         // 7 new-schema entries: knowledge_rate=0.6, friction_density=1.2
         let new_schema: Vec<ScoreResult> = (0..7)
             .map(|i| {
-                make_score_result(3.0, 50.0, 10.0, 0.6, 20.0, 25.0, 15.0, 30.0, 4.0, 0.20, 1.2, now - Duration::days(i))
+                make_score_result(
+                    3.0,
+                    50.0,
+                    10.0,
+                    0.6,
+                    20.0,
+                    25.0,
+                    15.0,
+                    30.0,
+                    4.0,
+                    0.20,
+                    1.2,
+                    now - Duration::days(i),
+                )
             })
             .collect();
 
@@ -1066,27 +1368,72 @@ mod tests {
                         name: "depth".into(),
                         signal: Signal::Yellow,
                         indicators: vec![
-                            Indicator { name: "dreyfus".into(), actual: 3.0, target: String::new(), signal: Signal::Yellow },
-                            Indicator { name: "decision_quality".into(), actual: 50.0, target: String::new(), signal: Signal::Yellow },
-                            Indicator { name: "depth_output".into(), actual: 10.0, target: String::new(), signal: Signal::Yellow },
+                            Indicator {
+                                name: "dreyfus".into(),
+                                actual: 3.0,
+                                target: String::new(),
+                                signal: Signal::Yellow,
+                            },
+                            Indicator {
+                                name: "decision_quality".into(),
+                                actual: 50.0,
+                                target: String::new(),
+                                signal: Signal::Yellow,
+                            },
+                            Indicator {
+                                name: "depth_output".into(),
+                                actual: 10.0,
+                                target: String::new(),
+                                signal: Signal::Yellow,
+                            },
                         ],
                     },
                     LayerScore {
                         name: "breadth".into(),
                         signal: Signal::Yellow,
                         indicators: vec![
-                            Indicator { name: "exploration".into(), actual: 20.0, target: String::new(), signal: Signal::Yellow },
-                            Indicator { name: "deep_invest".into(), actual: 25.0, target: String::new(), signal: Signal::Yellow },
-                            Indicator { name: "fragmentation".into(), actual: 15.0, target: String::new(), signal: Signal::Yellow },
+                            Indicator {
+                                name: "exploration".into(),
+                                actual: 20.0,
+                                target: String::new(),
+                                signal: Signal::Yellow,
+                            },
+                            Indicator {
+                                name: "deep_invest".into(),
+                                actual: 25.0,
+                                target: String::new(),
+                                signal: Signal::Yellow,
+                            },
+                            Indicator {
+                                name: "fragmentation".into(),
+                                actual: 15.0,
+                                target: String::new(),
+                                signal: Signal::Yellow,
+                            },
                         ],
                     },
                     LayerScore {
                         name: "collaboration".into(),
                         signal: Signal::Yellow,
                         indicators: vec![
-                            Indicator { name: "delegation".into(), actual: 30.0, target: String::new(), signal: Signal::Yellow },
-                            Indicator { name: "mode_diversity".into(), actual: 4.0, target: String::new(), signal: Signal::Yellow },
-                            Indicator { name: "bug_decision".into(), actual: 0.20, target: String::new(), signal: Signal::Yellow },
+                            Indicator {
+                                name: "delegation".into(),
+                                actual: 30.0,
+                                target: String::new(),
+                                signal: Signal::Yellow,
+                            },
+                            Indicator {
+                                name: "mode_diversity".into(),
+                                actual: 4.0,
+                                target: String::new(),
+                                signal: Signal::Yellow,
+                            },
+                            Indicator {
+                                name: "bug_decision".into(),
+                                actual: 0.20,
+                                target: String::new(),
+                                signal: Signal::Yellow,
+                            },
                         ],
                     },
                 ],
@@ -1097,14 +1444,25 @@ mod tests {
 
         let history: Vec<ScoreResult> = new_schema.into_iter().chain(old_schema).collect();
         let baseline = compute_personal_baseline(&history);
-        assert!(baseline.is_some(), "should produce baseline with 10 mixed-schema entries");
-        let Some(baseline) = baseline else { return; };
+        assert!(
+            baseline.is_some(),
+            "should produce baseline with 10 mixed-schema entries"
+        );
+        let Some(baseline) = baseline else {
+            return;
+        };
 
         // Must be 0.6 (avg of 7 matches), not 0.42 (0.6*7/10 with old divisor bug)
-        assert!((baseline.knowledge_rate_avg - 0.6).abs() < f64::EPSILON,
-            "knowledge_rate_avg should be 0.6, got {}", baseline.knowledge_rate_avg);
-        assert!((baseline.friction_density_avg - 1.2).abs() < f64::EPSILON,
-            "friction_density_avg should be 1.2, got {}", baseline.friction_density_avg);
+        assert!(
+            (baseline.knowledge_rate_avg - 0.6).abs() < f64::EPSILON,
+            "knowledge_rate_avg should be 0.6, got {}",
+            baseline.knowledge_rate_avg
+        );
+        assert!(
+            (baseline.friction_density_avg - 1.2).abs() < f64::EPSILON,
+            "friction_density_avg should be 1.2, got {}",
+            baseline.friction_density_avg
+        );
     }
 
     #[test]
@@ -1141,10 +1499,10 @@ mod tests {
             depth_output_avg: 10.0,
             exploration_avg: 20.0,
             deep_invest_avg: 25.0,
-            fragmentation_avg: 15.0,  // lower is better
-            delegation_avg: 30.0,     // lower is better
+            fragmentation_avg: 15.0, // lower is better
+            delegation_avg: 30.0,    // lower is better
             mode_diversity_avg: 4.0,
-            bug_decision_avg: 0.20,   // lower is better
+            bug_decision_avg: 0.20, // lower is better
             knowledge_rate_avg: 0.5,
             friction_density_avg: 1.0, // lower is better
         };
@@ -1242,14 +1600,30 @@ mod tests {
             0,
             0,
             vec![
-                ("proj-a", 5, vec![], vec![], vec!["learned Rust", "learned SQL", "learned async"]),
-                ("proj-b", 5, vec![], vec![], vec!["learned Docker", "learned K8s", "learned Nix"]),
+                (
+                    "proj-a",
+                    5,
+                    vec![],
+                    vec![],
+                    vec!["learned Rust", "learned SQL", "learned async"],
+                ),
+                (
+                    "proj-b",
+                    5,
+                    vec![],
+                    vec![],
+                    vec!["learned Docker", "learned K8s", "learned Nix"],
+                ),
             ],
         );
         let kr = knowledge_rate(&cluster);
         assert!((kr - 0.6).abs() < f64::EPSILON);
         let l1 = layer1(&cluster, &t);
-        let kr_ind = l1.indicators.iter().find(|i| i.name == "knowledge_rate").unwrap();
+        let kr_ind = l1
+            .indicators
+            .iter()
+            .find(|i| i.name == "knowledge_rate")
+            .unwrap();
         assert_eq!(kr_ind.signal, Signal::Green);
     }
 
@@ -1270,7 +1644,11 @@ mod tests {
         let kr = knowledge_rate(&cluster);
         assert!((kr - 0.1).abs() < f64::EPSILON);
         let l1 = layer1(&cluster, &t);
-        let kr_ind = l1.indicators.iter().find(|i| i.name == "knowledge_rate").unwrap();
+        let kr_ind = l1
+            .indicators
+            .iter()
+            .find(|i| i.name == "knowledge_rate")
+            .unwrap();
         assert_eq!(kr_ind.signal, Signal::Red);
     }
 
@@ -1291,14 +1669,30 @@ mod tests {
             10,
             2,
             vec![
-                ("proj-a", 5, vec![], vec!["slow build", "confusing API"], vec![]),
-                ("proj-b", 5, vec![], vec!["flaky test", "bad docs", "timeout"], vec![]),
+                (
+                    "proj-a",
+                    5,
+                    vec![],
+                    vec!["slow build", "confusing API"],
+                    vec![],
+                ),
+                (
+                    "proj-b",
+                    5,
+                    vec![],
+                    vec!["flaky test", "bad docs", "timeout"],
+                    vec![],
+                ),
             ],
         );
         let fd = friction_density(&cluster);
         assert!((fd - 0.5).abs() < f64::EPSILON);
         let l3 = layer3(&cluster, &t);
-        let fd_ind = l3.indicators.iter().find(|i| i.name == "friction_density").unwrap();
+        let fd_ind = l3
+            .indicators
+            .iter()
+            .find(|i| i.name == "friction_density")
+            .unwrap();
         assert_eq!(fd_ind.signal, Signal::Green);
     }
 
@@ -1319,14 +1713,35 @@ mod tests {
             10,
             2,
             vec![
-                ("proj-a", 5, vec![], vec!["f1","f2","f3","f4","f5","f6","f7","f8","f9","f10","f11","f12","f13"], vec![]),
-                ("proj-b", 5, vec![], vec!["f1","f2","f3","f4","f5","f6","f7","f8","f9","f10","f11","f12"], vec![]),
+                (
+                    "proj-a",
+                    5,
+                    vec![],
+                    vec![
+                        "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
+                        "f13",
+                    ],
+                    vec![],
+                ),
+                (
+                    "proj-b",
+                    5,
+                    vec![],
+                    vec![
+                        "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
+                    ],
+                    vec![],
+                ),
             ],
         );
         let fd = friction_density(&cluster);
         assert!(fd > 2.0);
         let l3 = layer3(&cluster, &t);
-        let fd_ind = l3.indicators.iter().find(|i| i.name == "friction_density").unwrap();
+        let fd_ind = l3
+            .indicators
+            .iter()
+            .find(|i| i.name == "friction_density")
+            .unwrap();
         assert_eq!(fd_ind.signal, Signal::Red);
     }
 
@@ -1334,7 +1749,10 @@ mod tests {
     fn test_layer1_has_4_indicators() {
         let t = Targets::default();
         let cluster = make_cluster(
-            HashMap::new(), HashMap::new(), 0, 0,
+            HashMap::new(),
+            HashMap::new(),
+            0,
+            0,
             vec![("proj-a", 5, vec![])],
         );
         let l1 = layer1(&cluster, &t);
@@ -1346,7 +1764,10 @@ mod tests {
     fn test_layer3_has_4_indicators() {
         let t = Targets::default();
         let cluster = make_cluster(
-            HashMap::new(), HashMap::new(), 0, 0,
+            HashMap::new(),
+            HashMap::new(),
+            0,
+            0,
             vec![("proj-a", 5, vec![])],
         );
         let l3 = layer3(&cluster, &t);

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -147,11 +147,7 @@ pub fn build_weekly_prompt(
         parts.push(format!("- {}", format_layer(layer)));
     }
     if let Some(tension) = &this.tension {
-        parts.push(format!(
-            "\n{}: {}",
-            t!("Tension", "张力"),
-            tension
-        ));
+        parts.push(format!("\n{}: {}", t!("Tension", "张力"), tension));
     }
 
     if let Some(last) = last {
@@ -220,15 +216,14 @@ fn extract_suggestions(report: &str) -> Vec<String> {
     for line in &lines {
         let trimmed = line.trim();
         // Detect suggestion section headers (Chinese and English)
-        if trimmed.contains("建议")
+        if (trimmed.contains("建议")
             || trimmed.to_lowercase().contains("suggestion")
             || trimmed.to_lowercase().contains("next week")
-            || trimmed.contains("下周")
+            || trimmed.contains("下周"))
+            && (trimmed.starts_with('#') || trimmed.starts_with("**"))
         {
-            if trimmed.starts_with('#') || trimmed.starts_with("**") {
-                in_suggestion_section = true;
-                continue;
-            }
+            in_suggestion_section = true;
+            continue;
         }
         // New section header ends suggestion section
         if in_suggestion_section
@@ -242,11 +237,13 @@ fn extract_suggestions(report: &str) -> Vec<String> {
         if in_suggestion_section && !trimmed.is_empty() {
             let is_list_item = trimmed.starts_with('-')
                 || trimmed.starts_with('*')
-                || trimmed.chars().next().map_or(false, |c| c.is_ascii_digit());
+                || trimmed.chars().next().is_some_and(|c| c.is_ascii_digit());
             if is_list_item {
                 // Strip leading bullet/number markers
                 let content = trimmed
-                    .trim_start_matches(|c: char| c == '-' || c == '*' || c.is_ascii_digit() || c == '.' || c == ')')
+                    .trim_start_matches(|c: char| {
+                        c == '-' || c == '*' || c.is_ascii_digit() || c == '.' || c == ')'
+                    })
                     .trim();
                 if !content.is_empty() {
                     suggestions.push(content.to_string());
@@ -309,11 +306,7 @@ async fn save_to_document(doc_repo: &Arc<dyn DocumentRepository>, report: &str) 
     Ok(())
 }
 
-async fn llm_with_retry(
-    client: &Arc<dyn LlmClient>,
-    prompt: &str,
-    system: &str,
-) -> Result<String> {
+async fn llm_with_retry(client: &Arc<dyn LlmClient>, prompt: &str, system: &str) -> Result<String> {
     let mut last_err = String::new();
     for attempt in 0..MAX_RETRIES {
         match client.complete(prompt, Some(system)).await {
@@ -334,7 +327,12 @@ async fn llm_with_retry(
                 eprintln!(
                     "  {}",
                     t!(
-                        format!("Retry ({}/{}) waiting {}s...", attempt + 1, MAX_RETRIES, delay),
+                        format!(
+                            "Retry ({}/{}) waiting {}s...",
+                            attempt + 1,
+                            MAX_RETRIES,
+                            delay
+                        ),
                         format!("重试 ({}/{}) 等待 {}s...", attempt + 1, MAX_RETRIES, delay)
                     )
                 );

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -199,13 +199,32 @@ pub fn build_weekly_prompt(
 
 fn load_last_weekly_record() -> Option<WeeklyRecord> {
     let path = mirror_dir().join("weekly-history.jsonl");
-    let file = std::fs::File::open(&path).ok()?;
+    let file = match std::fs::File::open(&path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!("load_last_weekly_record: failed to open {:?}: {}", path, e);
+            return None;
+        }
+    };
     let reader = std::io::BufReader::new(file);
-    reader
-        .lines()
-        .map_while(|l| l.ok())
-        .filter_map(|l| serde_json::from_str::<WeeklyRecord>(&l).ok())
-        .last()
+    let mut last: Option<WeeklyRecord> = None;
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!("load_last_weekly_record: IO error reading line: {}", e);
+                break;
+            }
+        };
+        match serde_json::from_str::<WeeklyRecord>(&line) {
+            Ok(rec) => last = Some(rec),
+            Err(e) => {
+                tracing::warn!("load_last_weekly_record: JSON parse error: {}", e);
+            }
+        }
+    }
+    last
 }
 
 fn extract_suggestions(report: &str) -> Vec<String> {

--- a/packages/core/src/session/aggregation.rs
+++ b/packages/core/src/session/aggregation.rs
@@ -187,7 +187,7 @@ fn find_current_section(content: &str, target_line: &str) -> Option<String> {
 /// 格式化 L1-L3 报告为可读文本
 pub fn format_report(report: &AggregationReport) -> String {
     let mut out = String::new();
-    out.push_str(&format!("=== Session Insights 报告 ===\n"));
+    out.push_str("=== Session Insights 报告 ===\n");
     out.push_str(&format!("分析会话数: {}\n\n", report.total_sessions));
 
     // L1

--- a/packages/core/src/session/analysis_routes.rs
+++ b/packages/core/src/session/analysis_routes.rs
@@ -60,20 +60,29 @@ fn build_project_overview(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
     let stats = &cluster.global_stats;
     let mut ctx = format!(
         "总会话: {}, 总决策: {}, 总Bug修复: {}, 项目数: {}\n\n",
-        stats.total_sessions, stats.total_decisions, stats.total_bugfixes,
+        stats.total_sessions,
+        stats.total_decisions,
+        stats.total_bugfixes,
         stats.project_ranking.len()
     );
 
     for (name, count) in stats.project_ranking.iter().take(15) {
         if let Some(p) = cluster.projects.get(name) {
-            ctx.push_str(&format!("## {} ({} sessions, {} decisions, {} bugs)\n",
-                name, count, p.decision_titles.len(), p.bugfix_titles.len()));
+            ctx.push_str(&format!(
+                "## {} ({} sessions, {} decisions, {} bugs)\n",
+                name,
+                count,
+                p.decision_titles.len(),
+                p.bugfix_titles.len()
+            ));
             for excerpt in p.summary_excerpts.iter().take(3) {
                 ctx.push_str(&format!("{}\n", excerpt));
             }
             ctx.push('\n');
         }
-        if ctx.len() > MAX_ROUTE_CONTEXT { break; }
+        if ctx.len() > MAX_ROUTE_CONTEXT {
+            break;
+        }
     }
 
     AnalysisRoute {
@@ -90,7 +99,9 @@ fn build_project_overview(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
 小项目合并为综述。用"你在 xx 中做了 xx"的第二人称。
 
 ## 数据
-{}"#, truncate(&ctx, MAX_ROUTE_CONTEXT)),
+{}"#,
+            truncate(&ctx, MAX_ROUTE_CONTEXT)
+        ),
     }
 }
 
@@ -98,14 +109,22 @@ fn build_decision_patterns(id: usize, cluster: &ClusterResult) -> AnalysisRoute 
     let mut ctx = String::new();
     for (name, _) in cluster.global_stats.project_ranking.iter().take(12) {
         if let Some(p) = cluster.projects.get(name) {
-            if p.decision_titles.is_empty() { continue; }
-            ctx.push_str(&format!("## {} ({} decisions)\n", name, p.decision_titles.len()));
+            if p.decision_titles.is_empty() {
+                continue;
+            }
+            ctx.push_str(&format!(
+                "## {} ({} decisions)\n",
+                name,
+                p.decision_titles.len()
+            ));
             for d in p.decision_titles.iter().take(25) {
                 ctx.push_str(&format!("- {}\n", d));
             }
             ctx.push('\n');
         }
-        if ctx.len() > MAX_ROUTE_CONTEXT { break; }
+        if ctx.len() > MAX_ROUTE_CONTEXT {
+            break;
+        }
     }
 
     AnalysisRoute {
@@ -121,7 +140,9 @@ fn build_decision_patterns(id: usize, cluster: &ClusterResult) -> AnalysisRoute 
 4. 每个模式引用 3-5 个具体决策作为证据
 
 ## 数据
-{}"#, truncate(&ctx, MAX_ROUTE_CONTEXT)),
+{}"#,
+            truncate(&ctx, MAX_ROUTE_CONTEXT)
+        ),
     }
 }
 
@@ -129,9 +150,15 @@ fn build_bug_patterns(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
     let mut ctx = String::new();
     for (name, _) in cluster.global_stats.project_ranking.iter().take(12) {
         if let Some(p) = cluster.projects.get(name) {
-            if p.bugfix_titles.is_empty() && p.frictions.is_empty() { continue; }
-            ctx.push_str(&format!("## {} ({} bugs, {} frictions)\n",
-                name, p.bugfix_titles.len(), p.frictions.len()));
+            if p.bugfix_titles.is_empty() && p.frictions.is_empty() {
+                continue;
+            }
+            ctx.push_str(&format!(
+                "## {} ({} bugs, {} frictions)\n",
+                name,
+                p.bugfix_titles.len(),
+                p.frictions.len()
+            ));
             for b in p.bugfix_titles.iter().take(20) {
                 ctx.push_str(&format!("- [bug] {}\n", b));
             }
@@ -140,7 +167,9 @@ fn build_bug_patterns(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
             }
             ctx.push('\n');
         }
-        if ctx.len() > MAX_ROUTE_CONTEXT { break; }
+        if ctx.len() > MAX_ROUTE_CONTEXT {
+            break;
+        }
     }
 
     AnalysisRoute {
@@ -157,13 +186,15 @@ fn build_bug_patterns(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
 5. 建议可复制到 CLAUDE.md 的预防规则
 
 ## 数据
-{}"#, truncate(&ctx, MAX_ROUTE_CONTEXT)),
+{}"#,
+            truncate(&ctx, MAX_ROUTE_CONTEXT)
+        ),
     }
 }
 
 fn build_cognitive_evolution(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
     let stats = &cluster.global_stats;
-    let mut ctx = format!("全局认知水平分布:\n");
+    let mut ctx = "全局认知水平分布:\n".to_string();
     let mut levels: Vec<_> = stats.cognitive_levels.iter().collect();
     levels.sort_by(|a, b| b.1.cmp(a.1));
     for (level, count) in &levels {
@@ -173,7 +204,9 @@ fn build_cognitive_evolution(id: usize, cluster: &ClusterResult) -> AnalysisRout
     ctx.push_str("\n按项目认知水平:\n");
     for (name, _) in stats.project_ranking.iter().take(10) {
         if let Some(p) = cluster.projects.get(name) {
-            if p.cognitive_levels.is_empty() { continue; }
+            if p.cognitive_levels.is_empty() {
+                continue;
+            }
             ctx.push_str(&format!("  {}: {:?}\n", name, p.cognitive_levels));
         }
     }
@@ -185,7 +218,9 @@ fn build_cognitive_evolution(id: usize, cluster: &ClusterResult) -> AnalysisRout
                 ctx.push_str(&format!("- [{}] {}\n", name, k));
             }
         }
-        if ctx.len() > MAX_ROUTE_CONTEXT { break; }
+        if ctx.len() > MAX_ROUTE_CONTEXT {
+            break;
+        }
     }
 
     AnalysisRoute {
@@ -202,7 +237,9 @@ fn build_cognitive_evolution(id: usize, cluster: &ClusterResult) -> AnalysisRout
 5. 各项目的认知水平差异说明什么
 
 ## 数据
-{}"#, truncate(&ctx, MAX_ROUTE_CONTEXT)),
+{}"#,
+            truncate(&ctx, MAX_ROUTE_CONTEXT)
+        ),
     }
 }
 
@@ -222,7 +259,9 @@ fn build_tech_radar(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
                 ctx.push_str(&format!("- [{}] {}\n", name, a));
             }
         }
-        if ctx.len() > MAX_ROUTE_CONTEXT { break; }
+        if ctx.len() > MAX_ROUTE_CONTEXT {
+            break;
+        }
     }
 
     AnalysisRoute {
@@ -241,13 +280,15 @@ fn build_tech_radar(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
 3. 分析技术栈的广度和深度
 
 ## 数据
-{}"#, truncate(&ctx, MAX_ROUTE_CONTEXT)),
+{}"#,
+            truncate(&ctx, MAX_ROUTE_CONTEXT)
+        ),
     }
 }
 
 fn build_ai_collaboration(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
     let stats = &cluster.global_stats;
-    let mut ctx = format!("全局协作模式分布:\n");
+    let mut ctx = "全局协作模式分布:\n".to_string();
     let mut modes: Vec<_> = stats.collaboration_modes.iter().collect();
     modes.sort_by(|a, b| b.1.cmp(a.1));
     for (mode, count) in &modes {
@@ -261,7 +302,9 @@ fn build_ai_collaboration(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
                 ctx.push_str(&format!("- [{}] {}\n", name, f));
             }
         }
-        if ctx.len() > MAX_ROUTE_CONTEXT { break; }
+        if ctx.len() > MAX_ROUTE_CONTEXT {
+            break;
+        }
     }
 
     AnalysisRoute {
@@ -277,22 +320,35 @@ fn build_ai_collaboration(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
 4. 给出 3-5 条可操作的 AI 协作优化建议
 
 ## 数据
-{}"#, truncate(&ctx, MAX_ROUTE_CONTEXT)),
+{}"#,
+            truncate(&ctx, MAX_ROUTE_CONTEXT)
+        ),
     }
 }
 
 fn build_workflow_patterns(id: usize, cluster: &ClusterResult) -> AnalysisRoute {
     let stats = &cluster.global_stats;
-    let mut ctx = format!("项目活跃度排名:\n");
+    let mut ctx = "项目活跃度排名:\n".to_string();
     for (name, count) in stats.project_ranking.iter().take(20) {
         ctx.push_str(&format!("  {}: {} sessions\n", name, count));
     }
     ctx.push_str(&format!("\n总项目数: {}\n", stats.project_ranking.len()));
 
-    let big = stats.project_ranking.iter().filter(|(_, c)| *c >= 10).count();
-    let medium = stats.project_ranking.iter().filter(|(_, c)| *c >= 3 && *c < 10).count();
+    let big = stats
+        .project_ranking
+        .iter()
+        .filter(|(_, c)| *c >= 10)
+        .count();
+    let medium = stats
+        .project_ranking
+        .iter()
+        .filter(|(_, c)| *c >= 3 && *c < 10)
+        .count();
     let small = stats.project_ranking.iter().filter(|(_, c)| *c < 3).count();
-    ctx.push_str(&format!("大项目(>=10): {}, 中项目(3-9): {}, 小项目(<3): {}\n", big, medium, small));
+    ctx.push_str(&format!(
+        "大项目(>=10): {}, 中项目(3-9): {}, 小项目(<3): {}\n",
+        big, medium, small
+    ));
 
     AnalysisRoute {
         id,
@@ -307,15 +363,19 @@ fn build_workflow_patterns(id: usize, cluster: &ClusterResult) -> AnalysisRoute 
 4. 深度工作: 哪些项目有持续深入
 
 ## 数据
-{}"#, truncate(&ctx, MAX_ROUTE_CONTEXT)),
+{}"#,
+            truncate(&ctx, MAX_ROUTE_CONTEXT)
+        ),
     }
 }
 
 fn build_project_deep_dive(id: usize, project: &ProjectCluster) -> AnalysisRoute {
     let mut ctx = format!(
         "项目: {} ({} sessions, {} decisions, {} bugs)\n\n",
-        project.project_name, project.session_count,
-        project.decision_titles.len(), project.bugfix_titles.len()
+        project.project_name,
+        project.session_count,
+        project.decision_titles.len(),
+        project.bugfix_titles.len()
     );
 
     ctx.push_str("会话摘要:\n");
@@ -354,7 +414,10 @@ fn build_project_deep_dive(id: usize, project: &ProjectCluster) -> AnalysisRoute
 5. 改进建议
 
 ## 数据
-{}"#, project.project_name, truncate(&ctx, MAX_ROUTE_CONTEXT)),
+{}"#,
+            project.project_name,
+            truncate(&ctx, MAX_ROUTE_CONTEXT)
+        ),
     }
 }
 
@@ -362,14 +425,18 @@ fn build_knowledge_network(id: usize, cluster: &ClusterResult) -> AnalysisRoute 
     let mut ctx = String::new();
     for (name, _) in cluster.global_stats.project_ranking.iter().take(15) {
         if let Some(p) = cluster.projects.get(name) {
-            if p.knowledge_gained.is_empty() { continue; }
+            if p.knowledge_gained.is_empty() {
+                continue;
+            }
             ctx.push_str(&format!("## {} 知识获取\n", name));
             for k in p.knowledge_gained.iter().take(10) {
                 ctx.push_str(&format!("- {}\n", k));
             }
             ctx.push('\n');
         }
-        if ctx.len() > MAX_ROUTE_CONTEXT { break; }
+        if ctx.len() > MAX_ROUTE_CONTEXT {
+            break;
+        }
     }
 
     AnalysisRoute {
@@ -385,7 +452,9 @@ fn build_knowledge_network(id: usize, cluster: &ClusterResult) -> AnalysisRoute 
 4. 学习深度评估
 
 ## 数据
-{}"#, truncate(&ctx, MAX_ROUTE_CONTEXT)),
+{}"#,
+            truncate(&ctx, MAX_ROUTE_CONTEXT)
+        ),
     }
 }
 
@@ -393,14 +462,18 @@ fn build_friction_deep_dive(id: usize, cluster: &ClusterResult) -> AnalysisRoute
     let mut ctx = String::new();
     for (name, _) in cluster.global_stats.project_ranking.iter().take(15) {
         if let Some(p) = cluster.projects.get(name) {
-            if p.frictions.is_empty() { continue; }
+            if p.frictions.is_empty() {
+                continue;
+            }
             ctx.push_str(&format!("## {} 阻力\n", name));
             for f in &p.frictions {
                 ctx.push_str(&format!("- {}\n", f));
             }
             ctx.push('\n');
         }
-        if ctx.len() > MAX_ROUTE_CONTEXT { break; }
+        if ctx.len() > MAX_ROUTE_CONTEXT {
+            break;
+        }
     }
 
     AnalysisRoute {
@@ -416,7 +489,9 @@ fn build_friction_deep_dive(id: usize, cluster: &ClusterResult) -> AnalysisRoute
 4. 给出 5 条可操作的预防建议
 
 ## 数据
-{}"#, truncate(&ctx, MAX_ROUTE_CONTEXT)),
+{}"#,
+            truncate(&ctx, MAX_ROUTE_CONTEXT)
+        ),
     }
 }
 

--- a/packages/core/src/session/discovery.rs
+++ b/packages/core/src/session/discovery.rs
@@ -32,10 +32,16 @@ pub fn discover_sessions_in(
 ) -> Vec<DiscoveredSession> {
     let mut results = Vec::new();
 
-    if source_filter.as_ref().map_or(true, |s| *s == SessionSource::ClaudeCode) {
+    if source_filter
+        .as_ref()
+        .map_or(true, |s| *s == SessionSource::ClaudeCode)
+    {
         discover_claude_code(home, &mut results);
     }
-    if source_filter.as_ref().map_or(true, |s| *s == SessionSource::Codex) {
+    if source_filter
+        .as_ref()
+        .map_or(true, |s| *s == SessionSource::Codex)
+    {
         discover_codex(home, &mut results);
     }
 
@@ -97,11 +103,7 @@ fn discover_codex(home: &Path, results: &mut Vec<DiscoveredSession>) {
     walk_jsonl_recursive(&sessions_dir, SessionSource::Codex, results);
 }
 
-fn walk_jsonl_recursive(
-    dir: &Path,
-    source: SessionSource,
-    results: &mut Vec<DiscoveredSession>,
-) {
+fn walk_jsonl_recursive(dir: &Path, source: SessionSource, results: &mut Vec<DiscoveredSession>) {
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(_) => return,
@@ -111,7 +113,7 @@ fn walk_jsonl_recursive(
         let path = entry.path();
         if path.is_dir() {
             // 跳过 subagents 目录
-            if path.file_name().map_or(false, |n| n == "subagents") {
+            if path.file_name().is_some_and(|n| n == "subagents") {
                 continue;
             }
             walk_jsonl_recursive(&path, source.clone(), results);
@@ -126,13 +128,13 @@ fn walk_jsonl_recursive(
 }
 
 fn is_session_jsonl(path: &Path) -> bool {
-    path.extension().map_or(false, |ext| ext == "jsonl")
+    path.extension().is_some_and(|ext| ext == "jsonl")
 }
 
 fn is_subagent_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|n| n.to_str())
-        .map_or(false, |name| name.starts_with("agent-"))
+        .is_some_and(|name| name.starts_with("agent-"))
 }
 
 /// 从路径提取项目名（最后一个目录组件）

--- a/packages/core/src/session/types.rs
+++ b/packages/core/src/session/types.rs
@@ -37,21 +37,11 @@ pub struct SessionMessage {
 }
 
 /// 会话元数据
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SessionMeta {
     pub project: Option<String>,
     pub model: Option<String>,
     pub started_at: Option<DateTime<Utc>>,
-}
-
-impl Default for SessionMeta {
-    fn default() -> Self {
-        Self {
-            project: None,
-            model: None,
-            started_at: None,
-        }
-    }
 }
 
 /// 统一会话结构


### PR DESCRIPTION
Closes #1

## Problem
`compute_personal_baseline` divided by `recent.len()` (total entries) instead of the number of entries that actually contain the indicator. Old schema records lack `knowledge_rate`/`friction_density`, so those baselines averaged near zero.

## Fix
Collect matching values first, then divide by their count. Returns `0.0` if no matches exist.

## Test
Added `test_personal_baseline_mixed_schema`: 7 new-schema entries (knowledge_rate=0.6, friction_density=1.2) + 3 old-schema entries without those fields. Verifies avg = 0.6/1.2, not 0.42/0.84 (the bugged result).