### PR TITLE
Reduce indicator extension cost via declarative registry

### DIFF
--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -1,6 +1,7 @@
 mod baseline;
 mod compute;
 mod display;
+mod indicators;
 mod persistence;
 mod types;
 

--- a/apps/mirror/src/score/baseline.rs
+++ b/apps/mirror/src/score/baseline.rs
@@ -1,6 +1,8 @@
 use chrono::{Duration, Utc};
+use std::collections::HashMap;
 
 use super::compute::analyze_tension;
+use super::indicators::{canonical_indicator_key, indicator_higher_is_better, indicator_specs};
 use super::types::{worst, ScoreResult, Signal};
 
 /// Minimum number of historical scores to activate personal baseline
@@ -10,52 +12,55 @@ const BASELINE_MIN_ENTRIES: usize = 7;
 const BASELINE_WINDOW_DAYS: i64 = 28;
 
 /// 4-week rolling averages for each indicator
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PersonalBaseline {
-    pub dreyfus_avg: f64,
-    pub decision_quality_avg: f64,
-    pub depth_output_avg: f64,
-    pub exploration_avg: f64,
-    pub deep_invest_avg: f64,
-    pub fragmentation_avg: f64,
-    pub delegation_avg: f64,
-    pub mode_diversity_avg: f64,
-    pub bug_decision_avg: f64,
-    pub knowledge_rate_avg: f64,
-    pub friction_density_avg: f64,
+    averages: HashMap<String, f64>,
+}
+
+impl PersonalBaseline {
+    pub fn average(&self, name: &str) -> Option<f64> {
+        self.averages.get(name).copied()
+    }
+
+    #[cfg(test)]
+    pub fn from_averages(entries: &[(&str, f64)]) -> Self {
+        Self {
+            averages: entries
+                .iter()
+                .map(|(name, value)| ((*name).to_string(), *value))
+                .collect(),
+        }
+    }
 }
 
 /// Extract a named indicator's actual value from a ScoreResult.
 /// Returns None if the indicator is not found.
 fn extract_indicator(result: &ScoreResult, name: &str) -> Option<f64> {
-    fn canonical_indicator_name(raw: &str) -> &str {
-        match raw {
-            // Legacy localized/label names in historical snapshots.
-            "决策质量" | "Decision Quality" => "decision_quality",
-            "深度产出比" | "Depth Output" => "depth_output",
-            "探索率" | "探索占比" | "Exploration" => "exploration",
-            "深耕率" | "深挖率" | "深挖占比" | "Deep Invest" => "deep_invest",
-            "碎片化" | "Fragmentation" => "fragmentation",
-            "委派率" | "委派比" | "delegation" | "Delegation" => "delegation",
-            "模式多样性" | "Mode Diversity" => "mode_diversity",
-            "bug/决策" | "Bug/Decision" | "bug/decision" => "bug_decision",
-            "知识获取" | "Knowledge" => "knowledge_rate",
-            "摩擦密度" | "Friction" => "friction_density",
-            "Dreyfus" => "dreyfus",
-            _ => raw,
-        }
-    }
-
     result
         .layers
         .iter()
         .flat_map(|l| &l.indicators)
-        .find(|i| canonical_indicator_name(&i.name) == name)
+        .find(|i| canonical_indicator_key(&i.name) == name)
         .map(|i| i.actual)
 }
 
 /// Compute personal baseline from historical scores within the last 28 days.
 /// Returns None if fewer than BASELINE_MIN_ENTRIES scores exist in that window.
+fn avg_from_scores(scores: &[&ScoreResult], indicator_name: &str) -> f64 {
+    let (sum, count) = scores
+        .iter()
+        .filter_map(|score| extract_indicator(score, indicator_name))
+        .fold((0.0, 0usize), |(sum, count), value| {
+            (sum + value, count + 1)
+        });
+
+    if count == 0 {
+        0.0
+    } else {
+        sum / count as f64
+    }
+}
+
 pub fn compute_personal_baseline(history: &[ScoreResult]) -> Option<PersonalBaseline> {
     let cutoff = Utc::now() - Duration::days(BASELINE_WINDOW_DAYS);
     let recent: Vec<&ScoreResult> = history.iter().filter(|s| s.timestamp >= cutoff).collect();
@@ -64,34 +69,12 @@ pub fn compute_personal_baseline(history: &[ScoreResult]) -> Option<PersonalBase
         return None;
     }
 
