### PR TITLE
FUT-107 refactor(mirror): deduplicate Signal conversions

### DIFF
--- a/apps/mirror/src/advice.rs
+++ b/apps/mirror/src/advice.rs
@@ -54,14 +54,6 @@ fn save_cached(advice: &str, short: &str) -> Result<()> {
     Ok(())
 }
 
-fn signal_label(s: Signal) -> &'static str {
-    match s {
-        Signal::Green => "green",
-        Signal::Yellow => "yellow",
-        Signal::Red => "red",
-    }
-}
-
 fn build_prompt(score: &ScoreResult) -> String {
     let mut lines = Vec::new();
     lines.push(t!("Current metrics:", "当前指标:").to_string());
@@ -74,7 +66,7 @@ fn build_prompt(score: &ScoreResult) -> String {
         lines.push(format!(
             "- {} [{}]: {}",
             layer_display(&layer.name),
-            signal_label(layer.signal),
+            layer.signal.as_str(),
             inds.join(", ")
         ));
     }

--- a/apps/mirror/src/dashboard.rs
+++ b/apps/mirror/src/dashboard.rs
@@ -1,5 +1,5 @@
 use crate::lang::t;
-use crate::score::{self, ScoreResult, Signal};
+use crate::score::{self, ScoreResult};
 use anyhow::{Context, Result};
 use refine_core::knowledge::ItemRepository;
 use refine_core::session::cluster_observations;
@@ -28,11 +28,11 @@ fn box_w() -> usize {
     76
 }
 
-pub async fn handle_dashboard(
-    repo: Arc<dyn ItemRepository>,
-    since: Option<String>,
-) -> Result<()> {
-    let all_items = repo.find_all().await.map_err(|e| anyhow::anyhow!("{}", e))?;
+pub async fn handle_dashboard(repo: Arc<dyn ItemRepository>, since: Option<String>) -> Result<()> {
+    let all_items = repo
+        .find_all()
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
     let items = score::filter_since(all_items, &since)?;
     if items.is_empty() {
         println!(
@@ -56,7 +56,10 @@ pub async fn handle_dashboard(
     let w = box_w();
 
     p(&border_top(w));
-    p(&row_center(t!("Mirror Cognitive Dashboard", "Mirror 认知仪表盘"), w));
+    p(&row_center(
+        t!("Mirror Cognitive Dashboard", "Mirror 认知仪表盘"),
+        w,
+    ));
     p(&border_mid(w));
 
     let pad: usize = t!(14, 10);
@@ -77,7 +80,10 @@ pub async fn handle_dashboard(
         Some(ref t) => format!("{}{}", t!("Tension: ", "张力: "), t),
         None => t!("Tension: no obvious conflict", "张力: 无明显维度冲突").to_string(),
     };
-    p(&padded_row(&format!(" {}", truncate(&tension_text, w - 4)), w));
+    p(&padded_row(
+        &format!(" {}", truncate(&tension_text, w - 4)),
+        w,
+    ));
     p(&border_mid(w));
 
     p(&padded_row(
@@ -107,7 +113,11 @@ fn p(s: &str) {
 }
 
 fn format_indicator(ind: &score::Indicator) -> String {
-    format!("{} {}", score::indicator_display(&ind.name), ind.display_value())
+    format!(
+        "{} {}",
+        score::indicator_display(&ind.name),
+        ind.display_value()
+    )
 }
 
 fn print_trend(current: &ScoreResult, w: usize) -> Result<()> {
@@ -123,7 +133,7 @@ fn print_trend(current: &ScoreResult, w: usize) -> Result<()> {
             let lights: String = s
                 .layers
                 .iter()
-                .map(|l| signal_ansi(l.signal))
+                .map(|l| l.signal.to_string())
                 .collect::<Vec<_>>()
                 .join("");
             format!("{} {}", date, lights)
@@ -131,14 +141,6 @@ fn print_trend(current: &ScoreResult, w: usize) -> Result<()> {
         .collect();
     p(&padded_row(&format!("  {}", entries.join("  ")), w));
     Ok(())
-}
-
-fn signal_ansi(s: Signal) -> &'static str {
-    match s {
-        Signal::Green => "\x1b[32m●\x1b[0m",
-        Signal::Yellow => "\x1b[33m●\x1b[0m",
-        Signal::Red => "\x1b[31m●\x1b[0m",
-    }
 }
 
 fn truncate(s: &str, max_w: usize) -> String {
@@ -190,7 +192,12 @@ fn row_center(text: &str, w: usize) -> String {
     let inner = w.saturating_sub(2);
     let left = inner.saturating_sub(tw) / 2;
     let right = inner.saturating_sub(tw).saturating_sub(left);
-    format!("\u{2551}{}{}{}\u{2551}", " ".repeat(left), text, " ".repeat(right))
+    format!(
+        "\u{2551}{}{}{}\u{2551}",
+        " ".repeat(left),
+        text,
+        " ".repeat(right)
+    )
 }
 
 fn padded_row(content: &str, w: usize) -> String {

--- a/apps/mirror/src/motd.rs
+++ b/apps/mirror/src/motd.rs
@@ -18,14 +18,6 @@ fn default_lang_en() -> String {
     "en".into()
 }
 
-fn signal_emoji(s: Signal) -> &'static str {
-    match s {
-        Signal::Green => "🟢",
-        Signal::Yellow => "🟡",
-        Signal::Red => "🔴",
-    }
-}
-
 /// Signal severity: Red=0, Yellow=1, Green=2 (lower is worse)
 fn signal_severity(s: Signal) -> u8 {
     match s {
@@ -261,9 +253,9 @@ pub fn handle_motd() -> Result<()> {
         None
     };
 
-    let depth_e = signal_emoji(current.layers[0].signal);
-    let breadth_e = signal_emoji(current.layers[1].signal);
-    let collab_e = signal_emoji(current.layers[2].signal);
+    let depth_e = current.layers[0].signal.emoji();
+    let breadth_e = current.layers[1].signal.emoji();
+    let collab_e = current.layers[2].signal.emoji();
 
     // Trend arrows: compare current vs previous signals
     let depth_t = previous
@@ -342,10 +334,10 @@ mod tests {
     }
 
     #[test]
-    fn test_signal_emoji() {
-        assert_eq!(signal_emoji(Signal::Green), "🟢");
-        assert_eq!(signal_emoji(Signal::Yellow), "🟡");
-        assert_eq!(signal_emoji(Signal::Red), "🔴");
+    fn test_signal_emoji_method() {
+        assert_eq!(Signal::Green.emoji(), "🟢");
+        assert_eq!(Signal::Yellow.emoji(), "🟡");
+        assert_eq!(Signal::Red.emoji(), "🔴");
     }
 
     #[test]

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -45,6 +45,24 @@ pub enum Signal {
     Red,
 }
 
+impl Signal {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Signal::Green => "green",
+            Signal::Yellow => "yellow",
+            Signal::Red => "red",
+        }
+    }
+
+    pub const fn emoji(self) -> &'static str {
+        match self {
+            Signal::Green => "🟢",
+            Signal::Yellow => "🟡",
+            Signal::Red => "🔴",
+        }
+    }
+}
+
 impl std::fmt::Display for Signal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -1163,6 +1181,21 @@ mod tests {
         // knowledge_rate / friction_density did not exist in older snapshots.
         remove_indicator(result, "knowledge_rate");
         remove_indicator(result, "friction_density");
+    }
+
+    #[test]
+    fn test_signal_conversions_are_canonical() {
+        let cases = [
+            (Signal::Green, "green", "🟢", "\x1b[32m●\x1b[0m"),
+            (Signal::Yellow, "yellow", "🟡", "\x1b[33m●\x1b[0m"),
+            (Signal::Red, "red", "🔴", "\x1b[31m●\x1b[0m"),
+        ];
+
+        for (signal, plain, emoji, ansi) in cases {
+            assert_eq!(signal.as_str(), plain);
+            assert_eq!(signal.emoji(), emoji);
+            assert_eq!(signal.to_string(), ansi);
+        }
     }
 
     #[test]

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -1,6 +1,6 @@
 use crate::config::{ensure_mirror_dir, mirror_dir};
 use crate::lang::t;
-use crate::score::{self, LayerScore, ScoreResult, Signal};
+use crate::score::{self, LayerScore, ScoreResult};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, Utc};
 use refine_core::infra::LlmClient;
@@ -130,17 +130,9 @@ fn format_layer(layer: &LayerScore) -> String {
     format!(
         "{}[{}]: {}",
         score::layer_display(&layer.name),
-        signal_str(&layer.signal),
+        layer.signal.as_str(),
         indicators.join(", ")
     )
-}
-
-fn signal_str(s: &Signal) -> &'static str {
-    match s {
-        Signal::Green => "green",
-        Signal::Yellow => "yellow",
-        Signal::Red => "red",
-    }
 }
 
 pub fn build_weekly_prompt(
@@ -302,15 +294,15 @@ fn save_weekly_record(score: &ScoreResult, suggestions: Vec<String>) -> Result<(
         scores: [
             LayerSignal {
                 name: score.layers[0].name.clone(),
-                signal: signal_str(&score.layers[0].signal).to_string(),
+                signal: score.layers[0].signal.as_str().to_string(),
             },
             LayerSignal {
                 name: score.layers[1].name.clone(),
-                signal: signal_str(&score.layers[1].signal).to_string(),
+                signal: score.layers[1].signal.as_str().to_string(),
             },
             LayerSignal {
                 name: score.layers[2].name.clone(),
-                signal: signal_str(&score.layers[2].signal).to_string(),
+                signal: score.layers[2].signal.as_str().to_string(),
             },
         ],
         suggestions,
@@ -390,6 +382,7 @@ async fn llm_with_retry(client: &Arc<dyn LlmClient>, prompt: &str, system: &str)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::score::Signal;
     use refine_core::knowledge::{ItemId, RestoreParams, Tag};
 
     fn make_item_at(time: DateTime<Utc>, idx: usize) -> Item {


### PR DESCRIPTION
## Summary
- centralize Signal conversion in mirror on `Signal::as_str()`, `Signal::emoji()`, and existing `Display`
- remove duplicated conversion helpers in `dashboard.rs`, `motd.rs`, `weekly.rs`, and `advice.rs`
- add canonical conversion test coverage in `score.rs` and update MOTD emoji test

## Validation
- cargo fmt --all
- cargo clippy -p mirror --all-targets -- -D warnings
- cargo test -p mirror test_signal_conversions_are_canonical
- cargo test -p mirror test_signal_emoji_method
- cargo test -p mirror

Refs: FUT-107
