### PR TITLE
fix(mirror): add serde defaults for ScoreResult/WeeklyRecord

### DIFF
--- a/apps/mirror/src/score/tests.rs
+++ b/apps/mirror/src/score/tests.rs
@@ -435,6 +435,20 @@ fn test_load_recent_scores_reports_invalid_jsonl_line() {
 }
 
 #[test]
+fn test_load_recent_scores_accepts_legacy_missing_timestamp() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("scores.jsonl");
+
+    let legacy_line = r#"{"layers":[{"name":"L1","signal":"Green","indicators":[]},{"name":"L2","signal":"Yellow","indicators":[]},{"name":"L3","signal":"Red","indicators":[]}],"tension":"legacy tension"}"#;
+    std::fs::write(&path, format!("{}\n", legacy_line)).unwrap();
+
+    let loaded = load_recent_scores_from_path(&path, 10).unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].tension.as_deref(), Some("legacy tension"));
+    assert_eq!(loaded[0].timestamp, DateTime::<Utc>::UNIX_EPOCH);
+}
+
+#[test]
 fn test_personal_baseline_calculation() {
     let now = Utc::now();
     // Build 10 historical scores within the last 28 days

--- a/apps/mirror/src/score/types.rs
+++ b/apps/mirror/src/score/types.rs
@@ -64,10 +64,41 @@ pub struct LayerScore {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct ScoreResult {
     pub layers: [LayerScore; 3],
     pub tension: Option<String>,
     pub timestamp: DateTime<Utc>,
+}
+
+impl Default for ScoreResult {
+    fn default() -> Self {
+        Self {
+            layers: default_layers(),
+            tension: None,
+            timestamp: DateTime::<Utc>::UNIX_EPOCH,
+        }
+    }
+}
+
+fn default_layers() -> [LayerScore; 3] {
+    [
+        LayerScore {
+            name: "depth".to_string(),
+            signal: Signal::Yellow,
+            indicators: Vec::new(),
+        },
+        LayerScore {
+            name: "breadth".to_string(),
+            signal: Signal::Yellow,
+            indicators: Vec::new(),
+        },
+        LayerScore {
+            name: "collaboration".to_string(),
+            signal: Signal::Yellow,
+            indicators: Vec::new(),
+        },
+    ]
 }
 
 /// Green > Yellow > Red

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -24,10 +24,34 @@ fn system_prompt() -> &'static str {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct WeeklyRecord {
     pub week_end: DateTime<Utc>,
     pub scores: [LayerSignal; 3],
     pub suggestions: Vec<String>,
+}
+
+impl Default for WeeklyRecord {
+    fn default() -> Self {
+        Self {
+            week_end: DateTime::<Utc>::UNIX_EPOCH,
+            scores: [
+                LayerSignal {
+                    name: "depth".to_string(),
+                    signal: "yellow".to_string(),
+                },
+                LayerSignal {
+                    name: "breadth".to_string(),
+                    signal: "yellow".to_string(),
+                },
+                LayerSignal {
+                    name: "collaboration".to_string(),
+                    signal: "yellow".to_string(),
+                },
+            ],
+            suggestions: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -558,5 +582,22 @@ Everything looks good. No changes needed.
         let last = load_last_weekly_record_from_path(&path).unwrap();
         assert!(last.is_some());
         assert_eq!(last.unwrap().suggestions, vec!["second".to_string()]);
+    }
+
+    #[test]
+    fn test_load_last_weekly_record_accepts_legacy_missing_suggestions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("weekly-history.jsonl");
+        let legacy_line = format!(
+            "{{\"week_end\":\"{}\",\"scores\":[{{\"name\":\"depth\",\"signal\":\"green\"}},{{\"name\":\"breadth\",\"signal\":\"yellow\"}},{{\"name\":\"collaboration\",\"signal\":\"red\"}}]}}",
+            Utc::now().to_rfc3339()
+        );
+        std::fs::write(&path, format!("{}\n", legacy_line)).unwrap();
+
+        let record = load_last_weekly_record_from_path(&path)
+            .unwrap()
+            .expect("expected record from legacy line");
+        assert!(record.suggestions.is_empty());
+        assert_eq!(record.scores[0].name, "depth");
     }
 }


### PR DESCRIPTION
## Summary
- add `#[serde(default)]` + `Default` impl for `ScoreResult`
- add `#[serde(default)]` + `Default` impl for `WeeklyRecord`
- add legacy JSONL regression tests for missing `timestamp` and missing `suggestions`

## Validation
- cargo fmt --all
- cargo test -p mirror legacy_missing -- --nocapture
- cargo test -p mirror
- cargo run -p mirror -- motd (with legacy score line missing timestamp)

## Linear
- FUT-109
