### PR TITLE
Deduplicate save_to_document in mirror

### DIFF
--- a/apps/mirror/src/document_save.rs
+++ b/apps/mirror/src/document_save.rs
@@ -1,0 +1,93 @@
+use anyhow::{Context, Result};
+use refine_core::knowledge::{Document, DocumentId, DocumentRepository};
+use std::sync::Arc;
+
+pub struct SaveDocumentOptions {
+    pub source: &'static str,
+    pub title_prefix: &'static str,
+    pub url_scheme: &'static str,
+    pub save_error_context: &'static str,
+}
+
+pub async fn save_report_to_document(
+    doc_repo: &Arc<dyn DocumentRepository>,
+    report: &str,
+    options: SaveDocumentOptions,
+) -> Result<DocumentId> {
+    let mut doc = Document::new(options.source, report);
+    let created_at = doc.created_at();
+    let title = format!("{} {}", options.title_prefix, created_at.format("%Y-%m-%d"));
+    doc.set_title(&title);
+    doc.set_url(&format!(
+        "{}://{}",
+        options.url_scheme,
+        created_at.to_rfc3339()
+    ));
+    doc_repo
+        .save(&doc)
+        .await
+        .context(options.save_error_context)?;
+
+    Ok(doc.id().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use refine_core::infra::SqliteStore;
+    use refine_core::knowledge::DocumentRepository;
+
+    #[tokio::test]
+    async fn test_save_report_to_document_sets_weekly_metadata() {
+        let store = Arc::new(SqliteStore::in_memory().unwrap());
+        let repo: Arc<dyn DocumentRepository> = store.clone();
+
+        let doc_id = save_report_to_document(
+            &repo,
+            "weekly report body",
+            SaveDocumentOptions {
+                source: "mirror-weekly",
+                title_prefix: "Mirror Weekly",
+                url_scheme: "mirror-weekly",
+                save_error_context: "Failed to save weekly report",
+            },
+        )
+        .await
+        .unwrap();
+
+        let saved = store.find_by_id(&doc_id).await.unwrap().unwrap();
+        let expected_title = format!("Mirror Weekly {}", saved.created_at().format("%Y-%m-%d"));
+        let expected_url = format!("mirror-weekly://{}", saved.created_at().to_rfc3339());
+        assert_eq!(saved.source(), "mirror-weekly");
+        assert_eq!(saved.raw_content(), "weekly report body");
+        assert_eq!(saved.title(), Some(expected_title.as_str()));
+        assert_eq!(saved.url(), expected_url.as_str());
+    }
+
+    #[tokio::test]
+    async fn test_save_report_to_document_sets_profile_metadata() {
+        let store = Arc::new(SqliteStore::in_memory().unwrap());
+        let repo: Arc<dyn DocumentRepository> = store.clone();
+
+        let doc_id = save_report_to_document(
+            &repo,
+            "profile narrative",
+            SaveDocumentOptions {
+                source: "mirror-profile",
+                title_prefix: "Mirror Profile",
+                url_scheme: "mirror-profile",
+                save_error_context: "Failed to save profile",
+            },
+        )
+        .await
+        .unwrap();
+
+        let saved = store.find_by_id(&doc_id).await.unwrap().unwrap();
+        let expected_title = format!("Mirror Profile {}", saved.created_at().format("%Y-%m-%d"));
+        let expected_url = format!("mirror-profile://{}", saved.created_at().to_rfc3339());
+        assert_eq!(saved.source(), "mirror-profile");
+        assert_eq!(saved.raw_content(), "profile narrative");
+        assert_eq!(saved.title(), Some(expected_title.as_str()));
+        assert_eq!(saved.url(), expected_url.as_str());
+    }
+}

--- a/apps/mirror/src/main.rs
+++ b/apps/mirror/src/main.rs
@@ -2,6 +2,7 @@ mod advice;
 mod cli;
 mod config;
 mod dashboard;
+mod document_save;
 mod lang;
 mod motd;
 mod profile;
@@ -37,9 +38,7 @@ async fn main() -> Result<()> {
     };
     ensure_db_dir(&db_path).map_err(|e| anyhow::anyhow!(e))?;
 
-    let store = Arc::new(
-        SqliteStore::open(&db_path).context("Failed to open database")?,
-    );
+    let store = Arc::new(SqliteStore::open(&db_path).context("Failed to open database")?);
 
     match cli.command {
         Commands::Score { since } => {

--- a/apps/mirror/src/profile.rs
+++ b/apps/mirror/src/profile.rs
@@ -1,10 +1,10 @@
 use crate::config::ensure_mirror_dir;
+use crate::document_save::{save_report_to_document, SaveDocumentOptions};
 use crate::lang::t;
 use crate::score::{self, layer_display, Signal};
-use anyhow::{Context, Result};
-use chrono::Utc;
+use anyhow::Result;
 use refine_core::infra::LlmClient;
-use refine_core::knowledge::{Document, DocumentRepository, Item, ItemRepository, ItemType};
+use refine_core::knowledge::{DocumentRepository, Item, ItemRepository, ItemType};
 use refine_core::session::{cluster_observations, ClusterResult};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -31,7 +31,11 @@ struct ProfileData {
     score_summary: String,
 }
 
-fn extract_profile_data(cluster: &ClusterResult, score_summary: &str, items: &[Item]) -> ProfileData {
+fn extract_profile_data(
+    cluster: &ClusterResult,
+    score_summary: &str,
+    items: &[Item],
+) -> ProfileData {
     let total_sessions = cluster.global_stats.total_sessions;
     let total_projects = cluster.projects.len();
 
@@ -76,9 +80,14 @@ fn extract_profile_data(cluster: &ClusterResult, score_summary: &str, items: &[I
 
     // Session complexity: count observations per document_id
     let mut doc_obs_count: HashMap<String, usize> = HashMap::new();
-    for item in items.iter().filter(|i| i.item_type() == ItemType::Observation) {
+    for item in items
+        .iter()
+        .filter(|i| i.item_type() == ItemType::Observation)
+    {
         if let Some(doc_id) = item.document_id() {
-            *doc_obs_count.entry(doc_id.as_str().to_string()).or_insert(0) += 1;
+            *doc_obs_count
+                .entry(doc_id.as_str().to_string())
+                .or_insert(0) += 1;
         }
     }
 
@@ -202,23 +211,6 @@ fn save_profile_summary(data: &ProfileData) -> Result<()> {
     Ok(())
 }
 
-async fn save_to_document(doc_repo: &Arc<dyn DocumentRepository>, report: &str) -> Result<()> {
-    let mut doc = Document::new("mirror-profile", report);
-    let title = format!("Mirror Profile {}", Utc::now().format("%Y-%m-%d"));
-    doc.set_title(&title);
-    doc.set_url(&format!("mirror-profile://{}", Utc::now().to_rfc3339()));
-    doc_repo
-        .save(&doc)
-        .await
-        .context("Failed to save profile")?;
-    println!(
-        "\n{} (ID: {})",
-        t!("Profile saved", "画像已保存"),
-        doc.id()
-    );
-    Ok(())
-}
-
 pub async fn handle_profile(
     item_repo: Arc<dyn ItemRepository>,
     doc_repo: Arc<dyn DocumentRepository>,
@@ -255,7 +247,18 @@ pub async fn handle_profile(
     println!("{}", narrative);
 
     save_profile_summary(&data)?;
-    save_to_document(&doc_repo, &narrative).await?;
+    let doc_id = save_report_to_document(
+        &doc_repo,
+        &narrative,
+        SaveDocumentOptions {
+            source: "mirror-profile",
+            title_prefix: "Mirror Profile",
+            url_scheme: "mirror-profile",
+            save_error_context: "Failed to save profile",
+        },
+    )
+    .await?;
+    println!("\n{} (ID: {})", t!("Profile saved", "画像已保存"), doc_id);
     Ok(())
 }
 
@@ -343,10 +346,7 @@ mod tests {
                     m
                 },
                 tool_frequency: HashMap::new(),
-                project_ranking: vec![
-                    ("proj-a".to_string(), 50),
-                    ("proj-b".to_string(), 20),
-                ],
+                project_ranking: vec![("proj-a".to_string(), 50), ("proj-b".to_string(), 20)],
             },
             untagged_count: 0,
         }

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -1,10 +1,11 @@
 use crate::config::{ensure_mirror_dir, mirror_dir};
+use crate::document_save::{save_report_to_document, SaveDocumentOptions};
 use crate::lang::t;
 use crate::score::{self, LayerScore, ScoreResult};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, Utc};
 use refine_core::infra::LlmClient;
-use refine_core::knowledge::{Document, DocumentRepository, Item, ItemRepository, ItemType};
+use refine_core::knowledge::{DocumentRepository, Item, ItemRepository, ItemType};
 use refine_core::session::cluster_observations;
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, Write};
@@ -130,7 +131,24 @@ pub async fn handle_weekly(
 
     let suggestions = extract_suggestions(&report);
     save_weekly_record(&this_score, suggestions)?;
-    save_to_document(&doc_repo, &report).await?;
+    let doc_id = save_report_to_document(
+        &doc_repo,
+        &report,
+        SaveDocumentOptions {
+            source: "mirror-weekly",
+            title_prefix: "Mirror Weekly",
+            url_scheme: "mirror-weekly",
+            save_error_context: "Failed to save weekly report",
+        },
+    )
+    .await?;
+    println!(
+        "\n{}",
+        t!(
+            format!("Weekly report saved (ID: {})", doc_id),
+            format!("周报已保存 (ID: {})", doc_id)
+        )
+    );
 
     Ok(())
 }
@@ -421,28 +439,6 @@ fn write_weekly_history_lines_atomically(path: &Path, lines: &[String]) -> Resul
     }
 
     write_result
-}
-
-async fn save_to_document(doc_repo: &Arc<dyn DocumentRepository>, report: &str) -> Result<()> {
-    let mut doc = Document::new("mirror-weekly", report);
-    let title = format!("Mirror Weekly {}", doc.created_at().format("%Y-%m-%d"));
-    doc.set_title(&title);
-    doc.set_url(&format!(
-        "mirror-weekly://{}",
-        doc.created_at().to_rfc3339()
-    ));
-    doc_repo
-        .save(&doc)
-        .await
-        .context("Failed to save weekly report")?;
-    println!(
-        "\n{}",
-        t!(
-            format!("Weekly report saved (ID: {})", doc.id()),
-            format!("周报已保存 (ID: {})", doc.id())
-        )
-    );
-    Ok(())
 }
 
 async fn llm_with_retry(client: &Arc<dyn LlmClient>, prompt: &str, system: &str) -> Result<String> {


### PR DESCRIPTION
## Summary
- add a shared `document_save` helper module for mirror report persistence
- replace duplicate `save_to_document` implementations in weekly/profile with the shared helper
- add targeted tests to verify saved document metadata for weekly/profile configurations

## Validation
- cargo fmt --all
- cargo test -p mirror document_save::tests
- cargo test -p mirror
- cargo clippy -p mirror -- -D warnings

Refs FUT-113
