### PR TITLE
fix(mirror): isatty detection for ANSI output (FUT-116)

### DIFF
--- a/apps/mirror/src/score/tests.rs
+++ b/apps/mirror/src/score/tests.rs
@@ -5,6 +5,7 @@ use super::persistence::persist_score_to_path;
 use crate::config::Targets;
 use refine_core::session::{ClusterResult, GlobalStats, ProjectCluster};
 use std::collections::{HashMap, HashSet};
+use std::io::IsTerminal;
 use std::sync::{Arc, Barrier};
 
 fn make_cluster(
@@ -251,7 +252,17 @@ fn test_signal_conversions_are_canonical() {
     for (signal, plain, emoji, ansi) in cases {
         assert_eq!(signal.as_str(), plain);
         assert_eq!(signal.emoji(), emoji);
-        assert_eq!(signal.to_string(), ansi);
+        assert_eq!(signal.ansi_dot(), ansi);
+        assert_eq!(signal.plain_dot(), emoji);
+        assert_eq!(signal.render(true), ansi);
+        assert_eq!(signal.render(false), emoji);
+
+        let expected_display = if std::io::stdout().is_terminal() {
+            ansi
+        } else {
+            emoji
+        };
+        assert_eq!(signal.to_string(), expected_display);
     }
 }
 

--- a/apps/mirror/src/score/types.rs
+++ b/apps/mirror/src/score/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::io::IsTerminal;
 
 use super::indicators::format_indicator_value;
 
@@ -26,15 +27,35 @@ impl Signal {
             Signal::Red => "🔴",
         }
     }
+
+    pub const fn ansi_dot(self) -> &'static str {
+        match self {
+            Signal::Green => "\x1b[32m●\x1b[0m",
+            Signal::Yellow => "\x1b[33m●\x1b[0m",
+            Signal::Red => "\x1b[31m●\x1b[0m",
+        }
+    }
+
+    pub const fn plain_dot(self) -> &'static str {
+        self.emoji()
+    }
+
+    pub const fn render(self, ansi: bool) -> &'static str {
+        if ansi {
+            self.ansi_dot()
+        } else {
+            self.plain_dot()
+        }
+    }
+
+    fn supports_ansi_on_stdout() -> bool {
+        std::io::stdout().is_terminal()
+    }
 }
 
 impl std::fmt::Display for Signal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Signal::Green => write!(f, "\x1b[32m●\x1b[0m"),
-            Signal::Yellow => write!(f, "\x1b[33m●\x1b[0m"),
-            Signal::Red => write!(f, "\x1b[31m●\x1b[0m"),
-        }
+        f.write_str(self.render(Self::supports_ansi_on_stdout()))
     }
 }
 


### PR DESCRIPTION
## Summary
- gate `Signal` ANSI formatting on `stdout.is_terminal()`
- keep deterministic render helpers for ANSI and plain output branches
- update score signal conversion test to validate both render branches and tty-aware Display behavior

## Validation
- `rustfmt --check apps/mirror/src/score/types.rs apps/mirror/src/score/tests.rs`
- `cargo test -p mirror test_signal_conversions_are_canonical -- --exact`
- `cargo test -p mirror`
- `cargo run -p mirror -- --db /tmp/fut116-mirror-2.db --lang en score --since 2099-01-01 | sed -n '1,30p' | cat -v`
- `output=$(cargo run -p mirror -- --db /tmp/fut116-mirror-4.db --lang en score --since 2099-01-01); printf '%s' "$output" | LC_ALL=C grep -qF $'\x1b['`

## Issue
- Linear: FUT-116
- Imported source: https://github.com/majiayu000/refine/issues/13
