### PR TITLE
fix(mirror): make persist_score atomic via read-modify-write + rename

### DIFF
--- a/apps/mirror/Cargo.toml
+++ b/apps/mirror/Cargo.toml
@@ -21,6 +21,7 @@ chrono.workspace = true
 dirs = "5"
 toml = "0.8"
 unicode-width = "0.2"
+fs2 = "0.4.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -2,6 +2,7 @@ use crate::config::{ensure_mirror_dir, mirror_dir, Targets};
 use crate::lang::t;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, NaiveDate, Utc};
+use fs2::FileExt;
 use refine_core::knowledge::{Item, ItemRepository};
 use refine_core::session::{cluster_observations, ClusterResult, GlobalStats};
 use serde::{Deserialize, Serialize};
@@ -737,19 +738,34 @@ static PERSIST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 pub fn persist_score(result: &ScoreResult) -> Result<()> {
     let dir = ensure_mirror_dir()?;
     let path = dir.join("scores.jsonl");
+    let lock_path = dir.join("scores.jsonl.lock");
     let new_line = serde_json::to_string(result)?;
 
+    // Intra-process serialisation.
     let mutex = PERSIST_LOCK.get_or_init(|| Mutex::new(()));
     let _guard = mutex.lock().map_err(|_| anyhow::anyhow!("persist_score: lock poisoned"))?;
 
-    // Read existing lines
+    // Cross-process serialisation: acquire an exclusive flock on the lock file
+    // before touching scores.jsonl.  Both the read and the rename happen while
+    // this lock is held, so no other process can interleave its own
+    // read-modify-write and silently drop entries.
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("persist_score: open lock file {}", lock_path.display()))?;
+    lock_file
+        .lock_exclusive()
+        .with_context(|| format!("persist_score: acquire lock {}", lock_path.display()))?;
+
+    // Read existing lines (while lock is held).
     let existing = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
         Err(e) => return Err(e.into()),
     };
 
-    // Build updated line list in memory, then rotate
+    // Build updated line list in memory, then rotate.
     let mut lines: Vec<&str> = existing.lines().collect();
     lines.push(&new_line);
     if lines.len() > 365 {
@@ -758,9 +774,7 @@ pub fn persist_score(result: &ScoreResult) -> Result<()> {
     }
     let content = lines.join("\n") + "\n";
 
-    // Atomic write: unique temp file → rename.
-    // Using PID + nanoseconds makes the temp path unique per process and per
-    // call, so concurrent processes cannot clobber each other's temp file.
+    // Atomic write: unique temp file → rename (still inside the flock).
     let tmp = path.with_file_name(format!(
         "scores.jsonl.{}.{}.tmp",
         std::process::id(),
@@ -772,6 +786,7 @@ pub fn persist_score(result: &ScoreResult) -> Result<()> {
     std::fs::write(&tmp, &content)?;
     std::fs::rename(&tmp, &path)?;
 
+    // flock is released when lock_file is dropped here.
     Ok(())
 }
 

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Duration, NaiveDate, Utc};
 use refine_core::knowledge::{Item, ItemRepository};
 use refine_core::session::{cluster_observations, ClusterResult, GlobalStats};
 use serde::{Deserialize, Serialize};
-use std::io::{BufRead, Write};
+use std::io::BufRead;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -732,22 +732,29 @@ pub fn compute(cluster: &ClusterResult, targets: &Targets) -> ScoreResult {
 pub fn persist_score(result: &ScoreResult) -> Result<()> {
     let dir = ensure_mirror_dir()?;
     let path = dir.join("scores.jsonl");
-    let line = serde_json::to_string(result)?;
+    let new_line = serde_json::to_string(result)?;
 
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)?;
-    writeln!(file, "{}", line)?;
-    drop(file);
+    // Read existing lines
+    let existing = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e.into()),
+    };
 
-    // Rotate: keep last 365 entries
-    let content = std::fs::read_to_string(&path)?;
-    let lines: Vec<&str> = content.lines().collect();
+    // Build updated line list in memory, then rotate
+    let mut lines: Vec<&str> = existing.lines().collect();
+    lines.push(&new_line);
     if lines.len() > 365 {
-        let keep = &lines[lines.len() - 365..];
-        std::fs::write(&path, keep.join("\n") + "\n")?;
+        let drop_n = lines.len() - 365;
+        lines.drain(..drop_n);
     }
+    let content = lines.join("\n") + "\n";
+
+    // Atomic write: temp file → rename
+    let tmp = path.with_extension("jsonl.tmp");
+    std::fs::write(&tmp, &content)?;
+    std::fs::rename(&tmp, &path)?;
+
     Ok(())
 }
 
