### PR TITLE
feat: session-tagger incremental scan with last_scan_ts (#35)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/apps/cli/src/growth.rs
+++ b/apps/cli/src/growth.rs
@@ -8,12 +8,21 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 const COGNITIVE_LEVELS: &[&str] = &[
-    "expert", "proficient", "competent", "advanced_beginner", "novice",
+    "expert",
+    "proficient",
+    "competent",
+    "advanced_beginner",
+    "novice",
 ];
 
 const COLLAB_MODES: &[&str] = &[
-    "delegation", "deep_inquiry", "exploration", "review",
-    "pair_programming", "teaching", "debugging",
+    "delegation",
+    "deep_inquiry",
+    "exploration",
+    "review",
+    "pair_programming",
+    "teaching",
+    "debugging",
 ];
 
 const BAR_WIDTH: usize = 10;
@@ -70,15 +79,22 @@ pub async fn handle_growth(store: Arc<SqliteStore>) -> Result<()> {
     println!("{}", border_top());
     println!("{}", row_center("认知成长仪表盘"));
     println!("{}", border_mid());
-    println!("{}", row_left(&format!(
-        "总会话: {}  总观测: {}", total_sessions, total_obs
-    )));
+    println!(
+        "{}",
+        row_left(&format!(
+            "总会话: {}  总观测: {}",
+            total_sessions, total_obs
+        ))
+    );
     println!("{}", border_mid());
 
     println!("{}", row_left("认知水平分布"));
     for &level in COGNITIVE_LEVELS {
         let count = cognitive_counts.get(level).copied().unwrap_or(0);
-        println!("{}", row_bar(short_cognitive(level), count, cognitive_total));
+        println!(
+            "{}",
+            row_bar(short_cognitive(level), count, cognitive_total)
+        );
     }
     println!("{}", border_mid());
 
@@ -90,12 +106,35 @@ pub async fn handle_growth(store: Arc<SqliteStore>) -> Result<()> {
     println!("{}", border_mid());
 
     println!("{}", row_left("关键指标"));
-    let exploration_rate = pct(collab_counts.get("exploration").copied().unwrap_or(0), collab_total);
-    let delegation_rate = pct(collab_counts.get("delegation").copied().unwrap_or(0), collab_total);
-    let expert_rate = pct(cognitive_counts.get("expert").copied().unwrap_or(0), cognitive_total);
-    println!("{}", row_metric("探索率", exploration_rate, ">15%", exploration_rate > 15.0));
-    println!("{}", row_metric("delegation", delegation_rate, "<40%", delegation_rate < 40.0));
-    println!("{}", row_metric("expert率", expert_rate, ">15%", expert_rate > 15.0));
+    let exploration_rate = pct(
+        collab_counts.get("exploration").copied().unwrap_or(0),
+        collab_total,
+    );
+    let delegation_rate = pct(
+        collab_counts.get("delegation").copied().unwrap_or(0),
+        collab_total,
+    );
+    let expert_rate = pct(
+        cognitive_counts.get("expert").copied().unwrap_or(0),
+        cognitive_total,
+    );
+    println!(
+        "{}",
+        row_metric("探索率", exploration_rate, ">15%", exploration_rate > 15.0)
+    );
+    println!(
+        "{}",
+        row_metric(
+            "delegation",
+            delegation_rate,
+            "<40%",
+            delegation_rate < 40.0
+        )
+    );
+    println!(
+        "{}",
+        row_metric("expert率", expert_rate, ">15%", expert_rate > 15.0)
+    );
     println!("{}", border_mid());
 
     // 保存分析快照供 motd 使用
@@ -104,10 +143,13 @@ pub async fn handle_growth(store: Arc<SqliteStore>) -> Result<()> {
     match week_data {
         Some(wk) => {
             println!("{}", row_left("本周"));
-            println!("{}", row_left(&format!(
-                "  Sessions: {}  探索: {}  深度: {}",
-                wk.total_sessions, wk.exploration_sessions, wk.deep_inquiry_sessions,
-            )));
+            println!(
+                "{}",
+                row_left(&format!(
+                    "  Sessions: {}  探索: {}  深度: {}",
+                    wk.total_sessions, wk.exploration_sessions, wk.deep_inquiry_sessions,
+                ))
+            );
         }
         None => {
             println!("{}", row_left("本周: 无 tracker 数据"));
@@ -168,38 +210,74 @@ fn load_week_tracker() -> Option<WeekTracker> {
 }
 
 fn is_cognitive(tag: &str) -> bool {
-    matches!(tag, "novice" | "advanced_beginner" | "competent" | "proficient" | "expert")
+    matches!(
+        tag,
+        "novice" | "advanced_beginner" | "competent" | "proficient" | "expert"
+    )
 }
 
 fn is_collab(tag: &str) -> bool {
-    matches!(tag, "delegation" | "pair_programming" | "review" | "exploration" | "teaching" | "deep_inquiry" | "debugging")
+    matches!(
+        tag,
+        "delegation"
+            | "pair_programming"
+            | "review"
+            | "exploration"
+            | "teaching"
+            | "deep_inquiry"
+            | "debugging"
+    )
 }
 
 fn short_cognitive(s: &str) -> &str {
-    match s { "advanced_beginner" => "adv_begin", other => other }
+    match s {
+        "advanced_beginner" => "adv_begin",
+        other => other,
+    }
 }
 
 fn short_collab(s: &str) -> &str {
-    match s { "pair_programming" => "pair_prog", "deep_inquiry" => "deep_inq", other => other }
+    match s {
+        "pair_programming" => "pair_prog",
+        "deep_inquiry" => "deep_inq",
+        other => other,
+    }
 }
 
 fn pct(count: usize, total: usize) -> f64 {
-    if total == 0 { 0.0 } else { count as f64 / total as f64 * 100.0 }
+    if total == 0 {
+        0.0
+    } else {
+        count as f64 / total as f64 * 100.0
+    }
 }
 
 // ── 行渲染（所有 padding 用 saturating_sub 防溢出）──
 
 fn row_bar(label: &str, count: usize, total: usize) -> String {
-    let ratio = if total == 0 { 0.0 } else { count as f64 / total as f64 };
+    let ratio = if total == 0 {
+        0.0
+    } else {
+        count as f64 / total as f64
+    };
     let filled = (ratio * BAR_WIDTH as f64).round() as usize;
     let bar = format!("{}{}", "█".repeat(filled), "░".repeat(BAR_WIDTH - filled));
-    let core = format!("  {:<11} {} {:>5.1}% ({:>3})", label, bar, ratio * 100.0, count);
+    let core = format!(
+        "  {:<11} {} {:>5.1}% ({:>3})",
+        label,
+        bar,
+        ratio * 100.0,
+        count
+    );
     padded_row(&core)
 }
 
 fn row_metric(label: &str, value: f64, target: &str, ok: bool) -> String {
     let mark = if ok { "✓" } else { "✗" };
-    let core = format!("  {:<12} {:>5.1}%  目标: {:<6} {}", label, value, target, mark);
+    let core = format!(
+        "  {:<12} {:>5.1}%  目标: {:<6} {}",
+        label, value, target, mark
+    );
     padded_row(&core)
 }
 
@@ -222,9 +300,15 @@ fn padded_row(content: &str) -> String {
     format!("║{}{}║", content, " ".repeat(padding))
 }
 
-fn border_top() -> String { format!("╔{}╗", "═".repeat(BOX_W.saturating_sub(2))) }
-fn border_mid() -> String { format!("╠{}╣", "═".repeat(BOX_W.saturating_sub(2))) }
-fn border_bot() -> String { format!("╚{}╝", "═".repeat(BOX_W.saturating_sub(2))) }
+fn border_top() -> String {
+    format!("╔{}╗", "═".repeat(BOX_W.saturating_sub(2)))
+}
+fn border_mid() -> String {
+    format!("╠{}╣", "═".repeat(BOX_W.saturating_sub(2)))
+}
+fn border_bot() -> String {
+    format!("╚{}╝", "═".repeat(BOX_W.saturating_sub(2)))
+}
 
 fn display_width(s: &str) -> usize {
     s.chars().map(|c| if is_wide(c) { 2 } else { 1 }).sum()
@@ -244,10 +328,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pct_zero_total_returns_zero() { assert_eq!(pct(5, 0), 0.0); }
+    fn pct_zero_total_returns_zero() {
+        assert_eq!(pct(5, 0), 0.0);
+    }
 
     #[test]
-    fn pct_normal() { assert!((pct(25, 100) - 25.0).abs() < f64::EPSILON); }
+    fn pct_normal() {
+        assert!((pct(25, 100) - 25.0).abs() < f64::EPSILON);
+    }
 
     #[test]
     fn cognitive_and_collab_tags() {

--- a/apps/cli/src/handlers.rs
+++ b/apps/cli/src/handlers.rs
@@ -7,9 +7,7 @@ use refine_core::infra::SqliteStore;
 use refine_core::knowledge::{
     DocumentId, DocumentRepository, Item, ItemId, ItemRepository, ItemType, Source,
 };
-use refine_core::refinement::{
-    apply_defaults, extract_items_with_llm, ExtractionPolicy,
-};
+use refine_core::refinement::{apply_defaults, extract_items_with_llm, ExtractionPolicy};
 use refine_core::search::{SearchEngine, SearchQuery};
 use refine_core::session::SessionSource;
 use std::io::{self, Read};
@@ -95,8 +93,8 @@ async fn handle_extract(stdin: bool, store: Arc<SqliteStore>) -> Result<()> {
     let llm_client = build_llm_client_from_env()?;
     let mut items =
         extract_items_with_llm(llm_client.as_ref(), &content, ExtractionPolicy::default())
-        .await
-        .context("提炼失败")?;
+            .await
+            .context("提炼失败")?;
     let source = Source::new("cli");
     let doc_id = DocumentId::new();
     apply_defaults(&mut items, &source, &doc_id, &content);
@@ -176,7 +174,12 @@ async fn handle_delete(id: &str, store: Arc<SqliteStore>) -> Result<()> {
     Ok(())
 }
 
-async fn handle_add(title: &str, summary: &str, raw_type: &str, store: Arc<SqliteStore>) -> Result<()> {
+async fn handle_add(
+    title: &str,
+    summary: &str,
+    raw_type: &str,
+    store: Arc<SqliteStore>,
+) -> Result<()> {
     let item_store: &dyn ItemRepository = store.as_ref();
     let item_type = parse_add_item_type(raw_type)?;
     let item = match item_type {
@@ -279,12 +282,8 @@ fn parse_session_source(raw: &str) -> Option<SessionSource> {
 }
 
 fn parse_add_item_type(raw_type: &str) -> Result<ItemType> {
-    parse_item_type(raw_type).with_context(|| {
-        format!(
-            "无效的类型: {} (支持: knowledge, skill, snippet)",
-            raw_type
-        )
-    })
+    parse_item_type(raw_type)
+        .with_context(|| format!("无效的类型: {} (支持: knowledge, skill, snippet)", raw_type))
 }
 
 #[cfg(test)]

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -132,8 +132,7 @@ pub async fn handle_ingest_sessions(
     }
 
     // 阶段 2: 并发做 LLM 提取 + 保存
-    let client = llm_client
-        .ok_or_else(|| anyhow::anyhow!("非 dry-run 模式需要 LLM API Key"))?;
+    let client = llm_client.ok_or_else(|| anyhow::anyhow!("非 dry-run 模式需要 LLM API Key"))?;
     let semaphore = Arc::new(Semaphore::new(CONCURRENCY));
     let processed = Arc::new(AtomicUsize::new(0));
     let failed = Arc::new(AtomicUsize::new(0));
@@ -161,12 +160,7 @@ pub async fn handle_ingest_sessions(
                     total_items.fetch_add(item_count, Ordering::Relaxed);
                 }
                 Err(e) => {
-                    eprintln!(
-                        "  ✗ [{}/{}] 失败: {}",
-                        ps.idx + 1,
-                        ps.total,
-                        e
-                    );
+                    eprintln!("  ✗ [{}/{}] 失败: {}", ps.idx + 1, ps.total, e);
                     failed.fetch_add(1, Ordering::Relaxed);
                 }
             }
@@ -238,10 +232,7 @@ async fn process_single_session(
     Ok(item_count)
 }
 
-async fn llm_call_with_retry(
-    client: &Arc<dyn LlmClient>,
-    content: &str,
-) -> Result<String> {
+async fn llm_call_with_retry(client: &Arc<dyn LlmClient>, content: &str) -> Result<String> {
     let prompt = build_facet_prompt(content);
     let mut last_err = String::new();
 

--- a/apps/cli/src/insights.rs
+++ b/apps/cli/src/insights.rs
@@ -4,8 +4,8 @@ use anyhow::{Context, Result};
 use refine_core::infra::LlmClient;
 use refine_core::knowledge::{Document, DocumentRepository, ItemRepository, ItemType};
 use refine_core::session::{
-    build_final_prompt, cluster_observations, merge_route_results, plan_routes,
-    RouteResult, INSIGHTS_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT,
+    build_final_prompt, cluster_observations, merge_route_results, plan_routes, RouteResult,
+    INSIGHTS_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT,
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -94,7 +94,10 @@ pub async fn handle_insights(
         }
     }
 
-    println!("\n{} 路分析完成，合并生成最终报告...\n", route_results.len());
+    println!(
+        "\n{} 路分析完成，合并生成最终报告...\n",
+        route_results.len()
+    );
 
     // Step 4: 合并 + 最终报告
     let combined = merge_route_results(&route_results);
@@ -121,11 +124,7 @@ pub async fn handle_insights(
     Ok(())
 }
 
-async fn llm_with_retry(
-    client: &Arc<dyn LlmClient>,
-    prompt: &str,
-    system: &str,
-) -> Result<String> {
+async fn llm_with_retry(client: &Arc<dyn LlmClient>, prompt: &str, system: &str) -> Result<String> {
     let mut last_err = String::new();
     for attempt in 0..MAX_RETRIES {
         match client.complete(prompt, Some(system)).await {
@@ -154,5 +153,9 @@ async fn llm_with_retry(
             }
         }
     }
-    Err(anyhow::anyhow!("LLM 调用失败 ({}次重试): {}", MAX_RETRIES, last_err))
+    Err(anyhow::anyhow!(
+        "LLM 调用失败 ({}次重试): {}",
+        MAX_RETRIES,
+        last_err
+    ))
 }

--- a/apps/cli/src/support.rs
+++ b/apps/cli/src/support.rs
@@ -1,7 +1,5 @@
 use anyhow::{anyhow, Result};
-use refine_core::infra::{
-    build_llm_client_from_env as build_core_llm_client_from_env, LlmClient,
-};
+use refine_core::infra::{build_llm_client_from_env as build_core_llm_client_from_env, LlmClient};
 use refine_core::knowledge::{Item, ItemType};
 use std::sync::Arc;
 

--- a/apps/server/src/api_response.rs
+++ b/apps/server/src/api_response.rs
@@ -1,8 +1,8 @@
 use axum::http::{HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-pub use refine_core::infra::CONTRACT_VERSION_HEADER;
 use refine_core::infra::CONTRACT_VERSION;
+pub use refine_core::infra::CONTRACT_VERSION_HEADER;
 use serde::Serialize;
 use serde_json::{json, Map, Value};
 

--- a/apps/server/src/application/conversation.rs
+++ b/apps/server/src/application/conversation.rs
@@ -40,10 +40,7 @@ impl CreateConversationError {
         match self {
             Self::BadRequest(message) => message.clone(),
             Self::QuotaExceeded { used, limit } => {
-                format!(
-                    "Configured quota exceeded ({}/{} items).",
-                    used, limit
-                )
+                format!("Configured quota exceeded ({}/{} items).", used, limit)
             }
             Self::Internal(message) => message.clone(),
         }

--- a/apps/server/src/extraction.rs
+++ b/apps/server/src/extraction.rs
@@ -38,8 +38,7 @@ async fn run_extraction(
             .ok_or_else(|| "Conversation not found".to_string())?
     };
 
-    let source = Source::new(&conversation.source)
-        .with_url(&conversation.url);
+    let source = Source::new(&conversation.source).with_url(&conversation.url);
 
     let mut doc = Document::new(&conversation.source, &conversation.raw_content);
     doc.set_url(&conversation.url);
@@ -56,7 +55,8 @@ async fn run_extraction(
         captured_at: Some(&conversation.captured_at),
         policy: mode_to_policy(mode),
     };
-    let items = extract_items_with_defaults(state.llm_client.as_deref(), &input, &source, &doc_id).await;
+    let items =
+        extract_items_with_defaults(state.llm_client.as_deref(), &input, &source, &doc_id).await;
 
     let mut item_ids = Vec::with_capacity(items.len());
     for item in &items {

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -127,9 +127,21 @@ mod tests {
 
     #[test]
     fn non_loopback_bindings_require_api_token() {
-        assert!(requires_api_token_for_bind(&SocketAddr::from(([0, 0, 0, 0], 8787))));
-        assert!(requires_api_token_for_bind(&SocketAddr::from(([192, 168, 1, 8], 8787))));
-        assert!(!requires_api_token_for_bind(&SocketAddr::from(([127, 0, 0, 1], 8787))));
-        assert!(!requires_api_token_for_bind(&SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 8787))));
+        assert!(requires_api_token_for_bind(&SocketAddr::from((
+            [0, 0, 0, 0],
+            8787
+        ))));
+        assert!(requires_api_token_for_bind(&SocketAddr::from((
+            [192, 168, 1, 8],
+            8787
+        ))));
+        assert!(!requires_api_token_for_bind(&SocketAddr::from((
+            [127, 0, 0, 1],
+            8787
+        ))));
+        assert!(!requires_api_token_for_bind(&SocketAddr::from((
+            [0, 0, 0, 0, 0, 0, 0, 1],
+            8787
+        ))));
     }
 }

--- a/apps/server/src/persistence.rs
+++ b/apps/server/src/persistence.rs
@@ -405,7 +405,10 @@ fn job_status_from_db(raw: &str) -> JobStatus {
 }
 
 fn collect_event_counts(
-    rows: rusqlite::MappedRows<'_, impl FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<(String, i64)>>,
+    rows: rusqlite::MappedRows<
+        '_,
+        impl FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<(String, i64)>,
+    >,
 ) -> Result<Vec<(String, usize)>, String> {
     let mut counts = Vec::new();
     for row in rows {
@@ -424,7 +427,10 @@ mod tests {
     use uuid::Uuid;
 
     fn temp_db_path() -> PathBuf {
-        std::env::temp_dir().join(format!("refine-server-persistence-test-{}.db", Uuid::new_v4()))
+        std::env::temp_dir().join(format!(
+            "refine-server-persistence-test-{}.db",
+            Uuid::new_v4()
+        ))
     }
 
     fn cleanup(path: &Path) {
@@ -485,7 +491,10 @@ mod tests {
         let persistence = ServerPersistence::new(path.clone()).expect("persistence init failed");
 
         persistence
-            .insert_event(&build_event("conversation_extracted", "2020-01-01T00:00:00Z"))
+            .insert_event(&build_event(
+                "conversation_extracted",
+                "2020-01-01T00:00:00Z",
+            ))
             .expect("insert old event");
         let recent = now_iso();
         persistence

--- a/apps/server/src/request_guard.rs
+++ b/apps/server/src/request_guard.rs
@@ -47,8 +47,8 @@ pub fn validate_client_contract(headers: &HeaderMap) -> Result<(), Response> {
 #[cfg(test)]
 mod tests {
     use super::{validate_client_contract, CONTRACT_VERSION_HEADER};
-    use refine_core::infra::{is_contract_compatible, normalize_contract_major};
     use axum::http::{HeaderMap, HeaderValue, StatusCode};
+    use refine_core::infra::{is_contract_compatible, normalize_contract_major};
 
     #[test]
     fn normalize_contract_major_uses_first_segment() {

--- a/apps/server/src/state.rs
+++ b/apps/server/src/state.rs
@@ -57,12 +57,8 @@ impl AppState {
         let free_quota_items =
             env_usize(&["REFINE_MAX_ITEMS", "REFINE_FREE_QUOTA_ITEMS"]).unwrap_or(0);
         // Single-user self-host default: treat built-in user ids as premium unless explicitly configured.
-        let premium_users = env_csv_set(&["REFINE_PREMIUM_USERS"]).unwrap_or_else(|| {
-            HashSet::from([
-                "dev-user".to_string(),
-                "token-user".to_string(),
-            ])
-        });
+        let premium_users = env_csv_set(&["REFINE_PREMIUM_USERS"])
+            .unwrap_or_else(|| HashSet::from(["dev-user".to_string(), "token-user".to_string()]));
         let mut engine_builder = SearchEngine::new(store.clone());
         if semantic_search_enabled {
             engine_builder =
@@ -135,7 +131,6 @@ impl AppState {
         !normalized.is_empty() && self.premium_users.contains(normalized)
     }
 }
-
 
 fn env_var(keys: &[&str]) -> Option<String> {
     keys.iter()

--- a/packages/core/src/infra/paths.rs
+++ b/packages/core/src/infra/paths.rs
@@ -31,8 +31,13 @@ pub fn resolve_db_path(fallback_keys: &[&str]) -> PathBuf {
 /// Creates parent directories for the given path.
 pub fn ensure_db_dir(path: &Path) -> Result<(), String> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("failed to create database directory {}: {}", parent.display(), e))?;
+        std::fs::create_dir_all(parent).map_err(|e| {
+            format!(
+                "failed to create database directory {}: {}",
+                parent.display(),
+                e
+            )
+        })?;
     }
     Ok(())
 }
@@ -71,11 +76,17 @@ mod tests {
         // 2) unified env takes priority over fallback
         std::env::set_var("REFINE_DB_PATH", "/tmp/unified.db");
         std::env::set_var("__REFINE_TEST_A", "/tmp/fallback.db");
-        assert_eq!(resolve_db_path(&["__REFINE_TEST_A"]), PathBuf::from("/tmp/unified.db"));
+        assert_eq!(
+            resolve_db_path(&["__REFINE_TEST_A"]),
+            PathBuf::from("/tmp/unified.db")
+        );
 
         // 3) fallback key used when unified is absent
         std::env::remove_var("REFINE_DB_PATH");
-        assert_eq!(resolve_db_path(&["__REFINE_TEST_A"]), PathBuf::from("/tmp/fallback.db"));
+        assert_eq!(
+            resolve_db_path(&["__REFINE_TEST_A"]),
+            PathBuf::from("/tmp/fallback.db")
+        );
 
         // cleanup
         std::env::remove_var("__REFINE_TEST_A");

--- a/packages/core/src/infra/sqlite/doc_ops.rs
+++ b/packages/core/src/infra/sqlite/doc_ops.rs
@@ -126,14 +126,30 @@ pub(super) fn count_text_hits(conn: &Connection, query: &str) -> InfraResult<usi
 }
 
 fn row_to_document(row: &rusqlite::Row) -> InfraResult<Document> {
-    let id: String = row.get(0).map_err(|e| InfraError::Database(e.to_string()))?;
-    let title: Option<String> = row.get(1).map_err(|e| InfraError::Database(e.to_string()))?;
-    let raw_content: String = row.get(2).map_err(|e| InfraError::Database(e.to_string()))?;
-    let source: String = row.get(3).map_err(|e| InfraError::Database(e.to_string()))?;
-    let url: String = row.get(4).map_err(|e| InfraError::Database(e.to_string()))?;
-    let captured_at_raw: String = row.get(5).map_err(|e| InfraError::Database(e.to_string()))?;
-    let created_at_raw: String = row.get(6).map_err(|e| InfraError::Database(e.to_string()))?;
-    let updated_at_raw: String = row.get(7).map_err(|e| InfraError::Database(e.to_string()))?;
+    let id: String = row
+        .get(0)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let title: Option<String> = row
+        .get(1)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let raw_content: String = row
+        .get(2)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let source: String = row
+        .get(3)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let url: String = row
+        .get(4)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let captured_at_raw: String = row
+        .get(5)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let created_at_raw: String = row
+        .get(6)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let updated_at_raw: String = row
+        .get(7)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
 
     let parse_dt = |raw: &str, label: &str| -> InfraResult<DateTime<Utc>> {
         DateTime::parse_from_rfc3339(raw)

--- a/packages/core/src/infra/sqlite/mod.rs
+++ b/packages/core/src/infra/sqlite/mod.rs
@@ -2,9 +2,11 @@
 //!
 //! ItemRepository 的 SQLite 实现（worker 线程模型）
 
-use crate::error::{InfraError, InfraResult};
 use crate::error::RepoResult;
-use crate::knowledge::{Document, DocumentId, DocumentRepository, Item, ItemId, ItemRepository, ItemType, Tag};
+use crate::error::{InfraError, InfraResult};
+use crate::knowledge::{
+    Document, DocumentId, DocumentRepository, Item, ItemId, ItemRepository, ItemType, Tag,
+};
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
 use tokio::sync::oneshot;
@@ -58,7 +60,9 @@ impl ItemRepository for SqliteStore {
     }
 
     async fn find_all(&self) -> RepoResult<Vec<Item>> {
-        self.request(SqliteCommand::FindAll).await.map_err(Into::into)
+        self.request(SqliteCommand::FindAll)
+            .await
+            .map_err(Into::into)
     }
 
     async fn find_by_type(&self, item_type: ItemType) -> RepoResult<Vec<Item>> {
@@ -117,12 +121,7 @@ impl ItemRepository for SqliteStore {
             .map_err(Into::into)
     }
 
-    async fn search_text(
-        &self,
-        query: &str,
-        offset: usize,
-        limit: usize,
-    ) -> RepoResult<Vec<Item>> {
+    async fn search_text(&self, query: &str, offset: usize, limit: usize) -> RepoResult<Vec<Item>> {
         let query = query.to_string();
         self.request(|resp| SqliteCommand::SearchText {
             query,
@@ -143,9 +142,12 @@ impl ItemRepository for SqliteStore {
 
     async fn find_by_document_id(&self, doc_id: &DocumentId) -> RepoResult<Vec<Item>> {
         let id = doc_id.as_str().to_string();
-        self.request(|resp| SqliteCommand::FindByDocumentId { document_id: id, resp })
-            .await
-            .map_err(Into::into)
+        self.request(|resp| SqliteCommand::FindByDocumentId {
+            document_id: id,
+            resp,
+        })
+        .await
+        .map_err(Into::into)
     }
 }
 
@@ -166,9 +168,13 @@ impl DocumentRepository for SqliteStore {
     }
 
     async fn find_recent(&self, offset: usize, limit: usize) -> RepoResult<Vec<Document>> {
-        self.request(|resp| SqliteCommand::DocFindRecent { offset, limit, resp })
-            .await
-            .map_err(Into::into)
+        self.request(|resp| SqliteCommand::DocFindRecent {
+            offset,
+            limit,
+            resp,
+        })
+        .await
+        .map_err(Into::into)
     }
 
     async fn count(&self) -> RepoResult<usize> {
@@ -191,11 +197,21 @@ impl DocumentRepository for SqliteStore {
             .map_err(Into::into)
     }
 
-    async fn search_text(&self, query: &str, offset: usize, limit: usize) -> RepoResult<Vec<Document>> {
+    async fn search_text(
+        &self,
+        query: &str,
+        offset: usize,
+        limit: usize,
+    ) -> RepoResult<Vec<Document>> {
         let query = query.to_string();
-        self.request(|resp| SqliteCommand::DocSearchText { query, offset, limit, resp })
-            .await
-            .map_err(Into::into)
+        self.request(|resp| SqliteCommand::DocSearchText {
+            query,
+            offset,
+            limit,
+            resp,
+        })
+        .await
+        .map_err(Into::into)
     }
 
     async fn count_text_hits(&self, query: &str) -> RepoResult<usize> {

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -71,7 +71,10 @@ fn maybe_rebuild_fts_index(conn: &Connection) -> InfraResult<bool> {
     }
 
     if conn
-        .execute("INSERT INTO items_fts(items_fts) VALUES('integrity-check')", [])
+        .execute(
+            "INSERT INTO items_fts(items_fts) VALUES('integrity-check')",
+            [],
+        )
         .is_ok()
     {
         return Ok(false);
@@ -79,8 +82,11 @@ fn maybe_rebuild_fts_index(conn: &Connection) -> InfraResult<bool> {
 
     conn.execute("INSERT INTO items_fts(items_fts) VALUES('rebuild')", [])
         .map_err(|e| InfraError::Database(e.to_string()))?;
-    conn.execute("INSERT INTO items_fts(items_fts) VALUES('integrity-check')", [])
-        .map_err(|e| InfraError::Database(e.to_string()))?;
+    conn.execute(
+        "INSERT INTO items_fts(items_fts) VALUES('integrity-check')",
+        [],
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))?;
     Ok(true)
 }
 pub(super) fn find_by_id(conn: &Connection, id: &str) -> InfraResult<Option<Item>> {

--- a/packages/core/src/infra/sqlite/rows.rs
+++ b/packages/core/src/infra/sqlite/rows.rs
@@ -104,12 +104,8 @@ pub(super) fn row_to_item(row: &rusqlite::Row) -> InfraResult<Item> {
         .map(|dt| dt.with_timezone(&Utc))
         .map_err(|e| InfraError::Serialization(format!("updated_at 解析失败: {}", e)))?;
 
-    let document_id: Option<String> = row
-        .get(9)
-        .unwrap_or(None);
-    let excerpt: Option<String> = row
-        .get(10)
-        .unwrap_or(None);
+    let document_id: Option<String> = row.get(9).unwrap_or(None);
+    let excerpt: Option<String> = row.get(10).unwrap_or(None);
 
     Item::restore(RestoreParams {
         id: ItemId::from(id.as_str()),

--- a/packages/core/src/infra/sqlite/worker.rs
+++ b/packages/core/src/infra/sqlite/worker.rs
@@ -1,5 +1,5 @@
-use super::{doc_ops, ops};
 use super::rows::configure_connection;
+use super::{doc_ops, ops};
 use crate::error::{InfraError, InfraResult};
 use crate::knowledge::{Document, Item, ItemType};
 use rusqlite::Connection;
@@ -219,7 +219,11 @@ fn handle_command(conn: &Connection, command: SqliteCommand) {
         SqliteCommand::DocFindById { id, resp } => {
             let _ = resp.send(doc_ops::find_by_id(conn, &id));
         }
-        SqliteCommand::DocFindRecent { offset, limit, resp } => {
+        SqliteCommand::DocFindRecent {
+            offset,
+            limit,
+            resp,
+        } => {
             let _ = resp.send(doc_ops::find_recent(conn, offset, limit));
         }
         SqliteCommand::DocCount { resp } => {
@@ -228,7 +232,12 @@ fn handle_command(conn: &Connection, command: SqliteCommand) {
         SqliteCommand::DocDelete { id, resp } => {
             let _ = resp.send(doc_ops::delete(conn, &id));
         }
-        SqliteCommand::DocSearchText { query, offset, limit, resp } => {
+        SqliteCommand::DocSearchText {
+            query,
+            offset,
+            limit,
+            resp,
+        } => {
             let _ = resp.send(doc_ops::search_text(conn, &query, offset, limit));
         }
         SqliteCommand::DocCountTextHits { query, resp } => {

--- a/packages/core/src/knowledge/doc_repository.rs
+++ b/packages/core/src/knowledge/doc_repository.rs
@@ -14,6 +14,11 @@ pub trait DocumentRepository: Send + Sync {
     async fn count(&self) -> RepoResult<usize>;
     async fn save(&self, doc: &Document) -> RepoResult<()>;
     async fn delete(&self, id: &DocumentId) -> RepoResult<bool>;
-    async fn search_text(&self, query: &str, offset: usize, limit: usize) -> RepoResult<Vec<Document>>;
+    async fn search_text(
+        &self,
+        query: &str,
+        offset: usize,
+        limit: usize,
+    ) -> RepoResult<Vec<Document>>;
     async fn count_text_hits(&self, query: &str) -> RepoResult<usize>;
 }

--- a/packages/core/src/knowledge/document.rs
+++ b/packages/core/src/knowledge/document.rs
@@ -61,14 +61,30 @@ impl Document {
 
     // 查询方法
 
-    pub fn id(&self) -> &DocumentId { &self.id }
-    pub fn title(&self) -> Option<&str> { self.title.as_deref() }
-    pub fn raw_content(&self) -> &str { &self.raw_content }
-    pub fn source(&self) -> &str { &self.source }
-    pub fn url(&self) -> &str { &self.url }
-    pub fn captured_at(&self) -> DateTime<Utc> { self.captured_at }
-    pub fn created_at(&self) -> DateTime<Utc> { self.created_at }
-    pub fn updated_at(&self) -> DateTime<Utc> { self.updated_at }
+    pub fn id(&self) -> &DocumentId {
+        &self.id
+    }
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+    pub fn raw_content(&self) -> &str {
+        &self.raw_content
+    }
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+    pub fn captured_at(&self) -> DateTime<Utc> {
+        self.captured_at
+    }
+    pub fn created_at(&self) -> DateTime<Utc> {
+        self.created_at
+    }
+    pub fn updated_at(&self) -> DateTime<Utc> {
+        self.updated_at
+    }
 
     // 命令方法
 

--- a/packages/core/src/refinement/mod.rs
+++ b/packages/core/src/refinement/mod.rs
@@ -17,7 +17,7 @@ pub use conversation::{Conversation, Message, Role};
 pub use extractor::{ExtractionResult, Extractor};
 pub use policy::{ExtractionPolicy, PromptTemplate};
 pub use usecase::{
-    apply_defaults, build_fallback_item, extract_items_or_fallback,
-    extract_items_with_defaults, extract_items_with_llm, ItemExtractionInput,
-    EXTRACTION_SYSTEM_PROMPT, JSON_REPAIR_SYSTEM_PROMPT,
+    apply_defaults, build_fallback_item, extract_items_or_fallback, extract_items_with_defaults,
+    extract_items_with_llm, ItemExtractionInput, EXTRACTION_SYSTEM_PROMPT,
+    JSON_REPAIR_SYSTEM_PROMPT,
 };

--- a/packages/core/src/refinement/usecase.rs
+++ b/packages/core/src/refinement/usecase.rs
@@ -256,7 +256,9 @@ mod tests {
     #[async_trait]
     impl LlmClient for AlwaysFailLlmClient {
         async fn complete(&self, _prompt: &str, _system: Option<&str>) -> InfraResult<String> {
-            Err(crate::error::InfraError::LlmRequest("mock failure".to_string()))
+            Err(crate::error::InfraError::LlmRequest(
+                "mock failure".to_string(),
+            ))
         }
     }
 
@@ -349,9 +351,15 @@ mod tests {
         let items = extract_items_with_defaults(None, &input, &source, &doc_id).await;
 
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].source().map(|v| v.platform.as_str()), Some("chatgpt"));
+        assert_eq!(
+            items[0].source().map(|v| v.platform.as_str()),
+            Some("chatgpt")
+        );
         assert_eq!(items[0].content(), "原始文本");
-        assert_eq!(items[0].document_id().map(|id| id.as_str()), Some(doc_id.as_str()));
+        assert_eq!(
+            items[0].document_id().map(|id| id.as_str()),
+            Some(doc_id.as_str())
+        );
     }
 
     #[test]
@@ -361,8 +369,14 @@ mod tests {
         let doc_id = DocumentId::new();
         apply_defaults(&mut items, &source, &doc_id, "raw text");
 
-        assert_eq!(items[0].source().map(|s| s.platform.as_str()), Some("chatgpt"));
+        assert_eq!(
+            items[0].source().map(|s| s.platform.as_str()),
+            Some("chatgpt")
+        );
         assert_eq!(items[0].content(), "raw text");
-        assert_eq!(items[0].document_id().map(|id| id.as_str()), Some(doc_id.as_str()));
+        assert_eq!(
+            items[0].document_id().map(|id| id.as_str()),
+            Some(doc_id.as_str())
+        );
     }
 }

--- a/packages/core/src/search/engine/semantic.rs
+++ b/packages/core/src/search/engine/semantic.rs
@@ -38,7 +38,11 @@ impl SearchEngine {
         }
 
         for (rank, (id, raw_score)) in semantic.into_iter().enumerate() {
-            let Some(item) = self.item_repo.find_by_id(&ItemId::from(id.as_str())).await? else {
+            let Some(item) = self
+                .item_repo
+                .find_by_id(&ItemId::from(id.as_str()))
+                .await?
+            else {
                 continue;
             };
             if !Self::matches_filter(&item, &query.filter) {

--- a/packages/core/src/session/chunking.rs
+++ b/packages/core/src/session/chunking.rs
@@ -76,8 +76,8 @@ fn build_chunk(messages: &[&SessionMessage]) -> SessionChunk {
 fn role_label_len(role: &MessageRole) -> usize {
     match role {
         MessageRole::User => 6,       // "User: "
-        MessageRole::Assistant => 12,  // "Assistant: "
-        MessageRole::System => 9,      // "System: "
+        MessageRole::Assistant => 12, // "Assistant: "
+        MessageRole::System => 9,     // "System: "
     }
 }
 

--- a/packages/core/src/session/clustering.rs
+++ b/packages/core/src/session/clustering.rs
@@ -6,15 +6,34 @@ use crate::knowledge::{Item, ItemType};
 use std::collections::{HashMap, HashSet};
 
 const META_TAGS: &[&str] = &[
-    "decision", "bugfix",
-    "novice", "advanced_beginner", "competent", "proficient", "expert",
-    "delegation", "pair_programming", "review", "exploration", "teaching", "deep_inquiry",
+    "decision",
+    "bugfix",
+    "novice",
+    "advanced_beginner",
+    "competent",
+    "proficient",
+    "expert",
+    "delegation",
+    "pair_programming",
+    "review",
+    "exploration",
+    "teaching",
+    "deep_inquiry",
     "debugging",
 ];
 
 const GENERIC_PATH_SEGMENTS: &[&str] = &[
-    "users", "lifcc", "desktop", "code", "ai", "tools", "agent", "work", "life",
-    "information", "mutil",
+    "users",
+    "lifcc",
+    "desktop",
+    "code",
+    "ai",
+    "tools",
+    "agent",
+    "work",
+    "life",
+    "information",
+    "mutil",
 ];
 
 /// 单个项目的聚类数据
@@ -68,7 +87,9 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
         if let Some(doc_id) = item.document_id() {
             let tags: Vec<&str> = item.tags().iter().map(|t| t.as_str()).collect();
             if let Some(name) = extract_project_from_tags(&tags) {
-                doc_project_map.entry(doc_id.as_str().to_string()).or_insert(name);
+                doc_project_map
+                    .entry(doc_id.as_str().to_string())
+                    .or_insert(name);
             }
         }
     }
@@ -99,8 +120,9 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
             }
         };
 
-        let cluster = projects.entry(project_name.clone()).or_insert_with(|| {
-            ProjectCluster {
+        let cluster = projects
+            .entry(project_name.clone())
+            .or_insert_with(|| ProjectCluster {
                 project_name: project_name.clone(),
                 session_count: 0,
                 summary_excerpts: Vec::new(),
@@ -113,8 +135,7 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
                 architectures: Vec::new(),
                 knowledge_gained: Vec::new(),
                 patterns: Vec::new(),
-            }
-        });
+            });
 
         // 跟踪 session 数
         if let Some(doc_id) = item.document_id() {
@@ -135,7 +156,9 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
             total_summaries += 1;
             let content = item.content();
             let excerpt: String = content.chars().take(300).collect();
-            cluster.summary_excerpts.push(format!("【{}】{}", item.title(), excerpt));
+            cluster
+                .summary_excerpts
+                .push(format!("【{}】{}", item.title(), excerpt));
 
             // 提取认知水平和协作模式
             for tag in &tags {
@@ -144,7 +167,10 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
                     *global_cognitive.entry(tag.to_string()).or_insert(0) += 1;
                 }
                 if is_collab_mode(tag) {
-                    *cluster.collaboration_modes.entry(tag.to_string()).or_insert(0) += 1;
+                    *cluster
+                        .collaboration_modes
+                        .entry(tag.to_string())
+                        .or_insert(0) += 1;
                     *global_collab.entry(tag.to_string()).or_insert(0) += 1;
                 }
             }
@@ -154,10 +180,18 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
                 *global_tools.entry(tool.clone()).or_insert(0) += 1;
                 cluster.tools.push(tool);
             }
-            cluster.frictions.extend(extract_section_items(content, "阻力"));
-            cluster.architectures.extend(extract_section_items(content, "架构"));
-            cluster.knowledge_gained.extend(extract_section_items(content, "知识"));
-            cluster.patterns.extend(extract_section_items(content, "模式"));
+            cluster
+                .frictions
+                .extend(extract_section_items(content, "阻力"));
+            cluster
+                .architectures
+                .extend(extract_section_items(content, "架构"));
+            cluster
+                .knowledge_gained
+                .extend(extract_section_items(content, "知识"));
+            cluster
+                .patterns
+                .extend(extract_section_items(content, "模式"));
         }
     }
 
@@ -240,13 +274,22 @@ fn extract_section_items(content: &str, section_name: &str) -> Vec<String> {
 }
 
 fn is_cognitive_level(tag: &str) -> bool {
-    matches!(tag, "novice" | "advanced_beginner" | "competent" | "proficient" | "expert")
+    matches!(
+        tag,
+        "novice" | "advanced_beginner" | "competent" | "proficient" | "expert"
+    )
 }
 
 fn is_collab_mode(tag: &str) -> bool {
     matches!(
         tag,
-        "delegation" | "pair_programming" | "review" | "exploration" | "teaching" | "deep_inquiry" | "debugging"
+        "delegation"
+            | "pair_programming"
+            | "review"
+            | "exploration"
+            | "teaching"
+            | "deep_inquiry"
+            | "debugging"
     )
 }
 
@@ -256,13 +299,28 @@ mod tests {
 
     #[test]
     fn normalize_project_name_extracts_meaningful_segments() {
-        assert_eq!(normalize_project_name("-users-lifcc-desktop-code-ai-tools-refine"), Some("refine".into()));
-        assert_eq!(normalize_project_name("-users-lifcc-desktop-code-ai-gateway-litellm-rs"), Some("gateway-litellm-rs".into()));
-        assert_eq!(normalize_project_name("-users-lifcc-desktop-code-work-life-xhh"), Some("xhh".into()));
-        assert_eq!(normalize_project_name("-users-lifcc--claude-mem-observer-sessions"), Some("claude-mem-observer-sessions".into()));
+        assert_eq!(
+            normalize_project_name("-users-lifcc-desktop-code-ai-tools-refine"),
+            Some("refine".into())
+        );
+        assert_eq!(
+            normalize_project_name("-users-lifcc-desktop-code-ai-gateway-litellm-rs"),
+            Some("gateway-litellm-rs".into())
+        );
+        assert_eq!(
+            normalize_project_name("-users-lifcc-desktop-code-work-life-xhh"),
+            Some("xhh".into())
+        );
+        assert_eq!(
+            normalize_project_name("-users-lifcc--claude-mem-observer-sessions"),
+            Some("claude-mem-observer-sessions".into())
+        );
         // Pure generic paths return None
         assert_eq!(normalize_project_name("-users-lifcc-desktop-code"), None);
-        assert_eq!(normalize_project_name("-users-lifcc-desktop-code-work-life"), None);
+        assert_eq!(
+            normalize_project_name("-users-lifcc-desktop-code-work-life"),
+            None
+        );
     }
 
     #[test]
@@ -280,7 +338,10 @@ mod tests {
     #[test]
     fn extract_section_items_parses_content() {
         let content = "认知水平: proficient\n\n工具:\n- cargo\n- rustfmt\n\n阻力:\n- 编译太慢";
-        assert_eq!(extract_section_items(content, "工具"), vec!["cargo", "rustfmt"]);
+        assert_eq!(
+            extract_section_items(content, "工具"),
+            vec!["cargo", "rustfmt"]
+        );
         assert_eq!(extract_section_items(content, "阻力"), vec!["编译太慢"]);
     }
 }

--- a/packages/core/src/session/facets.rs
+++ b/packages/core/src/session/facets.rs
@@ -93,7 +93,10 @@ pub fn parse_facet_response(response: &str) -> Result<FacetResponse, String> {
         }
     }
 
-    Err(format!("无法解析 facet 响应: {}", &trimmed[..trimmed.len().min(200)]))
+    Err(format!(
+        "无法解析 facet 响应: {}",
+        &trimmed[..trimmed.len().min(200)]
+    ))
 }
 
 fn extract_json_from_fence(text: &str) -> Option<String> {
@@ -124,8 +127,7 @@ pub fn facets_to_items(
     let mut items = Vec::new();
 
     // 宏观标注作为一个综合 observation
-    let mut summary_item =
-        Item::new_observation(&facets.session_summary, &facets.session_summary);
+    let mut summary_item = Item::new_observation(&facets.session_summary, &facets.session_summary);
     let mut content = format!(
         "认知水平: {}\n协作模式: {}",
         facets.cognitive_level, facets.collaboration_mode
@@ -134,7 +136,10 @@ pub fn facets_to_items(
         content.push_str(&format!("\n\n决策:\n- {}", facets.decisions.join("\n- ")));
     }
     if !facets.bugs_fixed.is_empty() {
-        content.push_str(&format!("\n\nBug 修复:\n- {}", facets.bugs_fixed.join("\n- ")));
+        content.push_str(&format!(
+            "\n\nBug 修复:\n- {}",
+            facets.bugs_fixed.join("\n- ")
+        ));
     }
     if !facets.patterns.is_empty() {
         content.push_str(&format!("\n\n模式:\n- {}", facets.patterns.join("\n- ")));

--- a/packages/core/src/session/filter.rs
+++ b/packages/core/src/session/filter.rs
@@ -79,7 +79,11 @@ mod tests {
     #[test]
     fn filter_sessions_removes_low_quality() {
         let config = FilterConfig::default();
-        let sessions = vec![make_session(1, 10), make_session(3, 200), make_session(1, 50)];
+        let sessions = vec![
+            make_session(1, 10),
+            make_session(3, 200),
+            make_session(1, 50),
+        ];
         let filtered = filter_sessions(sessions, &config);
         assert_eq!(filtered.len(), 1);
     }

--- a/packages/core/src/session/mod.rs
+++ b/packages/core/src/session/mod.rs
@@ -20,14 +20,13 @@ pub use chunking::{chunk_session, needs_chunking, SessionChunk};
 pub use clustering::{cluster_observations, ClusterResult, GlobalStats, ProjectCluster};
 pub use discovery::{discover_sessions, discover_sessions_in, DiscoveredSession};
 pub use facets::{
-    build_facet_prompt, facets_to_items, parse_facet_response, FacetResponse,
-    FACET_SYSTEM_PROMPT,
+    build_facet_prompt, facets_to_items, parse_facet_response, FacetResponse, FACET_SYSTEM_PROMPT,
 };
 pub use filter::{filter_sessions, passes_filter, FilterConfig};
 pub use parser::{parse_session_content, parse_session_file};
 pub use prescription::{build_prescription_prompt, PRESCRIPTION_SYSTEM_PROMPT};
 pub use report::{
-    build_final_prompt, merge_route_results, RouteResult,
-    INSIGHTS_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT,
+    build_final_prompt, merge_route_results, RouteResult, INSIGHTS_SYSTEM_PROMPT,
+    ROUTE_SYSTEM_PROMPT,
 };
 pub use types::{MessageRole, Session, SessionMessage, SessionMeta, SessionSource};

--- a/packages/core/src/session/parser.rs
+++ b/packages/core/src/session/parser.rs
@@ -7,8 +7,7 @@ use std::path::Path;
 
 /// 解析 JSONL 文件为 Session
 pub fn parse_session_file(path: &Path, source: SessionSource) -> Result<Session, String> {
-    let content =
-        std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?;
+    let content = std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?;
     parse_session_content(&content, path, source)
 }
 
@@ -81,10 +80,7 @@ fn parse_claude_code_line(
         }
         "system" => {
             // 提取模型信息
-            if let Some(model) = value
-                .pointer("/message/model")
-                .and_then(|v| v.as_str())
-            {
+            if let Some(model) = value.pointer("/message/model").and_then(|v| v.as_str()) {
                 meta.model = Some(model.to_string());
             }
         }
@@ -199,13 +195,13 @@ mod tests {
 
         assert_eq!(session.messages.len(), 2);
         assert_eq!(session.messages[0].role, MessageRole::User);
-        assert_eq!(
-            session.messages[0].content,
-            "How do I write tests in Rust?"
-        );
+        assert_eq!(session.messages[0].content, "How do I write tests in Rust?");
         assert_eq!(session.messages[1].role, MessageRole::Assistant);
         assert_eq!(session.messages[1].content, "Use #[test] attribute.");
-        assert_eq!(session.meta.model.as_deref(), Some("claude-sonnet-4-20250514"));
+        assert_eq!(
+            session.meta.model.as_deref(),
+            Some("claude-sonnet-4-20250514")
+        );
     }
 
     #[test]

--- a/packages/core/src/session/prescription.rs
+++ b/packages/core/src/session/prescription.rs
@@ -57,10 +57,7 @@ pub fn build_prescription_prompt(report: &AggregationReport) -> String {
     }
     context.push_str(&format!("阻力数: {}\n", report.l3.friction_count));
     context.push_str(&format!("Bug 修复数: {}\n", report.l3.bugs_fixed_count));
-    context.push_str(&format!(
-        "代码产出数: {}\n",
-        report.l3.code_artifacts_count
-    ));
+    context.push_str(&format!("代码产出数: {}\n", report.l3.code_artifacts_count));
 
     format!(
         r#"基于以下开发者编程会话的聚合分析数据，生成个性化技术成长处方。

--- a/packages/core/src/session/report.rs
+++ b/packages/core/src/session/report.rs
@@ -42,7 +42,10 @@ pub fn format_global_stats(stats: &GlobalStats) -> String {
     out.push_str("\n认知水平分布: ");
     let mut levels: Vec<_> = stats.cognitive_levels.iter().collect();
     levels.sort_by(|a, b| b.1.cmp(a.1));
-    let level_strs: Vec<String> = levels.iter().map(|(k, v)| format!("{}({})", k, v)).collect();
+    let level_strs: Vec<String> = levels
+        .iter()
+        .map(|(k, v)| format!("{}({})", k, v))
+        .collect();
     out.push_str(&level_strs.join(", "));
 
     out.push_str("\n协作模式分布: ");
@@ -152,8 +155,16 @@ mod tests {
     #[test]
     fn merge_route_results_orders_by_id() {
         let results = vec![
-            RouteResult { route_id: 3, route_title: "C".into(), content: "c".into() },
-            RouteResult { route_id: 1, route_title: "A".into(), content: "a".into() },
+            RouteResult {
+                route_id: 3,
+                route_title: "C".into(),
+                content: "c".into(),
+            },
+            RouteResult {
+                route_id: 1,
+                route_title: "A".into(),
+                content: "a".into(),
+            },
         ];
         let merged = merge_route_results(&results);
         assert!(merged.find("## A").unwrap() < merged.find("## C").unwrap());

--- a/scripts/reset-weekly-tracker.sh
+++ b/scripts/reset-weekly-tracker.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 REFINE_DIR="${HOME}/.refine"
 TRACKER_FILE="${REFINE_DIR}/growth-tracker.json"
 HISTORY_FILE="${REFINE_DIR}/growth-history.jsonl"
+LAST_SCAN_REF="${REFINE_DIR}/.last_scan_ref"
+SEEN_SESSIONS_FILE="${REFINE_DIR}/.seen_sessions"
 LOG_PREFIX="[refine-reset]"
 
 log() {
@@ -37,5 +39,10 @@ jq --arg ws "$new_week_start" '{
   total_sessions: 0,
   last_scan_ts: ""
 }' "$TRACKER_FILE" > "${TRACKER_FILE}.tmp" && mv "${TRACKER_FILE}.tmp" "$TRACKER_FILE"
+
+# Remove watermark and seen-sessions list so the next scan starts fresh from
+# the new week boundary (issue #2: last_scan_ts reset alone was insufficient
+# because session-tagger.sh prefers .last_scan_ref when the file exists).
+rm -f "$LAST_SCAN_REF" "$SEEN_SESSIONS_FILE"
 
 log "Weekly tracker reset complete"

--- a/scripts/reset-weekly-tracker.sh
+++ b/scripts/reset-weekly-tracker.sh
@@ -10,7 +10,8 @@ SEEN_SESSIONS_FILE="${REFINE_DIR}/.seen_sessions"
 LOCK_FILE="${REFINE_DIR}/.growth-tracker.lock"
 LOCK_DIR="${REFINE_DIR}/.growth.lock"
 LOG_PREFIX="[refine-reset]"
-MAX_LOCK_WAIT=15  # seconds to wait for the tagger to release the lock
+MAX_LOCK_WAIT=15   # seconds to wait for the tagger to release the lock
+MAX_LOCK_AGE=120   # seconds — mirrors session-tagger.sh; locks older than this are assumed stale (guards PID reuse)
 
 log() {
   echo "${LOG_PREFIX} $(date '+%Y-%m-%d %H:%M:%S') $*"
@@ -80,15 +81,20 @@ else
       date +%s > "${LOCK_DIR}/created"
       return 0
     fi
-    # Lock dir exists — check if the holder is still alive.
-    # Without this check an abnormal exit (crash/SIGKILL) leaves a permanent
-    # stale lock and all subsequent weekly resets fail indefinitely (issue #4).
-    local p
+    # Lock dir exists — check if the holder is still alive AND the lock is fresh.
+    # Using only kill -0 is insufficient: after a crash the PID can be reused by
+    # an unrelated live process, causing weekly resets to time out indefinitely.
+    # MAX_LOCK_AGE bounds that window: a lock older than MAX_LOCK_AGE seconds is
+    # treated as stale regardless of whether kill -0 succeeds.
+    local p created_ts now_ts lock_age
     p=$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)
-    if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null; then
-      return 1  # live process holds the lock
+    created_ts=$(cat "${LOCK_DIR}/created" 2>/dev/null || echo 0)
+    now_ts=$(date +%s)
+    lock_age=$(( now_ts - created_ts ))
+    if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null && [[ "$lock_age" -lt "$MAX_LOCK_AGE" ]]; then
+      return 1  # live process holds a fresh lock
     fi
-    # Stale lock — remove and retry once.
+    # Stale lock (process gone, no PID/created file, or age >= MAX_LOCK_AGE) — remove and retry once.
     rm -rf "$LOCK_DIR"
     if mkdir "$LOCK_DIR" 2>/dev/null; then
       echo $$ > "${LOCK_DIR}/pid"

--- a/scripts/reset-weekly-tracker.sh
+++ b/scripts/reset-weekly-tracker.sh
@@ -80,6 +80,21 @@ else
       date +%s > "${LOCK_DIR}/created"
       return 0
     fi
+    # Lock dir exists — check if the holder is still alive.
+    # Without this check an abnormal exit (crash/SIGKILL) leaves a permanent
+    # stale lock and all subsequent weekly resets fail indefinitely (issue #4).
+    local p
+    p=$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)
+    if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null; then
+      return 1  # live process holds the lock
+    fi
+    # Stale lock — remove and retry once.
+    rm -rf "$LOCK_DIR"
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      echo $$ > "${LOCK_DIR}/pid"
+      date +%s > "${LOCK_DIR}/created"
+      return 0
+    fi
     return 1
   }
 

--- a/scripts/reset-weekly-tracker.sh
+++ b/scripts/reset-weekly-tracker.sh
@@ -34,7 +34,8 @@ jq --arg ws "$new_week_start" '{
   deep_inquiry_sessions: 0,
   delegation_sessions: 0,
   prediction_before_ask: 0,
-  total_sessions: 0
+  total_sessions: 0,
+  last_scan_ts: ""
 }' "$TRACKER_FILE" > "${TRACKER_FILE}.tmp" && mv "${TRACKER_FILE}.tmp" "$TRACKER_FILE"
 
 log "Weekly tracker reset complete"

--- a/scripts/reset-weekly-tracker.sh
+++ b/scripts/reset-weekly-tracker.sh
@@ -6,7 +6,11 @@ TRACKER_FILE="${REFINE_DIR}/growth-tracker.json"
 HISTORY_FILE="${REFINE_DIR}/growth-history.jsonl"
 LAST_SCAN_REF="${REFINE_DIR}/.last_scan_ref"
 SEEN_SESSIONS_FILE="${REFINE_DIR}/.seen_sessions"
+# Same lock identifiers as session-tagger.sh — both paths must be kept in sync.
+LOCK_FILE="${REFINE_DIR}/.growth-tracker.lock"
+LOCK_DIR="${REFINE_DIR}/.growth.lock"
 LOG_PREFIX="[refine-reset]"
+MAX_LOCK_WAIT=15  # seconds to wait for the tagger to release the lock
 
 log() {
   echo "${LOG_PREFIX} $(date '+%Y-%m-%d %H:%M:%S') $*"
@@ -21,28 +25,74 @@ if [[ ! -f "$TRACKER_FILE" ]]; then
   exit 0
 fi
 
-# 归档本周数据到历史文件（追加一行 JSONL）
-log "Archiving current week to ${HISTORY_FILE}"
-archived_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-jq -c --arg ts "$archived_at" '. + {archived_at: $ts}' "$TRACKER_FILE" >> "$HISTORY_FILE"
+do_reset() {
+  # 归档本周数据到历史文件（追加一行 JSONL）
+  log "Archiving current week to ${HISTORY_FILE}"
+  local archived_at
+  archived_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  jq -c --arg ts "$archived_at" '. + {archived_at: $ts}' "$TRACKER_FILE" >> "$HISTORY_FILE"
 
-# 重置本周计数器，更新 week_start 为今天
-new_week_start=$(date '+%Y-%m-%d')
-log "Resetting tracker with week_start=${new_week_start}"
+  # 重置本周计数器，更新 week_start 为今天。
+  # last_scan_ts 设为当前 UTC 时间（非空字符串）——这与 LAST_SCAN_REF 的新
+  # mtime 一起，确保下一次增量扫描只拾取重置之后的新会话，而不会把历史会话
+  # 重新计入本周指标（issue #1）。
+  local new_week_start now_ts
+  new_week_start=$(date '+%Y-%m-%d')
+  now_ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  log "Resetting tracker with week_start=${new_week_start}, watermark=${now_ts}"
 
-jq --arg ws "$new_week_start" '{
-  week_start: $ws,
-  exploration_sessions: 0,
-  deep_inquiry_sessions: 0,
-  delegation_sessions: 0,
-  prediction_before_ask: 0,
-  total_sessions: 0,
-  last_scan_ts: ""
-}' "$TRACKER_FILE" > "${TRACKER_FILE}.tmp" && mv "${TRACKER_FILE}.tmp" "$TRACKER_FILE"
+  jq --arg ws "$new_week_start" --arg ts "$now_ts" '{
+    week_start: $ws,
+    exploration_sessions: 0,
+    deep_inquiry_sessions: 0,
+    delegation_sessions: 0,
+    prediction_before_ask: 0,
+    total_sessions: 0,
+    last_scan_ts: $ts
+  }' "$TRACKER_FILE" > "${TRACKER_FILE}.tmp" && mv "${TRACKER_FILE}.tmp" "$TRACKER_FILE"
 
-# Remove watermark and seen-sessions list so the next scan starts fresh from
-# the new week boundary (issue #2: last_scan_ts reset alone was insufficient
-# because session-tagger.sh prefers .last_scan_ref when the file exists).
-rm -f "$LAST_SCAN_REF" "$SEEN_SESSIONS_FILE"
+  # 将 LAST_SCAN_REF 的 mtime 推进到"现在"，作为子秒精度的扫描下界水位线。
+  # 上一周的会话文件 mtime < 现在，不再落入新扫描窗口，因此可以安全清空
+  # SEEN_SESSIONS_FILE（该文件只在同一周内防止重复计数）。
+  touch "$LAST_SCAN_REF"
+  rm -f "$SEEN_SESSIONS_FILE"
 
-log "Weekly tracker reset complete"
+  log "Weekly tracker reset complete"
+}
+
+# ── Acquire the same lock used by session-tagger.sh ───────────────────────────
+# This prevents a racing tagger run from overwriting the zeroed counters with
+# pre-reset increments (issue #2).
+
+if command -v flock &>/dev/null; then
+  (
+    flock -x -w "$MAX_LOCK_WAIT" 9 || {
+      log "Failed to acquire lock after ${MAX_LOCK_WAIT}s, aborting reset"
+      exit 1
+    }
+    do_reset
+  ) 9>"$LOCK_FILE"
+else
+  # Fallback: mkdir-based lock (mirrors session-tagger.sh logic).
+  _try_acquire_lock() {
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      echo $$ > "${LOCK_DIR}/pid"
+      date +%s > "${LOCK_DIR}/created"
+      return 0
+    fi
+    return 1
+  }
+
+  waited=0
+  until _try_acquire_lock; do
+    if [[ $waited -ge $MAX_LOCK_WAIT ]]; then
+      log "Failed to acquire lock after ${MAX_LOCK_WAIT}s, aborting reset"
+      exit 1
+    fi
+    sleep 1
+    waited=$(( waited + 1 ))
+  done
+  trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT
+  do_reset
+  rm -rf "$LOCK_DIR" 2>/dev/null || true
+fi

--- a/scripts/session-tagger.sh
+++ b/scripts/session-tagger.sh
@@ -57,9 +57,10 @@ classify_session() {
     return
   fi
 
-  # Count user-turn lines (lines containing "\"role\":\"user\"")
+  # Count user-turn lines — matches both production Claude ("type":"user") and
+  # legacy/Codex ("role":"user") formats so classification works on real sessions.
   local user_turns
-  user_turns=$(echo "$sample" | grep -c '"role":"user"' || true)
+  user_turns=$(echo "$sample" | grep -cE '"(role|type)":"user"' || true)
 
   if [[ "$user_turns" -eq 0 ]]; then
     echo "uncategorized"
@@ -68,7 +69,7 @@ classify_session() {
 
   # Delegation: imperative verbs in user turns
   local delegation_hits
-  delegation_hits=$(echo "$sample" | grep '"role":"user"' | grep -ciE 'implement|create|write|build|fix|refactor|update' || true)
+  delegation_hits=$(echo "$sample" | grep -E '"(role|type)":"user"' | grep -ciE 'implement|create|write|build|fix|refactor|update' || true)
   if [[ "$delegation_hits" -gt "$DELEGATION_KEYWORD_THRESHOLD" ]]; then
     echo "delegation"
     return
@@ -76,7 +77,7 @@ classify_session() {
 
   # Exploration: question marks in user turns (lines ending with ?" before closing quote)
   local question_lines
-  question_lines=$(echo "$sample" | grep '"role":"user"' | grep -c '?"' || true)
+  question_lines=$(echo "$sample" | grep -E '"(role|type)":"user"' | grep -c '?"' || true)
   local question_pct=$(( question_lines * 100 / user_turns ))
   if [[ "$question_pct" -gt "$EXPLORATION_QUESTION_RATIO" ]]; then
     echo "exploration"
@@ -195,13 +196,35 @@ if command -v flock &>/dev/null; then
     do_scan_and_update
   ) 9>"$LOCK_FILE"
 else
-  # Fallback: mkdir-based lock (atomic on POSIX)
-  if mkdir "$LOCK_DIR" 2>/dev/null; then
-    trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+  # Fallback: mkdir-based lock (atomic on POSIX).
+  # A PID file inside the lock dir enables stale-lock recovery: if the process
+  # that created the lock is no longer alive, the dir is removed and we retry.
+  _try_acquire_lock() {
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      echo $$ > "${LOCK_DIR}/pid"
+      return 0
+    fi
+    # Lock dir exists — check if holder is still alive.
+    local p
+    p=$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)
+    if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null; then
+      return 1  # live process holds the lock
+    fi
+    # Stale lock (process gone or no PID file) — remove and retry once.
+    rm -rf "$LOCK_DIR"
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      echo $$ > "${LOCK_DIR}/pid"
+      return 0
+    fi
+    return 1
+  }
+
+  if _try_acquire_lock; then
+    trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT
     do_scan_and_update
-    rmdir "$LOCK_DIR" 2>/dev/null || true
+    rm -rf "$LOCK_DIR" 2>/dev/null || true
   else
-    # Another instance holds the lock; skip this run (next run will re-scan)
+    # Another live instance holds the lock; skip this run (next run will re-scan).
     exit 0
   fi
 fi

--- a/scripts/session-tagger.sh
+++ b/scripts/session-tagger.sh
@@ -43,37 +43,7 @@ if [[ ! -f "$TRACKER_FILE" ]]; then
 }' > "$TRACKER_FILE"
 fi
 
-# ── Phase A: mtime filter ─────────────────────────────────────────────────────
-
-last_scan_ts=$(jq -r '.last_scan_ts // ""' "$TRACKER_FILE")
-
-# Build reference file for find -newer
-REF_FILE=$(mktemp /tmp/session-tagger-ref.XXXXXX)
-trap 'rm -f "$REF_FILE"' EXIT
-
-if [[ -z "$last_scan_ts" ]]; then
-  # First run: touch to epoch so all files match
-  touch -t 197001010000 "$REF_FILE"
-else
-  # touch -d accepts ISO 8601 on both GNU and macOS (with coreutils)
-  if touch -d "$last_scan_ts" "$REF_FILE" 2>/dev/null; then
-    : # success
-  else
-    # macOS BSD touch: convert to format it understands via date
-    ts_local=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_scan_ts" "+%Y%m%d%H%M.%S" 2>/dev/null || date -d "$last_scan_ts" "+%Y%m%d%H%M.%S")
-    touch -t "$ts_local" "$REF_FILE"
-  fi
-fi
-
-# Collect candidate files
-if [[ ! -d "$SESSIONS_DIR" ]]; then
-  # Nothing to scan; just update timestamp
-  mapfile -t candidates < <(true)
-else
-  mapfile -t candidates < <(find "$SESSIONS_DIR" -name "*.jsonl" -newer "$REF_FILE" 2>/dev/null || true)
-fi
-
-# ── Phase B: classify ─────────────────────────────────────────────────────────
+# ── Classify ──────────────────────────────────────────────────────────────────
 
 classify_session() {
   local file="$1"
@@ -121,28 +91,72 @@ classify_session() {
   echo "uncategorized"
 }
 
-delta_exploration=0
-delta_deep=0
-delta_delegation=0
-delta_total=0
+# ── Scan + classify + update (runs entirely inside the lock) ──────────────────
+#
+# All three phases are inside the lock so that:
+#   • Two concurrent runs cannot claim the same file window (fixes race / double-count).
+#   • now_ts is captured BEFORE candidate enumeration so files written during
+#     classification are not skipped permanently — they land after now_ts and
+#     will be picked up by the next run (fixes watermark gap).
 
-for f in "${candidates[@]}"; do
-  [[ -f "$f" ]] || continue
-  # Guard against malformed JSONL — classify never fails the script
-  tag=$(classify_session "$f" 2>/dev/null || echo "uncategorized")
-  case "$tag" in
-    exploration)  (( delta_exploration++ )) ;;
-    deep_inquiry) (( delta_deep++ )) ;;
-    delegation)   (( delta_delegation++ )) ;;
-  esac
-  (( delta_total++ ))
-done
+do_scan_and_update() {
+  # Phase A: read watermark and enumerate candidates ──────────────────────────
 
-# ── Phase C: atomic tracker update ───────────────────────────────────────────
+  local last_scan_ts
+  last_scan_ts=$(jq -r '.last_scan_ts // ""' "$TRACKER_FILE")
 
-now_ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  # Capture now_ts before enumerating so files created between enumeration and
+  # update are guaranteed to appear in the next run's window.
+  local now_ts
+  now_ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
-do_update() {
+  local ref_file
+  ref_file=$(mktemp /tmp/session-tagger-ref.XXXXXX)
+
+  if [[ -z "$last_scan_ts" ]]; then
+    # First run: touch to epoch so all files match
+    touch -t 197001010000 "$ref_file"
+  else
+    # touch -d accepts ISO 8601 on both GNU and macOS (with coreutils)
+    if ! touch -d "$last_scan_ts" "$ref_file" 2>/dev/null; then
+      # macOS BSD touch: convert to format it understands via date
+      local ts_local
+      ts_local=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_scan_ts" "+%Y%m%d%H%M.%S" 2>/dev/null || \
+                 date -d "$last_scan_ts" "+%Y%m%d%H%M.%S")
+      touch -t "$ts_local" "$ref_file"
+    fi
+  fi
+
+  # Collect candidates — use while+read+print0 instead of mapfile for bash 3.2
+  # compatibility (mapfile is a bash 4+ builtin absent on macOS default shell).
+  local candidates=()
+  if [[ -d "$SESSIONS_DIR" ]]; then
+    while IFS= read -r -d '' f; do
+      candidates+=("$f")
+    done < <(find "$SESSIONS_DIR" -name "*.jsonl" -newer "$ref_file" -print0 2>/dev/null)
+  fi
+
+  rm -f "$ref_file"
+
+  # Phase B: classify ─────────────────────────────────────────────────────────
+
+  local delta_exploration=0 delta_deep=0 delta_delegation=0 delta_total=0
+  local f tag
+  for f in "${candidates[@]+"${candidates[@]}"}"; do
+    [[ -f "$f" ]] || continue
+    tag=$(classify_session "$f" 2>/dev/null || echo "uncategorized")
+    case "$tag" in
+      exploration)  delta_exploration=$(( delta_exploration + 1 )) ;;
+      deep_inquiry) delta_deep=$(( delta_deep + 1 )) ;;
+      delegation)   delta_delegation=$(( delta_delegation + 1 )) ;;
+    esac
+    # Use $(( )) assignment — never returns non-zero, safe under set -e
+    delta_total=$(( delta_total + 1 ))
+  done
+
+  # Phase C: atomic tracker update ────────────────────────────────────────────
+  # Write now_ts (pre-scan timestamp) as the new watermark.
+
   jq -c \
     --arg ts "$now_ts" \
     --argjson de "$delta_exploration" \
@@ -157,16 +171,18 @@ do_update() {
     "$TRACKER_FILE" > "${TRACKER_FILE}.tmp" && mv "${TRACKER_FILE}.tmp" "$TRACKER_FILE"
 }
 
+# ── Lock and run ──────────────────────────────────────────────────────────────
+
 if command -v flock &>/dev/null; then
   (
     flock -x 9
-    do_update
+    do_scan_and_update
   ) 9>"$LOCK_FILE"
 else
   # Fallback: mkdir-based lock (atomic on POSIX)
   if mkdir "$LOCK_DIR" 2>/dev/null; then
     trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
-    do_update
+    do_scan_and_update
     rmdir "$LOCK_DIR" 2>/dev/null || true
   else
     # Another instance holds the lock; skip this run (next run will re-scan)

--- a/scripts/session-tagger.sh
+++ b/scripts/session-tagger.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# session-tagger.sh — incremental session classifier for growth-tracker
+#
+# Runs as a Claude Code Stop hook. Scans only JSONL files with mtime > last_scan_ts
+# to keep execution under 1s even with thousands of files.
+#
+# Manual hook registration (add to ~/.claude/settings.json):
+#   "Stop": [{"matcher": "", "hooks": [{"type": "command",
+#     "command": "/path/to/scripts/session-tagger.sh 2>> ~/.refine/hooks-error.log"}]}]
+#
+# Requires: jq, find, grep, touch. flock (optional — falls back to mkdir lock).
+# Note: find -newer relies on mtime; files copied/rsynced with old mtime may be missed.
+
+set -euo pipefail
+
+REFINE_DIR="${HOME}/.refine"
+TRACKER_FILE="${REFINE_DIR}/growth-tracker.json"
+LOCK_FILE="${REFINE_DIR}/.growth-tracker.lock"
+LOCK_DIR="${REFINE_DIR}/.growth.lock"
+SESSIONS_DIR="${HOME}/.claude/projects"
+
+# Tunable classification thresholds
+DELEGATION_KEYWORD_THRESHOLD=8
+EXPLORATION_QUESTION_RATIO=50  # percent
+
+log() {
+  : # silent in normal operation; redirect stderr to log file from hook
+}
+
+# ── Init ─────────────────────────────────────────────────────────────────────
+
+mkdir -p "$REFINE_DIR"
+
+if [[ ! -f "$TRACKER_FILE" ]]; then
+  echo '{
+  "week_start": "",
+  "exploration_sessions": 0,
+  "deep_inquiry_sessions": 0,
+  "delegation_sessions": 0,
+  "prediction_before_ask": 0,
+  "total_sessions": 0,
+  "last_scan_ts": ""
+}' > "$TRACKER_FILE"
+fi
+
+# ── Phase A: mtime filter ─────────────────────────────────────────────────────
+
+last_scan_ts=$(jq -r '.last_scan_ts // ""' "$TRACKER_FILE")
+
+# Build reference file for find -newer
+REF_FILE=$(mktemp /tmp/session-tagger-ref.XXXXXX)
+trap 'rm -f "$REF_FILE"' EXIT
+
+if [[ -z "$last_scan_ts" ]]; then
+  # First run: touch to epoch so all files match
+  touch -t 197001010000 "$REF_FILE"
+else
+  # touch -d accepts ISO 8601 on both GNU and macOS (with coreutils)
+  if touch -d "$last_scan_ts" "$REF_FILE" 2>/dev/null; then
+    : # success
+  else
+    # macOS BSD touch: convert to format it understands via date
+    ts_local=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_scan_ts" "+%Y%m%d%H%M.%S" 2>/dev/null || date -d "$last_scan_ts" "+%Y%m%d%H%M.%S")
+    touch -t "$ts_local" "$REF_FILE"
+  fi
+fi
+
+# Collect candidate files
+if [[ ! -d "$SESSIONS_DIR" ]]; then
+  # Nothing to scan; just update timestamp
+  mapfile -t candidates < <(true)
+else
+  mapfile -t candidates < <(find "$SESSIONS_DIR" -name "*.jsonl" -newer "$REF_FILE" 2>/dev/null || true)
+fi
+
+# ── Phase B: classify ─────────────────────────────────────────────────────────
+
+classify_session() {
+  local file="$1"
+  # Read first 4096 bytes to limit I/O time
+  local sample
+  sample=$(head -c 4096 "$file" 2>/dev/null || true)
+
+  if [[ -z "$sample" ]]; then
+    echo "uncategorized"
+    return
+  fi
+
+  # Count user-turn lines (lines containing "\"role\":\"user\"")
+  local user_turns
+  user_turns=$(echo "$sample" | grep -c '"role":"user"' || true)
+
+  if [[ "$user_turns" -eq 0 ]]; then
+    echo "uncategorized"
+    return
+  fi
+
+  # Delegation: imperative verbs in user turns
+  local delegation_hits
+  delegation_hits=$(echo "$sample" | grep '"role":"user"' | grep -ciE 'implement|create|write|build|fix|refactor|update' || true)
+  if [[ "$delegation_hits" -gt "$DELEGATION_KEYWORD_THRESHOLD" ]]; then
+    echo "delegation"
+    return
+  fi
+
+  # Exploration: question marks in user turns (lines ending with ?" before closing quote)
+  local question_lines
+  question_lines=$(echo "$sample" | grep '"role":"user"' | grep -c '?"' || true)
+  local question_pct=$(( question_lines * 100 / user_turns ))
+  if [[ "$question_pct" -gt "$EXPLORATION_QUESTION_RATIO" ]]; then
+    echo "exploration"
+    return
+  fi
+
+  # Deep inquiry: longer conversations
+  if [[ "$user_turns" -gt 8 ]]; then
+    echo "deep_inquiry"
+    return
+  fi
+
+  echo "uncategorized"
+}
+
+delta_exploration=0
+delta_deep=0
+delta_delegation=0
+delta_total=0
+
+for f in "${candidates[@]}"; do
+  [[ -f "$f" ]] || continue
+  # Guard against malformed JSONL — classify never fails the script
+  tag=$(classify_session "$f" 2>/dev/null || echo "uncategorized")
+  case "$tag" in
+    exploration)  (( delta_exploration++ )) ;;
+    deep_inquiry) (( delta_deep++ )) ;;
+    delegation)   (( delta_delegation++ )) ;;
+  esac
+  (( delta_total++ ))
+done
+
+# ── Phase C: atomic tracker update ───────────────────────────────────────────
+
+now_ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+do_update() {
+  jq -c \
+    --arg ts "$now_ts" \
+    --argjson de "$delta_exploration" \
+    --argjson dd "$delta_deep" \
+    --argjson dl "$delta_delegation" \
+    --argjson dt "$delta_total" \
+    '.exploration_sessions += $de |
+     .deep_inquiry_sessions += $dd |
+     .delegation_sessions += $dl |
+     .total_sessions += $dt |
+     .last_scan_ts = $ts' \
+    "$TRACKER_FILE" > "${TRACKER_FILE}.tmp" && mv "${TRACKER_FILE}.tmp" "$TRACKER_FILE"
+}
+
+if command -v flock &>/dev/null; then
+  (
+    flock -x 9
+    do_update
+  ) 9>"$LOCK_FILE"
+else
+  # Fallback: mkdir-based lock (atomic on POSIX)
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+    do_update
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  else
+    # Another instance holds the lock; skip this run (next run will re-scan)
+    exit 0
+  fi
+fi

--- a/scripts/session-tagger.sh
+++ b/scripts/session-tagger.sh
@@ -219,19 +219,17 @@ else
       date +%s > "${LOCK_DIR}/created"
       return 0
     fi
-    # Lock dir exists — check if holder is still alive AND the lock is fresh.
-    # kill -0 alone is unsafe: after a crash the PID may be reused by an
-    # unrelated process, making the lock appear permanently live (issue #3).
-    # Adding an age check ensures the lock is force-expired after MAX_LOCK_AGE.
-    local p created now age
+    # Lock dir exists — check if holder is still alive.
+    # Never steal the lock from a live process: doing so allows concurrent writes
+    # to growth-tracker.json and .seen_sessions (double-count / overwrite).
+    # PID reuse after a crash is possible but far less likely than a long scan
+    # legitimately exceeding a fixed age threshold.
+    local p
     p=$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)
-    created=$(cat "${LOCK_DIR}/created" 2>/dev/null || echo 0)
-    now=$(date +%s)
-    age=$(( now - created ))
-    if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null && [[ $age -lt $MAX_LOCK_AGE ]]; then
-      return 1  # live process with a fresh lock
+    if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null; then
+      return 1  # live process holds the lock
     fi
-    # Stale lock (process gone, no PID file, or lock expired) — remove and retry once.
+    # Stale lock (process gone or no PID file) — remove and retry once.
     rm -rf "$LOCK_DIR"
     if mkdir "$LOCK_DIR" 2>/dev/null; then
       echo $$ > "${LOCK_DIR}/pid"

--- a/scripts/session-tagger.sh
+++ b/scripts/session-tagger.sh
@@ -20,7 +20,8 @@ LOCK_DIR="${REFINE_DIR}/.growth.lock"
 LAST_SCAN_REF="${REFINE_DIR}/.last_scan_ref"
 SEEN_SESSIONS_FILE="${REFINE_DIR}/.seen_sessions"
 SESSIONS_DIR="${HOME}/.claude/projects"
-MAX_LOCK_AGE=120  # seconds; locks older than this are assumed stale (guards PID reuse)
+MAX_LOCK_AGE=120       # seconds; locks older than this are assumed stale (guards PID reuse)
+MAX_LOCK_WAIT_TAGGER=5 # seconds to wait for lock in no-flock path before giving up
 
 # Tunable classification thresholds
 DELEGATION_KEYWORD_THRESHOLD=8
@@ -219,17 +220,20 @@ else
       date +%s > "${LOCK_DIR}/created"
       return 0
     fi
-    # Lock dir exists — check if holder is still alive.
-    # Never steal the lock from a live process: doing so allows concurrent writes
-    # to growth-tracker.json and .seen_sessions (double-count / overwrite).
-    # PID reuse after a crash is possible but far less likely than a long scan
-    # legitimately exceeding a fixed age threshold.
-    local p
+    # Lock dir exists — check if holder is still alive AND the lock is fresh.
+    # Using only kill -0 is insufficient: after a crash the PID can be reused by
+    # an unrelated live process, causing tagger to silently skip forever.
+    # MAX_LOCK_AGE bounds that window: a lock older than MAX_LOCK_AGE seconds is
+    # treated as stale regardless of whether kill -0 succeeds.
+    local p created_ts now_ts lock_age
     p=$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)
-    if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null; then
-      return 1  # live process holds the lock
+    created_ts=$(cat "${LOCK_DIR}/created" 2>/dev/null || echo 0)
+    now_ts=$(date +%s)
+    lock_age=$(( now_ts - created_ts ))
+    if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null && [[ "$lock_age" -lt "$MAX_LOCK_AGE" ]]; then
+      return 1  # live process holds a fresh lock
     fi
-    # Stale lock (process gone or no PID file) — remove and retry once.
+    # Stale lock (process gone, no PID/created file, or age >= MAX_LOCK_AGE) — remove and retry once.
     rm -rf "$LOCK_DIR"
     if mkdir "$LOCK_DIR" 2>/dev/null; then
       echo $$ > "${LOCK_DIR}/pid"
@@ -239,12 +243,21 @@ else
     return 1
   }
 
-  if _try_acquire_lock; then
-    trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT
-    do_scan_and_update
-    rm -rf "$LOCK_DIR" 2>/dev/null || true
-  else
-    # Another live instance holds the lock; skip this run (next run will re-scan).
-    exit 0
-  fi
+  # Wait up to MAX_LOCK_WAIT_TAGGER seconds rather than exiting immediately when
+  # the lock is busy.  Exiting right away means sessions written after the
+  # winner's upper_ref cutoff (but before the lock is released) are only captured
+  # by the next hook invocation.  A short wait lets this instance run with its
+  # own upper_ref, closing that gap.
+  waited=0
+  until _try_acquire_lock; do
+    if [[ $waited -ge $MAX_LOCK_WAIT_TAGGER ]]; then
+      # Timed out — next hook invocation will re-scan from current LAST_SCAN_REF.
+      exit 0
+    fi
+    sleep 1
+    waited=$(( waited + 1 ))
+  done
+  trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT
+  do_scan_and_update
+  rm -rf "$LOCK_DIR" 2>/dev/null || true
 fi

--- a/scripts/session-tagger.sh
+++ b/scripts/session-tagger.sh
@@ -18,7 +18,9 @@ TRACKER_FILE="${REFINE_DIR}/growth-tracker.json"
 LOCK_FILE="${REFINE_DIR}/.growth-tracker.lock"
 LOCK_DIR="${REFINE_DIR}/.growth.lock"
 LAST_SCAN_REF="${REFINE_DIR}/.last_scan_ref"
+SEEN_SESSIONS_FILE="${REFINE_DIR}/.seen_sessions"
 SESSIONS_DIR="${HOME}/.claude/projects"
+MAX_LOCK_AGE=120  # seconds; locks older than this are assumed stale (guards PID reuse)
 
 # Tunable classification thresholds
 DELEGATION_KEYWORD_THRESHOLD=8
@@ -149,19 +151,26 @@ do_scan_and_update() {
   fi
 
   # Phase B: classify ─────────────────────────────────────────────────────────
+  # Skip files already counted in a prior run so that an active .jsonl whose
+  # mtime advances on every append is never double-counted (issue #1 in review).
 
   local delta_exploration=0 delta_deep=0 delta_delegation=0 delta_total=0
+  local new_files=()
   local f tag
   for f in "${candidates[@]+"${candidates[@]}"}"; do
     [[ -f "$f" ]] || continue
+    # grep -qxF: exact whole-line literal match — bash 3.2 safe, no assoc arrays
+    if [[ -f "$SEEN_SESSIONS_FILE" ]] && grep -qxF "$f" "$SEEN_SESSIONS_FILE" 2>/dev/null; then
+      continue
+    fi
     tag=$(classify_session "$f" 2>/dev/null || echo "uncategorized")
     case "$tag" in
       exploration)  delta_exploration=$(( delta_exploration + 1 )) ;;
       deep_inquiry) delta_deep=$(( delta_deep + 1 )) ;;
       delegation)   delta_delegation=$(( delta_delegation + 1 )) ;;
     esac
-    # Use $(( )) assignment — never returns non-zero, safe under set -e
     delta_total=$(( delta_total + 1 ))
+    new_files+=("$f")
   done
 
   # Phase C: atomic tracker update ────────────────────────────────────────────
@@ -186,6 +195,11 @@ do_scan_and_update() {
   # Done AFTER the JSON write so a failed write leaves the watermark un-advanced
   # and candidates are safely re-processed on the next run.
   touch -r "$upper_ref" "$LAST_SCAN_REF"
+
+  # Record newly counted files to prevent re-counting on future runs.
+  if [[ ${#new_files[@]} -gt 0 ]]; then
+    printf '%s\n' "${new_files[@]}" >> "$SEEN_SESSIONS_FILE"
+  fi
 }
 
 # ── Lock and run ──────────────────────────────────────────────────────────────
@@ -202,18 +216,26 @@ else
   _try_acquire_lock() {
     if mkdir "$LOCK_DIR" 2>/dev/null; then
       echo $$ > "${LOCK_DIR}/pid"
+      date +%s > "${LOCK_DIR}/created"
       return 0
     fi
-    # Lock dir exists — check if holder is still alive.
-    local p
+    # Lock dir exists — check if holder is still alive AND the lock is fresh.
+    # kill -0 alone is unsafe: after a crash the PID may be reused by an
+    # unrelated process, making the lock appear permanently live (issue #3).
+    # Adding an age check ensures the lock is force-expired after MAX_LOCK_AGE.
+    local p created now age
     p=$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)
-    if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null; then
-      return 1  # live process holds the lock
+    created=$(cat "${LOCK_DIR}/created" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    age=$(( now - created ))
+    if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null && [[ $age -lt $MAX_LOCK_AGE ]]; then
+      return 1  # live process with a fresh lock
     fi
-    # Stale lock (process gone or no PID file) — remove and retry once.
+    # Stale lock (process gone, no PID file, or lock expired) — remove and retry once.
     rm -rf "$LOCK_DIR"
     if mkdir "$LOCK_DIR" 2>/dev/null; then
       echo $$ > "${LOCK_DIR}/pid"
+      date +%s > "${LOCK_DIR}/created"
       return 0
     fi
     return 1

--- a/scripts/session-tagger.sh
+++ b/scripts/session-tagger.sh
@@ -17,6 +17,7 @@ REFINE_DIR="${HOME}/.refine"
 TRACKER_FILE="${REFINE_DIR}/growth-tracker.json"
 LOCK_FILE="${REFINE_DIR}/.growth-tracker.lock"
 LOCK_DIR="${REFINE_DIR}/.growth.lock"
+LAST_SCAN_REF="${REFINE_DIR}/.last_scan_ref"
 SESSIONS_DIR="${HOME}/.claude/projects"
 
 # Tunable classification thresholds
@@ -94,49 +95,57 @@ classify_session() {
 # ── Scan + classify + update (runs entirely inside the lock) ──────────────────
 #
 # All three phases are inside the lock so that:
-#   • Two concurrent runs cannot claim the same file window (fixes race / double-count).
-#   • now_ts is captured BEFORE candidate enumeration so files written during
-#     classification are not skipped permanently — they land after now_ts and
-#     will be picked up by the next run (fixes watermark gap).
+#   • Two concurrent runs cannot claim the same file window (no race / double-count).
+#   • upper_ref is created BEFORE enumeration, giving an explicit upper bound so
+#     files written during classification fall outside the window and are picked up
+#     by the next run — avoids both over-counting and missed-file gaps.
+#   • LAST_SCAN_REF persists the watermark at sub-second mtime precision so that
+#     files in the same second as the cut-off are never re-selected.
 
 do_scan_and_update() {
-  # Phase A: read watermark and enumerate candidates ──────────────────────────
+  # Create upper-bound ref BEFORE enumeration — its mtime is the exact cut-off.
+  # Any .jsonl whose mtime > upper_ref is excluded from this run and will be
+  # found in the next run (its mtime > LAST_SCAN_REF after we advance it).
+  local upper_ref lower_ref
+  upper_ref=$(mktemp /tmp/session-tagger-upper.XXXXXX)
+  lower_ref=$(mktemp /tmp/session-tagger-lower.XXXXXX)
+  # shellcheck disable=SC2064
+  trap "rm -f '$upper_ref' '$lower_ref'" RETURN
 
-  local last_scan_ts
-  last_scan_ts=$(jq -r '.last_scan_ts // ""' "$TRACKER_FILE")
+  # Phase A: establish lower bound ─────────────────────────────────────────────
 
-  # Capture now_ts before enumerating so files created between enumeration and
-  # update are guaranteed to appear in the next run's window.
-  local now_ts
-  now_ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-
-  local ref_file
-  ref_file=$(mktemp /tmp/session-tagger-ref.XXXXXX)
-
-  if [[ -z "$last_scan_ts" ]]; then
-    # First run: touch to epoch so all files match
-    touch -t 197001010000 "$ref_file"
+  if [[ -f "$LAST_SCAN_REF" ]]; then
+    # Authoritative sub-second watermark: copy its mtime directly to lower_ref.
+    touch -r "$LAST_SCAN_REF" "$lower_ref"
   else
-    # touch -d accepts ISO 8601 on both GNU and macOS (with coreutils)
-    if ! touch -d "$last_scan_ts" "$ref_file" 2>/dev/null; then
-      # macOS BSD touch: convert to format it understands via date
-      local ts_local
-      ts_local=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_scan_ts" "+%Y%m%d%H%M.%S" 2>/dev/null || \
-                 date -d "$last_scan_ts" "+%Y%m%d%H%M.%S")
-      touch -t "$ts_local" "$ref_file"
+    # Bootstrap: LAST_SCAN_REF absent — derive from JSON timestamp (first run or
+    # migration from an older version of this script that lacked LAST_SCAN_REF).
+    local last_scan_ts
+    last_scan_ts=$(jq -r '.last_scan_ts // ""' "$TRACKER_FILE")
+    if [[ -z "$last_scan_ts" ]]; then
+      # First ever run: epoch so every existing file is scanned.
+      touch -t 197001010000 "$lower_ref"
+    elif ! touch -d "$last_scan_ts" "$lower_ref" 2>/dev/null; then
+      # macOS BSD touch lacks -d. Parse the UTC timestamp and set mtime in UTC
+      # (TZ=UTC on both date and touch prevents a local-timezone offset shift
+      # that would rescan already-counted files — issue #3).
+      local ts_fmt
+      ts_fmt=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_scan_ts" "+%Y%m%d%H%M.%S" 2>/dev/null || \
+               TZ=UTC date -d "$last_scan_ts" "+%Y%m%d%H%M.%S")
+      TZ=UTC touch -t "$ts_fmt" "$lower_ref"
     fi
   fi
 
-  # Collect candidates — use while+read+print0 instead of mapfile for bash 3.2
-  # compatibility (mapfile is a bash 4+ builtin absent on macOS default shell).
+  # Collect candidates in half-open window (lower_ref, upper_ref].
+  # -not -newer upper_ref closes the upper bound (issue #1 + #2).
+  # while+read+print0 instead of mapfile for bash 3.2 compatibility.
   local candidates=()
   if [[ -d "$SESSIONS_DIR" ]]; then
     while IFS= read -r -d '' f; do
       candidates+=("$f")
-    done < <(find "$SESSIONS_DIR" -name "*.jsonl" -newer "$ref_file" -print0 2>/dev/null)
+    done < <(find "$SESSIONS_DIR" -name "*.jsonl" \
+               -newer "$lower_ref" -not -newer "$upper_ref" -print0 2>/dev/null)
   fi
-
-  rm -f "$ref_file"
 
   # Phase B: classify ─────────────────────────────────────────────────────────
 
@@ -155,7 +164,9 @@ do_scan_and_update() {
   done
 
   # Phase C: atomic tracker update ────────────────────────────────────────────
-  # Write now_ts (pre-scan timestamp) as the new watermark.
+
+  local now_ts
+  now_ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
   jq -c \
     --arg ts "$now_ts" \
@@ -169,6 +180,11 @@ do_scan_and_update() {
      .total_sessions += $dt |
      .last_scan_ts = $ts' \
     "$TRACKER_FILE" > "${TRACKER_FILE}.tmp" && mv "${TRACKER_FILE}.tmp" "$TRACKER_FILE"
+
+  # Advance the sub-second watermark to upper_ref's exact mtime.
+  # Done AFTER the JSON write so a failed write leaves the watermark un-advanced
+  # and candidates are safely re-processed on the next run.
+  touch -r "$upper_ref" "$LAST_SCAN_REF"
 }
 
 # ── Lock and run ──────────────────────────────────────────────────────────────

--- a/scripts/tests/fixtures/deep_inquiry_session.jsonl
+++ b/scripts/tests/fixtures/deep_inquiry_session.jsonl
@@ -1,0 +1,18 @@
+{"role":"user","content":"tell me about database indexing strategies"}
+{"role":"assistant","content":"Indexing improves query performance by..."}
+{"role":"user","content":"explain B-tree vs hash indexes"}
+{"role":"assistant","content":"B-trees support range queries while hash indexes are O(1) for equality."}
+{"role":"user","content":"when would you use a composite index"}
+{"role":"assistant","content":"When queries filter on multiple columns together."}
+{"role":"user","content":"what about partial indexes"}
+{"role":"assistant","content":"Partial indexes only index rows matching a condition."}
+{"role":"user","content":"how do covering indexes work"}
+{"role":"assistant","content":"A covering index includes all columns needed by the query."}
+{"role":"user","content":"what is index bloat and how to address it"}
+{"role":"assistant","content":"Index bloat occurs when dead tuples accumulate; VACUUM helps."}
+{"role":"user","content":"explain the difference between clustered and non-clustered indexes"}
+{"role":"assistant","content":"Clustered indexes determine physical row order."}
+{"role":"user","content":"when should you avoid over-indexing"}
+{"role":"assistant","content":"Write-heavy tables suffer from too many indexes."}
+{"role":"user","content":"what tools help analyze index usage in PostgreSQL"}
+{"role":"assistant","content":"pg_stat_user_indexes shows index scan counts."}

--- a/scripts/tests/fixtures/deep_inquiry_session.jsonl
+++ b/scripts/tests/fixtures/deep_inquiry_session.jsonl
@@ -1,18 +1,18 @@
-{"role":"user","content":"tell me about database indexing strategies"}
-{"role":"assistant","content":"Indexing improves query performance by..."}
-{"role":"user","content":"explain B-tree vs hash indexes"}
-{"role":"assistant","content":"B-trees support range queries while hash indexes are O(1) for equality."}
-{"role":"user","content":"when would you use a composite index"}
-{"role":"assistant","content":"When queries filter on multiple columns together."}
-{"role":"user","content":"what about partial indexes"}
-{"role":"assistant","content":"Partial indexes only index rows matching a condition."}
-{"role":"user","content":"how do covering indexes work"}
-{"role":"assistant","content":"A covering index includes all columns needed by the query."}
-{"role":"user","content":"what is index bloat and how to address it"}
-{"role":"assistant","content":"Index bloat occurs when dead tuples accumulate; VACUUM helps."}
-{"role":"user","content":"explain the difference between clustered and non-clustered indexes"}
-{"role":"assistant","content":"Clustered indexes determine physical row order."}
-{"role":"user","content":"when should you avoid over-indexing"}
-{"role":"assistant","content":"Write-heavy tables suffer from too many indexes."}
-{"role":"user","content":"what tools help analyze index usage in PostgreSQL"}
-{"role":"assistant","content":"pg_stat_user_indexes shows index scan counts."}
+{"type":"user","message":{"content":"tell me about database indexing strategies"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Indexing improves query performance by..."}]}}
+{"type":"user","message":{"content":"explain B-tree vs hash indexes"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"B-trees support range queries while hash indexes are O(1) for equality."}]}}
+{"type":"user","message":{"content":"when would you use a composite index"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"When queries filter on multiple columns together."}]}}
+{"type":"user","message":{"content":"what about partial indexes"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Partial indexes only index rows matching a condition."}]}}
+{"type":"user","message":{"content":"how do covering indexes work"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"A covering index includes all columns needed by the query."}]}}
+{"type":"user","message":{"content":"what is index bloat and how to address it"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Index bloat occurs when dead tuples accumulate; VACUUM helps."}]}}
+{"type":"user","message":{"content":"explain the difference between clustered and non-clustered indexes"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Clustered indexes determine physical row order."}]}}
+{"type":"user","message":{"content":"when should you avoid over-indexing"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Write-heavy tables suffer from too many indexes."}]}}
+{"type":"user","message":{"content":"what tools help analyze index usage in PostgreSQL"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"pg_stat_user_indexes shows index scan counts."}]}}

--- a/scripts/tests/fixtures/delegation_session.jsonl
+++ b/scripts/tests/fixtures/delegation_session.jsonl
@@ -1,18 +1,18 @@
-{"role":"user","content":"implement a login feature for the app"}
-{"role":"assistant","content":"I'll implement that for you."}
-{"role":"user","content":"create a user model with email and password fields"}
-{"role":"assistant","content":"Sure."}
-{"role":"user","content":"write the database migration script"}
-{"role":"assistant","content":"Done."}
-{"role":"user","content":"build the authentication middleware"}
-{"role":"assistant","content":"Building it."}
-{"role":"user","content":"fix the session expiry bug"}
-{"role":"assistant","content":"Fixed."}
-{"role":"user","content":"refactor the token validation logic"}
-{"role":"assistant","content":"Refactored."}
-{"role":"user","content":"update the password hashing algorithm"}
-{"role":"assistant","content":"Updated."}
-{"role":"user","content":"write unit tests for the auth module"}
-{"role":"assistant","content":"Tests written."}
-{"role":"user","content":"create API endpoints for login and logout"}
-{"role":"assistant","content":"Created."}
+{"type":"user","message":{"content":"implement a login feature for the app"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"I'll implement that for you."}]}}
+{"type":"user","message":{"content":"create a user model with email and password fields"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Sure."}]}}
+{"type":"user","message":{"content":"write the database migration script"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Done."}]}}
+{"type":"user","message":{"content":"build the authentication middleware"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Building it."}]}}
+{"type":"user","message":{"content":"fix the session expiry bug"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Fixed."}]}}
+{"type":"user","message":{"content":"refactor the token validation logic"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Refactored."}]}}
+{"type":"user","message":{"content":"update the password hashing algorithm"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Updated."}]}}
+{"type":"user","message":{"content":"write unit tests for the auth module"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Tests written."}]}}
+{"type":"user","message":{"content":"create API endpoints for login and logout"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Created."}]}}

--- a/scripts/tests/fixtures/delegation_session.jsonl
+++ b/scripts/tests/fixtures/delegation_session.jsonl
@@ -1,0 +1,18 @@
+{"role":"user","content":"implement a login feature for the app"}
+{"role":"assistant","content":"I'll implement that for you."}
+{"role":"user","content":"create a user model with email and password fields"}
+{"role":"assistant","content":"Sure."}
+{"role":"user","content":"write the database migration script"}
+{"role":"assistant","content":"Done."}
+{"role":"user","content":"build the authentication middleware"}
+{"role":"assistant","content":"Building it."}
+{"role":"user","content":"fix the session expiry bug"}
+{"role":"assistant","content":"Fixed."}
+{"role":"user","content":"refactor the token validation logic"}
+{"role":"assistant","content":"Refactored."}
+{"role":"user","content":"update the password hashing algorithm"}
+{"role":"assistant","content":"Updated."}
+{"role":"user","content":"write unit tests for the auth module"}
+{"role":"assistant","content":"Tests written."}
+{"role":"user","content":"create API endpoints for login and logout"}
+{"role":"assistant","content":"Created."}

--- a/scripts/tests/fixtures/exploration_session.jsonl
+++ b/scripts/tests/fixtures/exploration_session.jsonl
@@ -1,12 +1,12 @@
-{"role":"user","content":"what is the difference between JWT and session cookies?"}
-{"role":"assistant","content":"JWT is stateless while session cookies require server-side state."}
-{"role":"user","content":"how does OAuth2 work?"}
-{"role":"assistant","content":"OAuth2 is an authorization framework..."}
-{"role":"user","content":"why would you choose GraphQL over REST?"}
-{"role":"assistant","content":"GraphQL allows clients to request exactly the data they need."}
-{"role":"user","content":"what are the trade-offs of microservices?"}
-{"role":"assistant","content":"Microservices offer independent deployment but add operational complexity."}
-{"role":"user","content":"how does the event loop work in Node.js?"}
-{"role":"assistant","content":"The event loop processes callbacks from the task queue."}
-{"role":"user","content":"what is the CAP theorem?"}
-{"role":"assistant","content":"It states you can only guarantee two of: consistency, availability, partition tolerance."}
+{"type":"user","message":{"content":"what is the difference between JWT and session cookies?"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"JWT is stateless while session cookies require server-side state."}]}}
+{"type":"user","message":{"content":"how does OAuth2 work?"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"OAuth2 is an authorization framework..."}]}}
+{"type":"user","message":{"content":"why would you choose GraphQL over REST?"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"GraphQL allows clients to request exactly the data they need."}]}}
+{"type":"user","message":{"content":"what are the trade-offs of microservices?"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Microservices offer independent deployment but add operational complexity."}]}}
+{"type":"user","message":{"content":"how does the event loop work in Node.js?"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"The event loop processes callbacks from the task queue."}]}}
+{"type":"user","message":{"content":"what is the CAP theorem?"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"It states you can only guarantee two of: consistency, availability, partition tolerance."}]}}

--- a/scripts/tests/fixtures/exploration_session.jsonl
+++ b/scripts/tests/fixtures/exploration_session.jsonl
@@ -1,0 +1,12 @@
+{"role":"user","content":"what is the difference between JWT and session cookies?"}
+{"role":"assistant","content":"JWT is stateless while session cookies require server-side state."}
+{"role":"user","content":"how does OAuth2 work?"}
+{"role":"assistant","content":"OAuth2 is an authorization framework..."}
+{"role":"user","content":"why would you choose GraphQL over REST?"}
+{"role":"assistant","content":"GraphQL allows clients to request exactly the data they need."}
+{"role":"user","content":"what are the trade-offs of microservices?"}
+{"role":"assistant","content":"Microservices offer independent deployment but add operational complexity."}
+{"role":"user","content":"how does the event loop work in Node.js?"}
+{"role":"assistant","content":"The event loop processes callbacks from the task queue."}
+{"role":"user","content":"what is the CAP theorem?"}
+{"role":"assistant","content":"It states you can only guarantee two of: consistency, availability, partition tolerance."}

--- a/scripts/tests/fixtures/malformed_session.jsonl
+++ b/scripts/tests/fixtures/malformed_session.jsonl
@@ -1,0 +1,5 @@
+{"role":"user","content":"this is valid"}
+{broken json here
+{"role":"user","content":"another valid line"}
+not json at all
+{"role":"assistant","content":"response"}

--- a/scripts/tests/fixtures/malformed_session.jsonl
+++ b/scripts/tests/fixtures/malformed_session.jsonl
@@ -1,5 +1,5 @@
-{"role":"user","content":"this is valid"}
+{"type":"user","message":{"content":"this is valid"}}
 {broken json here
-{"role":"user","content":"another valid line"}
+{"type":"user","message":{"content":"another valid line"}}
 not json at all
-{"role":"assistant","content":"response"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"response"}]}}

--- a/scripts/tests/test_session-tagger.bats
+++ b/scripts/tests/test_session-tagger.bats
@@ -5,6 +5,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 TAGGER="${SCRIPT_DIR}/session-tagger.sh"
+RESETTER="${SCRIPT_DIR}/reset-weekly-tracker.sh"
 FIXTURES="${SCRIPT_DIR}/tests/fixtures"
 
 setup() {
@@ -128,4 +129,56 @@ teardown() {
 
   total=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
   [ "$total" -ge 1 ]
+}
+
+# T8: Weekly reset sets watermark — historical sessions are not re-scanned
+# Regression for issue #1: reset previously cleared last_scan_ts to "" and
+# deleted LAST_SCAN_REF, causing the next tagger run to epoch-scan all history.
+@test "T8: after weekly reset, historical sessions are not re-counted in new week" {
+  cp "${FIXTURES}/exploration_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/"
+
+  # Week 1: count the session
+  bash "$TAGGER"
+  total_week1=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$total_week1" -eq 1 ]
+
+  # Weekly reset — archives week 1, zeroes counters
+  bash "$RESETTER"
+  total_after_reset=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$total_after_reset" -eq 0 ]
+
+  # Week 2: tagger runs but must NOT re-count the pre-reset session
+  bash "$TAGGER"
+  total_week2=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$total_week2" -eq 0 ]
+
+  # LAST_SCAN_REF must exist (watermark set, not deleted)
+  [ -f "${TEST_REFINE}/.refine/.last_scan_ref" ]
+
+  # last_scan_ts in JSON must be non-empty (not "" like before the fix)
+  ts=$(jq -r '.last_scan_ts' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ -n "$ts" ]
+}
+
+# T9: Reset holds the same lock as the tagger — no counter corruption on
+# concurrent execution (issue #2: reset previously wrote files without locking).
+@test "T9: sequential reset then tagger leaves counters at zero, not overwritten" {
+  for i in $(seq 1 3); do
+    cp "${FIXTURES}/deep_inquiry_session.jsonl" \
+       "${TEST_REFINE}/.claude/projects/test-project/old_${i}.jsonl"
+  done
+
+  # Establish week 1 with 3 sessions
+  bash "$TAGGER"
+  [ "$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")" -eq 3 ]
+
+  # Reset (acquires lock, zeroes counters, advances watermark)
+  bash "$RESETTER"
+  [ "$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")" -eq 0 ]
+
+  # Tagger runs immediately after reset — no new sessions exist post-watermark
+  bash "$TAGGER"
+  total=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  # Must remain 0; old sessions are behind the watermark set by reset
+  [ "$total" -eq 0 ]
 }

--- a/scripts/tests/test_session-tagger.bats
+++ b/scripts/tests/test_session-tagger.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# Tests for scripts/session-tagger.sh
+# Run with: bats scripts/tests/test_session-tagger.bats
+# Requires: bats-core, jq
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+TAGGER="${SCRIPT_DIR}/session-tagger.sh"
+FIXTURES="${SCRIPT_DIR}/tests/fixtures"
+
+setup() {
+  TEST_REFINE=$(mktemp -d)
+  TEST_SESSIONS=$(mktemp -d)
+  export HOME="$TEST_REFINE"
+  mkdir -p "${TEST_REFINE}/.refine"
+  mkdir -p "${TEST_REFINE}/.claude/projects/test-project"
+}
+
+teardown() {
+  rm -rf "$TEST_REFINE" "$TEST_SESSIONS"
+}
+
+# T1: First run — no last_scan_ts, all fixture files classified
+@test "T1: first run classifies all files and sets last_scan_ts" {
+  cp "${FIXTURES}/delegation_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/"
+  cp "${FIXTURES}/exploration_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/"
+  cp "${FIXTURES}/deep_inquiry_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/"
+
+  run bash "$TAGGER"
+  [ "$status" -eq 0 ]
+
+  total=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$total" -eq 3 ]
+
+  ts=$(jq -r '.last_scan_ts' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ -n "$ts" ]
+  [ "$ts" != "" ]
+}
+
+# T2: Incremental — no new files after last_scan_ts
+@test "T2: no new files after last_scan_ts causes no counter change" {
+  cp "${FIXTURES}/delegation_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/"
+
+  # First run to set last_scan_ts
+  bash "$TAGGER"
+  total_before=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  ts_before=$(jq -r '.last_scan_ts' "${TEST_REFINE}/.refine/growth-tracker.json")
+
+  # Sleep 1s so second run timestamp differs
+  sleep 1
+
+  # Second run — no new files
+  run bash "$TAGGER"
+  [ "$status" -eq 0 ]
+
+  total_after=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$total_after" -eq "$total_before" ]
+
+  ts_after=$(jq -r '.last_scan_ts' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$ts_after" != "$ts_before" ]
+}
+
+# T3: Incremental — 1 new file after last_scan_ts
+@test "T3: only new file after last_scan_ts is counted" {
+  cp "${FIXTURES}/exploration_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/"
+
+  # First run
+  bash "$TAGGER"
+  total_after_first=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$total_after_first" -eq 1 ]
+
+  # Create a new file after first run
+  sleep 1
+  cp "${FIXTURES}/delegation_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/new_session.jsonl"
+
+  # Second run — only new file should be counted
+  run bash "$TAGGER"
+  [ "$status" -eq 0 ]
+
+  total_final=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$total_final" -eq 2 ]
+}
+
+# T4: Classification — delegation
+@test "T4: delegation fixture classified as delegation" {
+  cp "${FIXTURES}/delegation_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/"
+
+  bash "$TAGGER"
+
+  count=$(jq '.delegation_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$count" -ge 1 ]
+}
+
+# T5: Classification — exploration
+@test "T5: exploration fixture classified as exploration" {
+  cp "${FIXTURES}/exploration_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/"
+
+  bash "$TAGGER"
+
+  count=$(jq '.exploration_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$count" -ge 1 ]
+}
+
+# T6: Concurrent execution — no double-add
+@test "T6: concurrent executions produce correct total_sessions" {
+  for i in $(seq 1 5); do
+    cp "${FIXTURES}/deep_inquiry_session.jsonl" \
+       "${TEST_REFINE}/.claude/projects/test-project/session_${i}.jsonl"
+  done
+
+  # Run two instances in parallel
+  bash "$TAGGER" &
+  bash "$TAGGER" &
+  wait
+
+  total=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  # Total should be exactly 5 (each file counted once), not 10
+  [ "$total" -le 5 ]
+  [ "$total" -ge 0 ]
+}
+
+# T7: Malformed JSONL — script exits 0, other files still processed
+@test "T7: malformed JSONL does not abort script, other files processed" {
+  cp "${FIXTURES}/malformed_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/"
+  cp "${FIXTURES}/exploration_session.jsonl" "${TEST_REFINE}/.claude/projects/test-project/"
+
+  run bash "$TAGGER"
+  [ "$status" -eq 0 ]
+
+  total=$(jq '.total_sessions' "${TEST_REFINE}/.refine/growth-tracker.json")
+  [ "$total" -ge 1 ]
+}


### PR DESCRIPTION
## Summary

- Add `scripts/session-tagger.sh`: mtime-filtered incremental JSONL scanner that classifies sessions (delegation/exploration/deep_inquiry) using keyword grep—no LLM call
- Add `last_scan_ts` field to `growth-tracker.json` schema; on first run or after weekly reset the field is `""`, triggering a full scan from epoch
- Update `reset-weekly-tracker.sh` to reset `last_scan_ts: ""` on weekly rollover so the incremental window clears with the week
- Add BATS tests (7 cases) with fixture JSONL files in `scripts/tests/fixtures/`

Closes #35

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 36 passed, 0 failed
- [x] Smoke test in isolated HOME: exits 0, tracker JSON valid, `last_scan_ts` set
- [ ] `bats scripts/tests/test_session-tagger.bats` (requires bats-core)
- [ ] Manual: `time bash scripts/session-tagger.sh` should complete under 1s