-    let avg = |name: &str| -> f64 {
-        let (sum, count) = recent
-            .iter()
-            .filter_map(|s| extract_indicator(s, name))
-            .fold((0.0, 0usize), |(sum, count), value| {
-                (sum + value, count + 1)
-            });
+    let averages = indicator_specs()
+        .iter()
+        .map(|spec| (spec.key.to_string(), avg_from_scores(&recent, spec.key)))
+        .collect();
 
-        if count == 0 {
-            0.0
-        } else {
-            sum / count as f64
-        }
-    };
-
-    Some(PersonalBaseline {
-        dreyfus_avg: avg("dreyfus"),
-        decision_quality_avg: avg("decision_quality"),
-        depth_output_avg: avg("depth_output"),
-        exploration_avg: avg("exploration"),
-        deep_invest_avg: avg("deep_invest"),
-        fragmentation_avg: avg("fragmentation"),
-        delegation_avg: avg("delegation"),
-        mode_diversity_avg: avg("mode_diversity"),
-        bug_decision_avg: avg("bug_decision"),
-        knowledge_rate_avg: avg("knowledge_rate"),
-        friction_density_avg: avg("friction_density"),
-    })
+    Some(PersonalBaseline { averages })
 }
 
 /// Determine signal by comparing actual value against personal baseline.
@@ -122,83 +105,22 @@ pub fn signal_from_personal(actual: f64, baseline: f64, higher_is_better: bool) 
     }
 }
 
-/// Indicator config for personal baseline re-judgment
-struct IndicatorMeta {
-    name: &'static str,
-    baseline_value: f64,
-    higher_is_better: bool,
-}
-
 /// Apply personal baseline to override signals on a ScoreResult (in-place).
 pub(super) fn apply_personal_baseline(result: &mut ScoreResult, baseline: &PersonalBaseline) {
-    let metas = [
-        IndicatorMeta {
-            name: "dreyfus",
-            baseline_value: baseline.dreyfus_avg,
-            higher_is_better: true,
-        },
-        IndicatorMeta {
-            name: "decision_quality",
-            baseline_value: baseline.decision_quality_avg,
-            higher_is_better: true,
-        },
-        IndicatorMeta {
-            name: "depth_output",
-            baseline_value: baseline.depth_output_avg,
-            higher_is_better: true,
-        },
-        IndicatorMeta {
-            name: "exploration",
-            baseline_value: baseline.exploration_avg,
-            higher_is_better: true,
-        },
-        IndicatorMeta {
-            name: "deep_invest",
-            baseline_value: baseline.deep_invest_avg,
-            higher_is_better: true,
-        },
-        IndicatorMeta {
-            name: "fragmentation",
-            baseline_value: baseline.fragmentation_avg,
-            higher_is_better: false,
-        },
-        IndicatorMeta {
-            name: "delegation",
-            baseline_value: baseline.delegation_avg,
-            higher_is_better: false,
-        },
-        IndicatorMeta {
-            name: "mode_diversity",
-            baseline_value: baseline.mode_diversity_avg,
-            higher_is_better: true,
-        },
-        IndicatorMeta {
-            name: "bug_decision",
-            baseline_value: baseline.bug_decision_avg,
-            higher_is_better: false,
-        },
-        IndicatorMeta {
-            name: "knowledge_rate",
-            baseline_value: baseline.knowledge_rate_avg,
-            higher_is_better: true,
-        },
-        IndicatorMeta {
-            name: "friction_density",
-            baseline_value: baseline.friction_density_avg,
-            higher_is_better: false,
-        },
-    ];
-
     for layer in &mut result.layers {
         for indicator in &mut layer.indicators {
-            if let Some(meta) = metas.iter().find(|m| m.name == indicator.name) {
-                indicator.signal = signal_from_personal(
-                    indicator.actual,
-                    meta.baseline_value,
-                    meta.higher_is_better,
-                );
-            }
+            let key = canonical_indicator_key(&indicator.name);
+            let Some(higher_is_better) = indicator_higher_is_better(key) else {
+                continue;
+            };
+            let Some(baseline_value) = baseline.average(key) else {
+                continue;
+            };
+
+            indicator.signal =
+                signal_from_personal(indicator.actual, baseline_value, higher_is_better);
         }
+
         // Recalculate layer signal as worst of its indicators
         let sigs: Vec<Signal> = layer.indicators.iter().map(|i| i.signal).collect();
         layer.signal = worst(&sigs);

--- a/apps/mirror/src/score/display.rs
+++ b/apps/mirror/src/score/display.rs
@@ -1,5 +1,6 @@
 use crate::lang::t;
 
+use super::indicators::indicator_display_name;
 use super::types::{ScoreResult, Signal};
 
 // ── Display helpers ──
@@ -14,20 +15,7 @@ pub fn layer_display(key: &str) -> &'static str {
 }
 
 pub fn indicator_display(key: &str) -> &'static str {
-    match key {
-        "dreyfus" => "Dreyfus",
-        "decision_quality" => t!("Decision Quality", "决策质量"),
-        "depth_output" => t!("Depth Output", "深度产出比"),
-        "exploration" => t!("Exploration", "探索率"),
-        "deep_invest" => t!("Deep Invest", "深耕率"),
-        "fragmentation" => t!("Fragmentation", "碎片化"),
-        "delegation" => "delegation",
-        "mode_diversity" => t!("Mode Diversity", "模式多样性"),
-        "bug_decision" => "bug/decision",
-        "knowledge_rate" => t!("Knowledge", "知识获取"),
-        "friction_density" => t!("Friction", "摩擦密度"),
-        _ => "unknown",
-    }
+    indicator_display_name(key)
 }
 
 // ── Output ──

