### PR TITLE
FUT-114: Share llm_with_retry across Mirror commands

### DIFF
--- a/apps/mirror/Cargo.toml
+++ b/apps/mirror/Cargo.toml
@@ -24,4 +24,5 @@ unicode-width = "0.2"
 fs2 = "0.4"
 
 [dev-dependencies]
+async-trait.workspace = true
 tempfile = "3"

--- a/apps/mirror/src/advice.rs
+++ b/apps/mirror/src/advice.rs
@@ -1,4 +1,5 @@
 use crate::lang::t;
+use crate::llm_retry::llm_with_retry;
 use crate::score::{indicator_display, layer_display, ScoreResult, Signal};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -134,8 +135,7 @@ fn system_prompt() -> &'static str {
 /// Generate advice via LLM (single attempt, best-effort) and cache result
 pub async fn generate_and_cache(score: &ScoreResult, llm: &Arc<dyn LlmClient>) -> Result<String> {
     let prompt = build_prompt(score);
-    let response = llm
-        .complete(&prompt, Some(system_prompt()))
+    let response = llm_with_retry(llm, &prompt, system_prompt())
         .await
         .map_err(|e| anyhow::anyhow!("LLM advice generation failed: {}", e))?;
     let raw = response.trim().to_string();

--- a/apps/mirror/src/llm_retry.rs
+++ b/apps/mirror/src/llm_retry.rs
@@ -1,0 +1,191 @@
+use anyhow::Result;
+use refine_core::infra::LlmClient;
+use std::sync::Arc;
+use std::time::Duration;
+
+pub const DEFAULT_MAX_RETRIES: usize = 5;
+pub const DEFAULT_RETRY_BASE_DELAY_SECS: u64 = 10;
+
+#[derive(Clone, Copy, Debug)]
+pub struct LlmRetryPolicy {
+    pub max_retries: usize,
+    pub base_delay_secs: u64,
+}
+
+impl Default for LlmRetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: DEFAULT_MAX_RETRIES,
+            base_delay_secs: DEFAULT_RETRY_BASE_DELAY_SECS,
+        }
+    }
+}
+
+pub async fn llm_with_retry(
+    client: &Arc<dyn LlmClient>,
+    prompt: &str,
+    system: &str,
+) -> Result<String> {
+    llm_with_retry_policy(client, prompt, system, LlmRetryPolicy::default()).await
+}
+
+pub async fn llm_with_retry_policy(
+    client: &Arc<dyn LlmClient>,
+    prompt: &str,
+    system: &str,
+    policy: LlmRetryPolicy,
+) -> Result<String> {
+    let max_retries = policy.max_retries.max(1);
+    let mut last_err = String::new();
+
+    for attempt in 0..max_retries {
+        match client.complete(prompt, Some(system)).await {
+            Ok(response) => return Ok(response),
+            Err(e) => {
+                last_err = e.to_string();
+                if !is_retryable_error(&last_err) || attempt == max_retries - 1 {
+                    break;
+                }
+
+                let backoff_factor = 1u64.checked_shl(attempt as u32).unwrap_or(u64::MAX);
+                let delay = policy.base_delay_secs.saturating_mul(backoff_factor);
+                eprintln!(
+                    "    Retry ({}/{}) waiting {}s...",
+                    attempt + 1,
+                    max_retries,
+                    delay
+                );
+                if delay > 0 {
+                    tokio::time::sleep(Duration::from_secs(delay)).await;
+                }
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "LLM call failed ({} retries): {}",
+        max_retries,
+        last_err
+    ))
+}
+
+fn is_retryable_error(err: &str) -> bool {
+    err.contains("cooldown")
+        || err.contains("service_busy")
+        || err.contains("rate")
+        || err.contains("429")
+        || err.contains("Upstream")
+        || err.contains("timeout")
+        || err.contains("empty response")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use refine_core::error::{InfraError, InfraResult};
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    struct SequenceClient {
+        calls: AtomicUsize,
+        responses: Mutex<VecDeque<InfraResult<String>>>,
+    }
+
+    impl SequenceClient {
+        fn new(responses: Vec<InfraResult<String>>) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                responses: Mutex::new(VecDeque::from(responses)),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl LlmClient for SequenceClient {
+        async fn complete(&self, _prompt: &str, _system: Option<&str>) -> InfraResult<String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.responses
+                .lock()
+                .expect("lock poisoned")
+                .pop_front()
+                .unwrap_or_else(|| Err(InfraError::LlmRequest("no queued response".into())))
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_on_retryable_error_then_succeeds() {
+        let client = Arc::new(SequenceClient::new(vec![
+            Err(InfraError::LlmRequest("429 rate limit".into())),
+            Ok("ok".into()),
+        ]));
+
+        let result = llm_with_retry_policy(
+            &(client.clone() as Arc<dyn LlmClient>),
+            "prompt",
+            "system",
+            LlmRetryPolicy {
+                max_retries: 3,
+                base_delay_secs: 0,
+            },
+        )
+        .await
+        .expect("should succeed after retry");
+
+        assert_eq!(result, "ok");
+        assert_eq!(client.calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_non_retryable_error() {
+        let client = Arc::new(SequenceClient::new(vec![
+            Err(InfraError::LlmRequest("invalid api key".into())),
+            Ok("unused".into()),
+        ]));
+
+        let err = llm_with_retry_policy(
+            &(client.clone() as Arc<dyn LlmClient>),
+            "prompt",
+            "system",
+            LlmRetryPolicy {
+                max_retries: 5,
+                base_delay_secs: 0,
+            },
+        )
+        .await
+        .expect_err("non-retryable errors should fail fast");
+
+        assert!(err.to_string().contains("invalid api key"));
+        assert_eq!(client.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn stops_after_max_retries() {
+        let client = Arc::new(SequenceClient::new(vec![
+            Err(InfraError::LlmRequest("timeout".into())),
+            Err(InfraError::LlmRequest("timeout".into())),
+            Err(InfraError::LlmRequest("timeout".into())),
+            Ok("unused".into()),
+        ]));
+
+        let err = llm_with_retry_policy(
+            &(client.clone() as Arc<dyn LlmClient>),
+            "prompt",
+            "system",
+            LlmRetryPolicy {
+                max_retries: 3,
+                base_delay_secs: 0,
+            },
+        )
+        .await
+        .expect_err("should fail when retries exhausted");
+
+        assert!(err.to_string().contains("3 retries"));
+        assert_eq!(client.calls(), 3);
+    }
+}

--- a/apps/mirror/src/main.rs
+++ b/apps/mirror/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod dashboard;
 mod document_save;
 mod lang;
+mod llm_retry;
 mod motd;
 mod profile;
 mod score;

--- a/apps/mirror/src/profile.rs
+++ b/apps/mirror/src/profile.rs
@@ -1,6 +1,7 @@
 use crate::config::ensure_mirror_dir;
 use crate::document_save::{save_report_to_document, SaveDocumentOptions};
 use crate::lang::t;
+use crate::llm_retry::llm_with_retry;
 use crate::score::{self, layer_display, Signal};
 use anyhow::Result;
 use refine_core::infra::LlmClient;
@@ -239,8 +240,7 @@ pub async fn handle_profile(
         t!("Generating cognitive profile...", "正在生成认知画像...")
     );
 
-    let narrative = llm
-        .complete(&prompt, Some(system_prompt()))
+    let narrative = llm_with_retry(&llm, &prompt, system_prompt())
         .await
         .map_err(|e| anyhow::anyhow!("LLM profile generation failed: {}", e))?;
 

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -1,6 +1,7 @@
 use crate::config::{ensure_mirror_dir, mirror_dir};
 use crate::document_save::{save_report_to_document, SaveDocumentOptions};
 use crate::lang::t;
+use crate::llm_retry::llm_with_retry;
 use crate::score::{self, LayerScore, ScoreResult};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, Utc};
@@ -12,8 +13,6 @@ use std::io::{BufRead, Write};
 use std::path::Path;
 use std::sync::Arc;
 
-const MAX_RETRIES: usize = 5;
-const RETRY_BASE_DELAY_SECS: u64 = 10;
 const WEEKLY_HISTORY_LIMIT: usize = 52;
 
 fn system_prompt() -> &'static str {
@@ -439,47 +438,6 @@ fn write_weekly_history_lines_atomically(path: &Path, lines: &[String]) -> Resul
     }
 
     write_result
-}
-
-async fn llm_with_retry(client: &Arc<dyn LlmClient>, prompt: &str, system: &str) -> Result<String> {
-    let mut last_err = String::new();
-    for attempt in 0..MAX_RETRIES {
-        match client.complete(prompt, Some(system)).await {
-            Ok(response) => return Ok(response),
-            Err(e) => {
-                last_err = e.to_string();
-                let is_retryable = last_err.contains("cooldown")
-                    || last_err.contains("service_busy")
-                    || last_err.contains("rate")
-                    || last_err.contains("429")
-                    || last_err.contains("Upstream")
-                    || last_err.contains("timeout")
-                    || last_err.contains("empty response");
-                if !is_retryable || attempt == MAX_RETRIES - 1 {
-                    break;
-                }
-                let delay = RETRY_BASE_DELAY_SECS * (1 << attempt);
-                eprintln!(
-                    "  {}",
-                    t!(
-                        format!(
-                            "Retry ({}/{}) waiting {}s...",
-                            attempt + 1,
-                            MAX_RETRIES,
-                            delay
-                        ),
-                        format!("重试 ({}/{}) 等待 {}s...", attempt + 1, MAX_RETRIES, delay)
-                    )
-                );
-                tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
-            }
-        }
-    }
-    Err(anyhow::anyhow!(
-        "LLM call failed ({} retries): {}",
-        MAX_RETRIES,
-        last_err
-    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a shared `llm_retry` module in Mirror with common retry policy and retryable error matching
- switch `weekly`, `profile`, and `advice` flows to use shared `llm_with_retry`
- add focused retry behavior tests (retryable success, non-retryable fail-fast, max-retry stop)

## Validation
- `cargo fmt --all`
- `cargo clippy -p mirror --all-targets -- -D warnings`
- `cargo test -p mirror`
- `cargo test -p mirror llm_retry::tests::`

## Linear
- FUT-114
