### PR TITLE
fix(mirror): resolve growth-tracker path from db location (FUT-115)

### DIFF
--- a/apps/mirror/src/main.rs
+++ b/apps/mirror/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     match cli.command {
         Commands::Score { since } => {
             let llm = build_llm_client_from_env();
-            score::handle_score(store, llm, since).await
+            score::handle_score(store, llm, since, &db_path).await
         }
         Commands::Motd => motd::handle_motd(),
         Commands::Dashboard { since } => dashboard::handle_dashboard(store, since).await,

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -12,6 +12,7 @@ use anyhow::Result;
 use chrono::{DateTime, NaiveDate, Utc};
 use refine_core::knowledge::{Item, ItemRepository};
 use refine_core::session::cluster_observations;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub use baseline::compute_personal_baseline;
@@ -58,6 +59,7 @@ pub async fn handle_score(
     repo: Arc<dyn ItemRepository>,
     llm: Option<Arc<dyn refine_core::infra::LlmClient>>,
     since: Option<String>,
+    db_path: &Path,
 ) -> Result<()> {
     let all_items = repo
         .find_all()
@@ -98,10 +100,7 @@ pub async fn handle_score(
     }
 
     // Check for pending ingest from growth-tracker
-    let tracker_path = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".refine")
-        .join("growth-tracker.json");
+    let tracker_path = resolve_growth_tracker_path(db_path);
     if let Ok(content) = std::fs::read_to_string(&tracker_path) {
         if let Ok(tracker) = serde_json::from_str::<serde_json::Value>(&content) {
             let pending = tracker
@@ -129,4 +128,29 @@ pub async fn handle_score(
         }
     }
     Ok(())
+}
+
+fn resolve_growth_tracker_path(db_path: &Path) -> PathBuf {
+    let primary = growth_tracker_path_from_db(db_path);
+    let legacy = dirs::home_dir().map(|home| home.join(".refine").join("growth-tracker.json"));
+    choose_growth_tracker_path(primary, legacy)
+}
+
+fn growth_tracker_path_from_db(db_path: &Path) -> PathBuf {
+    db_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("growth-tracker.json")
+}
+
+fn choose_growth_tracker_path(primary: PathBuf, legacy: Option<PathBuf>) -> PathBuf {
+    if primary.exists() {
+        return primary;
+    }
+    if let Some(legacy_path) = legacy {
+        if legacy_path.exists() {
+            return legacy_path;
+        }
+    }
+    primary
 }

--- a/apps/mirror/src/score/tests.rs
+++ b/apps/mirror/src/score/tests.rs
@@ -1091,3 +1091,38 @@ fn test_layer3_has_4_indicators() {
     assert_eq!(l3.indicators.len(), 4);
     assert_eq!(l3.indicators[3].name, "friction_density");
 }
+
+#[test]
+fn growth_tracker_path_from_db_uses_db_parent_dir() {
+    let db_path = std::path::Path::new("/tmp/custom/refine.db");
+    let tracker_path = growth_tracker_path_from_db(db_path);
+    assert_eq!(
+        tracker_path,
+        std::path::PathBuf::from("/tmp/custom/growth-tracker.json")
+    );
+}
+
+#[test]
+fn choose_growth_tracker_path_prefers_primary_when_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let primary = dir.path().join("growth-tracker.json");
+    let legacy = dir.path().join("legacy").join("growth-tracker.json");
+    std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+    std::fs::write(&primary, r#"{"pending_ingest": 8}"#).unwrap();
+    std::fs::write(&legacy, r#"{"pending_ingest": 3}"#).unwrap();
+
+    let chosen = choose_growth_tracker_path(primary.clone(), Some(legacy));
+    assert_eq!(chosen, primary);
+}
+
+#[test]
+fn choose_growth_tracker_path_falls_back_to_legacy_when_primary_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let primary = dir.path().join("db").join("growth-tracker.json");
+    let legacy = dir.path().join(".refine").join("growth-tracker.json");
+    std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+    std::fs::write(&legacy, r#"{"pending_ingest": 5}"#).unwrap();
+
+    let chosen = choose_growth_tracker_path(primary, Some(legacy.clone()));
+    assert_eq!(chosen, legacy);
+}


### PR DESCRIPTION
## Summary
- pass resolved db path into mirror score handler
- resolve growth tracker path from the db directory instead of hardcoded ~/.refine
- keep legacy fallback to ~/.refine/growth-tracker.json when primary path is absent
- add unit tests for tracker-path resolution behavior

## Validation
- cargo fmt --all
- cargo clippy -p mirror --all-targets -- -D warnings
- cargo test -p mirror
- manual repro: REFINE_DB_PATH override + tracker next to DB now prints pending-ingest warning

## Linear
- FUT-115