--- a/apps/mirror/src/score/indicators.rs
+++ b/apps/mirror/src/score/indicators.rs
@@ -1,0 +1,163 @@
+use crate::lang::{lang, Lang};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum IndicatorFormat {
+    Percent0,
+    Fixed1,
+    Fixed2,
+    Integer,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct IndicatorSpec {
+    pub key: &'static str,
+    pub format: IndicatorFormat,
+    pub higher_is_better: bool,
+    aliases: &'static [&'static str],
+    display_en: &'static str,
+    display_zh: &'static str,
+}
+
+impl IndicatorSpec {
+    fn display_name(self) -> &'static str {
+        match lang() {
+            Lang::En => self.display_en,
+            Lang::Zh => self.display_zh,
+        }
+    }
+
+    fn matches(self, raw: &str) -> bool {
+        self.key == raw || self.aliases.contains(&raw)
+    }
+}
+
+const INDICATOR_SPECS: [IndicatorSpec; 11] = [
+    IndicatorSpec {
+        key: "dreyfus",
+        format: IndicatorFormat::Fixed1,
+        higher_is_better: true,
+        aliases: &["Dreyfus"],
+        display_en: "Dreyfus",
+        display_zh: "Dreyfus",
+    },
+    IndicatorSpec {
+        key: "decision_quality",
+        format: IndicatorFormat::Percent0,
+        higher_is_better: true,
+        aliases: &["Decision Quality", "决策质量"],
+        display_en: "Decision Quality",
+        display_zh: "决策质量",
+    },
+    IndicatorSpec {
+        key: "depth_output",
+        format: IndicatorFormat::Percent0,
+        higher_is_better: true,
+        aliases: &["Depth Output", "深度产出比"],
+        display_en: "Depth Output",
+        display_zh: "深度产出比",
+    },
+    IndicatorSpec {
+        key: "knowledge_rate",
+        format: IndicatorFormat::Fixed1,
+        higher_is_better: true,
+        aliases: &["Knowledge", "知识获取"],
+        display_en: "Knowledge",
+        display_zh: "知识获取",
+    },
+    IndicatorSpec {
+        key: "exploration",
+        format: IndicatorFormat::Percent0,
+        higher_is_better: true,
+        aliases: &["Exploration", "探索率", "探索占比"],
+        display_en: "Exploration",
+        display_zh: "探索率",
+    },
+    IndicatorSpec {
+        key: "deep_invest",
+        format: IndicatorFormat::Percent0,
+        higher_is_better: true,
+        aliases: &["Deep Invest", "深耕率", "深挖率", "深挖占比"],
+        display_en: "Deep Invest",
+        display_zh: "深耕率",
+    },
+    IndicatorSpec {
+        key: "fragmentation",
+        format: IndicatorFormat::Percent0,
+        higher_is_better: false,
+        aliases: &["Fragmentation", "碎片化"],
+        display_en: "Fragmentation",
+        display_zh: "碎片化",
+    },
+    IndicatorSpec {
+        key: "delegation",
+        format: IndicatorFormat::Percent0,
+        higher_is_better: false,
+        aliases: &["Delegation", "delegation", "委派率", "委派比"],
+        display_en: "delegation",
+        display_zh: "委派率",
+    },
+    IndicatorSpec {
+        key: "mode_diversity",
+        format: IndicatorFormat::Integer,
+        higher_is_better: true,
+        aliases: &["Mode Diversity", "模式多样性"],
+        display_en: "Mode Diversity",
+        display_zh: "模式多样性",
+    },
+    IndicatorSpec {
+        key: "bug_decision",
+        format: IndicatorFormat::Fixed2,
+        higher_is_better: false,
+        aliases: &["Bug/Decision", "bug/decision", "bug/决策"],
+        display_en: "bug/decision",
+        display_zh: "bug/决策",
+    },
+    IndicatorSpec {
+        key: "friction_density",
+        format: IndicatorFormat::Fixed1,
+        higher_is_better: false,
+        aliases: &["Friction", "摩擦密度"],
+        display_en: "Friction",
+        display_zh: "摩擦密度",
+    },
+];
+
+pub(super) fn indicator_specs() -> &'static [IndicatorSpec] {
+    &INDICATOR_SPECS
+}
+
+fn find_indicator_spec(raw: &str) -> Option<&'static IndicatorSpec> {
+    indicator_specs().iter().find(|spec| spec.matches(raw))
+}
+
+pub(super) fn canonical_indicator_key(raw: &str) -> &str {
+    find_indicator_spec(raw).map_or(raw, |spec| spec.key)
+}
+
+pub(super) fn indicator_spec(key: &str) -> Option<&'static IndicatorSpec> {
+    indicator_specs()
+        .iter()
+        .find(|spec| spec.key == canonical_indicator_key(key))
+}
+
+pub(super) fn indicator_display_name(key: &str) -> &'static str {
+    indicator_spec(key)
+        .map(|spec| spec.display_name())
+        .unwrap_or("unknown")
+}
+
+pub(super) fn format_indicator_value(name: &str, actual: f64) -> String {
+    match indicator_spec(name)
+        .map(|spec| spec.format)
+        .unwrap_or(IndicatorFormat::Percent0)
+    {
+        IndicatorFormat::Percent0 => format!("{:.0}%", actual),
+        IndicatorFormat::Fixed1 => format!("{:.1}", actual),
+        IndicatorFormat::Fixed2 => format!("{:.2}", actual),
+        IndicatorFormat::Integer => format!("{}", actual as usize),
+    }
+}
+
+pub(super) fn indicator_higher_is_better(name: &str) -> Option<bool> {
+    indicator_spec(name).map(|spec| spec.higher_is_better)
+}