@@ -931,6 +938,7 @@ mod tests {
     use super::*;
     use refine_core::session::{ClusterResult, GlobalStats, ProjectCluster};
     use std::collections::HashMap;
+    use std::io::Write;
 
     fn make_cluster(
         cognitive: HashMap<String, usize>,
@@ -1821,5 +1829,63 @@ mod tests {
         let l3 = layer3(&cluster, &t);
         assert_eq!(l3.indicators.len(), 4);
         assert_eq!(l3.indicators[3].name, "friction_density");
+    }
+
+    #[test]
+    fn test_persist_score_atomic_rotate() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("scores.jsonl");
+
+        let make = |signal: Signal| ScoreResult {
+            layers: [
+                LayerScore {
+                    name: "L1".into(),
+                    signal,
+                    indicators: Vec::new(),
+                },
+                LayerScore {
+                    name: "L2".into(),
+                    signal,
+                    indicators: Vec::new(),
+                },
+                LayerScore {
+                    name: "L3".into(),
+                    signal,
+                    indicators: Vec::new(),
+                },
+            ],
+            tension: None,
+            timestamp: Utc::now(),
+        };
+
+        // Write 365 lines manually to prime the file.
+        let lines: Vec<String> = (0..365)
+            .map(|_| serde_json::to_string(&make(Signal::Yellow)))
+            .collect::<Result<_, _>>()?;
+        std::fs::write(&path, lines.join("\n") + "\n")?;
+
+        // Apply the same rotate+atomic logic as persist_score.
+        let new_line = serde_json::to_string(&make(Signal::Green))?;
+        let existing = std::fs::read_to_string(&path)?;
+        let mut file_lines: Vec<&str> = existing.lines().collect();
+        file_lines.push(&new_line);
+        if file_lines.len() > 365 {
+            let drop_n = file_lines.len() - 365;
+            file_lines.drain(..drop_n);
+        }
+        let content = file_lines.join("\n") + "\n";
+        let tmp = path.with_extension("jsonl.tmp");
+        std::fs::write(&tmp, &content)?;
+        std::fs::rename(&tmp, &path)?;
+        assert!(!tmp.exists(), "temp file must be removed after rename");
+
+        // Exactly 365 entries remain and the last is the green one.
+        let loaded = load_recent_scores_from_path(&path, 1000)?;
+        assert_eq!(loaded.len(), 365);
+        assert_eq!(
+            loaded.last().map(|r| r.layers[0].signal),
+            Some(Signal::Green)
+        );
+        Ok(())
     }
 }

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -7,7 +7,7 @@ use refine_core::session::{cluster_observations, ClusterResult, GlobalStats};
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 
 /// Filter items to only those created since the given date string (YYYY-MM-DD).
 /// If `since` is None, returns all items unchanged.
@@ -729,10 +729,18 @@ pub fn compute(cluster: &ClusterResult, targets: &Targets) -> ScoreResult {
 
 // ── Persistence ──
 
+/// Process-level mutex so that concurrent `persist_score` calls within the
+/// same process are serialised: only one caller holds the lock while it
+/// reads, modifies, and atomically renames the JSONL file.
+static PERSIST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
 pub fn persist_score(result: &ScoreResult) -> Result<()> {
     let dir = ensure_mirror_dir()?;
     let path = dir.join("scores.jsonl");
     let new_line = serde_json::to_string(result)?;
+
+    let mutex = PERSIST_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = mutex.lock().map_err(|_| anyhow::anyhow!("persist_score: lock poisoned"))?;
 
     // Read existing lines
     let existing = match std::fs::read_to_string(&path) {
@@ -750,8 +758,17 @@ pub fn persist_score(result: &ScoreResult) -> Result<()> {
     }
     let content = lines.join("\n") + "\n";
 
-    // Atomic write: temp file → rename
-    let tmp = path.with_extension("jsonl.tmp");
+    // Atomic write: unique temp file → rename.
+    // Using PID + nanoseconds makes the temp path unique per process and per
+    // call, so concurrent processes cannot clobber each other's temp file.
+    let tmp = path.with_file_name(format!(
+        "scores.jsonl.{}.{}.tmp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos()
+    ));
     std::fs::write(&tmp, &content)?;
     std::fs::rename(&tmp, &path)?;
 


### PR DESCRIPTION
## Summary
- Replace append-then-overwrite with read→append-in-memory→write-to-temp→rename so concurrent writes cannot lose data
- Rotation (keep last 365 entries) is now applied in memory before the atomic rename, eliminating the TOCTOU window
- Temp file is cleaned up automatically by the rename; no partial state left on disk

## Test plan
- [ ] `cargo test --workspace` passes
- [ ] New test `test_persist_score_atomic_rotate` verifies rotation ceiling (365 entries) and that the last entry is correct after a rotate