--- a/apps/mirror/src/score/tests.rs
+++ b/apps/mirror/src/score/tests.rs
@@ -573,17 +573,91 @@ fn test_personal_baseline_calculation() {
     );
 
     let bl = baseline.unwrap();
-    assert!((bl.dreyfus_avg - 3.5).abs() < f64::EPSILON);
-    assert!((bl.decision_quality_avg - 60.0).abs() < f64::EPSILON);
-    assert!((bl.depth_output_avg - 10.0).abs() < f64::EPSILON);
-    assert!((bl.exploration_avg - 20.0).abs() < f64::EPSILON);
-    assert!((bl.deep_invest_avg - 25.0).abs() < f64::EPSILON);
-    assert!((bl.fragmentation_avg - 15.0).abs() < f64::EPSILON);
-    assert!((bl.delegation_avg - 30.0).abs() < f64::EPSILON);
-    assert!((bl.mode_diversity_avg - 4.0).abs() < f64::EPSILON);
-    assert!((bl.bug_decision_avg - 0.20).abs() < f64::EPSILON);
-    assert!((bl.knowledge_rate_avg - 0.5).abs() < f64::EPSILON);
-    assert!((bl.friction_density_avg - 0.8).abs() < f64::EPSILON);
+    assert!((bl.average("dreyfus").unwrap() - 3.5).abs() < f64::EPSILON);
+    assert!((bl.average("decision_quality").unwrap() - 60.0).abs() < f64::EPSILON);
+    assert!((bl.average("depth_output").unwrap() - 10.0).abs() < f64::EPSILON);
+    assert!((bl.average("exploration").unwrap() - 20.0).abs() < f64::EPSILON);
+    assert!((bl.average("deep_invest").unwrap() - 25.0).abs() < f64::EPSILON);
+    assert!((bl.average("fragmentation").unwrap() - 15.0).abs() < f64::EPSILON);
+    assert!((bl.average("delegation").unwrap() - 30.0).abs() < f64::EPSILON);
+    assert!((bl.average("mode_diversity").unwrap() - 4.0).abs() < f64::EPSILON);
+    assert!((bl.average("bug_decision").unwrap() - 0.20).abs() < f64::EPSILON);
+    assert!((bl.average("knowledge_rate").unwrap() - 0.5).abs() < f64::EPSILON);
+    assert!((bl.average("friction_density").unwrap() - 0.8).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_computed_indicators_have_registry_backed_metadata() {
+    let t = Targets::default();
+    let now = Utc::now();
+    let score = compute(
+        &make_cluster_with_data(
+            {
+                let mut m = HashMap::new();
+                m.insert("expert".into(), 3);
+                m.insert("proficient".into(), 2);
+                m
+            },
+            {
+                let mut m = HashMap::new();
+                m.insert("exploration".into(), 12);
+                m.insert("delegation".into(), 8);
+                m.insert("pair_programming".into(), 4);
+                m.insert("review".into(), 3);
+                m.insert("deep_inquiry".into(), 6);
+                m
+            },
+            16,
+            5,
+            vec![
+                (
+                    "proj-a",
+                    6,
+                    vec!["because caching helps", "采用 sqlite"],
+                    vec!["slow ci", "flaky test"],
+                    vec!["learned retry policy", "learned tracing"],
+                ),
+                (
+                    "proj-b",
+                    4,
+                    vec!["选择 rust"],
+                    vec!["timeout"],
+                    vec!["learned batching"],
+                ),
+            ],
+        ),
+        &t,
+    );
+
+    let history: Vec<ScoreResult> = (0..7)
+        .map(|i| {
+            let mut entry = score.clone();
+            entry.timestamp = now - Duration::days(i);
+            entry
+        })
+        .collect();
+    let baseline = compute_personal_baseline(&history).expect("baseline should exist");
+
+    for layer in &score.layers {
+        for indicator in &layer.indicators {
+            assert_ne!(
+                indicator_display(&indicator.name),
+                "unknown",
+                "indicator {} missing display metadata",
+                indicator.name
+            );
+            assert!(
+                !indicator.display_value().is_empty(),
+                "indicator {} missing format metadata",
+                indicator.name
+            );
+            assert!(
+                baseline.average(&indicator.name).is_some(),
+                "indicator {} missing baseline metadata",
+                indicator.name
+            );
+        }
+    }
 }
 
 #[test]
@@ -692,19 +766,19 @@ fn test_personal_baseline_mixed_legacy_schema_repro() {
 
     // Expected baseline should be stable despite mixed history schema.
     assert!(
-        (bl.decision_quality_avg - 80.0).abs() < f64::EPSILON,
+        (bl.average("decision_quality").unwrap() - 80.0).abs() < f64::EPSILON,
         "mixed-schema decision_quality should stay at 80.0, got {}",
-        bl.decision_quality_avg
+        bl.average("decision_quality").unwrap()
     );
     assert!(
-        (bl.knowledge_rate_avg - 0.9).abs() < f64::EPSILON,
+        (bl.average("knowledge_rate").unwrap() - 0.9).abs() < f64::EPSILON,
         "missing legacy entries should not dilute knowledge_rate avg, got {}",
-        bl.knowledge_rate_avg
+        bl.average("knowledge_rate").unwrap()
     );
     assert!(
-        (bl.friction_density_avg - 0.7).abs() < f64::EPSILON,
+        (bl.average("friction_density").unwrap() - 0.7).abs() < f64::EPSILON,
         "missing legacy entries should not dilute friction_density avg, got {}",
-        bl.friction_density_avg
+        bl.average("friction_density").unwrap()
     );
 }
 
@@ -736,19 +810,19 @@ fn test_apply_personal_baseline() {
     let now = Utc::now();
 
     // Baseline averages
-    let baseline = PersonalBaseline {
-        dreyfus_avg: 3.0,
-        decision_quality_avg: 50.0,
-        depth_output_avg: 10.0,
-        exploration_avg: 20.0,
-        deep_invest_avg: 25.0,
-        fragmentation_avg: 15.0, // lower is better
-        delegation_avg: 30.0,    // lower is better
-        mode_diversity_avg: 4.0,
-        bug_decision_avg: 0.20, // lower is better
-        knowledge_rate_avg: 0.5,
-        friction_density_avg: 1.0, // lower is better
-    };
+    let baseline = PersonalBaseline::from_averages(&[
+        ("dreyfus", 3.0),
+        ("decision_quality", 50.0),
+        ("depth_output", 10.0),
+        ("exploration", 20.0),
+        ("deep_invest", 25.0),
+        ("fragmentation", 15.0), // lower is better
+        ("delegation", 30.0),    // lower is better
+        ("mode_diversity", 4.0),
+        ("bug_decision", 0.20), // lower is better
+        ("knowledge_rate", 0.5),
+        ("friction_density", 1.0), // lower is better
+    ]);
 
     // Current score: all significantly above baseline
     let mut result = make_score_result(
@@ -787,19 +861,19 @@ fn test_apply_personal_baseline() {
 fn test_apply_personal_baseline_regression() {
     let now = Utc::now();
 
-    let baseline = PersonalBaseline {
-        dreyfus_avg: 4.0,
-        decision_quality_avg: 70.0,
-        depth_output_avg: 15.0,
-        exploration_avg: 25.0,
-        deep_invest_avg: 30.0,
-        fragmentation_avg: 10.0,
-        delegation_avg: 20.0,
-        mode_diversity_avg: 5.0,
-        bug_decision_avg: 0.15,
-        knowledge_rate_avg: 0.8,
-        friction_density_avg: 0.5,
-    };
+    let baseline = PersonalBaseline::from_averages(&[
+        ("dreyfus", 4.0),
+        ("decision_quality", 70.0),
+        ("depth_output", 15.0),
+        ("exploration", 25.0),
+        ("deep_invest", 30.0),
+        ("fragmentation", 10.0),
+        ("delegation", 20.0),
+        ("mode_diversity", 5.0),
+        ("bug_decision", 0.15),
+        ("knowledge_rate", 0.8),
+        ("friction_density", 0.5),
+    ]);
 
     // Current: all significantly worse than baseline
     let mut result = make_score_result(

--- a/apps/mirror/src/score/types.rs
+++ b/apps/mirror/src/score/types.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use super::indicators::format_indicator_value;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Signal {
     Green,
@@ -46,13 +48,7 @@ pub struct Indicator {
 
 impl Indicator {
     pub fn display_value(&self) -> String {
-        match self.name.as_str() {
-            "mode_diversity" => format!("{}", self.actual as usize),
-            "bug_decision" => format!("{:.2}", self.actual),
-            "dreyfus" => format!("{:.1}", self.actual),
-            "knowledge_rate" | "friction_density" => format!("{:.1}", self.actual),
-            _ => format!("{:.0}%", self.actual),
-        }
+        format_indicator_value(&self.name, self.actual)
     }
 }
 


### PR DESCRIPTION
## Summary
- add `apps/mirror/src/score/indicators.rs` as a single indicator metadata registry (display labels, value formatting, baseline direction, legacy aliases)
- refactor score display/value formatting/personal-baseline logic to consume the registry instead of per-file hardcoded matches
- replace `PersonalBaseline` fixed fields with map-backed averages keyed by indicator name
- add a regression test ensuring every computed indicator has registry-backed display/format/baseline metadata

## Validation
- `cargo fmt --all`
- `cargo clippy -p mirror --all-targets -- -D warnings`
- `cargo test -p mirror computed_indicators_have_registry_backed_metadata`
- `cargo test -p mirror personal_baseline_mixed_legacy_schema_repro`
- `cargo test -p mirror`

Linear: FUT-112
