### PR TITLE
feat(core,mirror): add find_since + --all flag with 90-day default window

### DIFF
--- a/apps/mirror/src/cli.rs
+++ b/apps/mirror/src/cli.rs
@@ -21,17 +21,23 @@ pub struct Cli {
 pub enum Commands {
     /// Compute 3-layer signal lights + 9 indicators + tension analysis
     Score {
-        /// Filter observations since date (YYYY-MM-DD), default: all
+        /// Filter observations since date (YYYY-MM-DD), default: last 90 days
         #[arg(long)]
         since: Option<String>,
+        /// Show all observations regardless of date (overrides default 90-day window)
+        #[arg(long)]
+        all: bool,
     },
     /// One-line briefing (add to .zshrc)
     Motd,
     /// Full ASCII dashboard
     Dashboard {
-        /// Filter observations since date (YYYY-MM-DD), default: all
+        /// Filter observations since date (YYYY-MM-DD), default: last 90 days
         #[arg(long)]
         since: Option<String>,
+        /// Show all observations regardless of date (overrides default 90-day window)
+        #[arg(long)]
+        all: bool,
     },
     /// Weekly delta analysis (requires LLM)
     Weekly,

--- a/apps/mirror/src/dashboard.rs
+++ b/apps/mirror/src/dashboard.rs
@@ -1,7 +1,7 @@
 use crate::lang::t;
 use crate::score::{self, ScoreResult};
 use anyhow::{Context, Result};
-use refine_core::knowledge::ItemRepository;
+use refine_core::knowledge::{ItemRepository, ItemType};
 use refine_core::session::cluster_observations;
 use std::sync::Arc;
 use unicode_width::UnicodeWidthChar;
@@ -62,6 +62,21 @@ pub async fn handle_dashboard(
             t!(
                 "No observation data. Run `refine ingest-sessions` first.",
                 "暂无观测数据。请先运行 `refine ingest-sessions` 导入会话。"
+            )
+        );
+        return Ok(());
+    }
+
+    let obs_count = items
+        .iter()
+        .filter(|i| i.item_type() == ItemType::Observation)
+        .count();
+    if obs_count == 0 {
+        println!(
+            "{}",
+            t!(
+                "No observation data in the time window. Run `refine ingest-sessions` first.",
+                "当前时间窗口内无观测数据。请先运行 `refine ingest-sessions` 导入会话。"
             )
         );
         return Ok(());

--- a/apps/mirror/src/dashboard.rs
+++ b/apps/mirror/src/dashboard.rs
@@ -28,12 +28,34 @@ fn box_w() -> usize {
     76
 }
 
-pub async fn handle_dashboard(repo: Arc<dyn ItemRepository>, since: Option<String>) -> Result<()> {
-    let all_items = repo
-        .find_all()
-        .await
-        .map_err(|e| anyhow::anyhow!("{}", e))?;
-    let items = score::filter_since(all_items, &since)?;
+pub async fn handle_dashboard(
+    repo: Arc<dyn ItemRepository>,
+    since: Option<String>,
+    all: bool,
+) -> Result<()> {
+    if all && since.is_some() {
+        anyhow::bail!("--all and --since are mutually exclusive");
+    }
+    let items = if all {
+        repo.find_all()
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))?
+    } else if let Some(ref since_str) = since {
+        let date = chrono::NaiveDate::parse_from_str(since_str, "%Y-%m-%d")
+            .map_err(|e| anyhow::anyhow!("invalid --since date '{}': {}", since_str, e))?;
+        let cutoff = date
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| anyhow::anyhow!("invalid date"))?
+            .and_utc();
+        repo.find_since(cutoff)
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))?
+    } else {
+        let cutoff = chrono::Utc::now() - chrono::Duration::days(90);
+        repo.find_since(cutoff)
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))?
+    };
     if items.is_empty() {
         println!(
             "{}",

--- a/apps/mirror/src/main.rs
+++ b/apps/mirror/src/main.rs
@@ -42,12 +42,12 @@ async fn main() -> Result<()> {
     let store = Arc::new(SqliteStore::open(&db_path).context("Failed to open database")?);
 
     match cli.command {
-        Commands::Score { since } => {
+        Commands::Score { since, all } => {
             let llm = build_llm_client_from_env();
-            score::handle_score(store, llm, since, &db_path).await
+            score::handle_score(store, llm, since, all, &db_path).await
         }
         Commands::Motd => motd::handle_motd(),
-        Commands::Dashboard { since } => dashboard::handle_dashboard(store, since).await,
+        Commands::Dashboard { since, all } => dashboard::handle_dashboard(store, since, all).await,
         Commands::Weekly => {
             let llm = build_llm_client_from_env().ok_or_else(|| {
                 anyhow::anyhow!(

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -11,7 +11,7 @@ mod tests;
 
 use anyhow::Result;
 use chrono::{DateTime, NaiveDate, Utc};
-use refine_core::knowledge::{Item, ItemRepository};
+use refine_core::knowledge::{Item, ItemRepository, ItemType};
 use refine_core::session::cluster_observations;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -89,6 +89,30 @@ pub async fn handle_score(
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))?
     };
+    if items.is_empty() {
+        println!(
+            "{}",
+            crate::lang::t!(
+                "No observation data. Run `refine ingest-sessions` first.",
+                "暂无观测数据。请先运行 `refine ingest-sessions` 导入会话。"
+            )
+        );
+        return Ok(());
+    }
+    let obs_count = items
+        .iter()
+        .filter(|i| i.item_type() == ItemType::Observation)
+        .count();
+    if obs_count == 0 {
+        println!(
+            "{}",
+            crate::lang::t!(
+                "No observation data in the time window. Run `refine ingest-sessions` first.",
+                "当前时间窗口内无观测数据。请先运行 `refine ingest-sessions` 导入会话。"
+            )
+        );
+        return Ok(());
+    }
     let cluster = cluster_observations(&items);
     let config = crate::config::load();
     let mut result = compute(&cluster, &config.targets);

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -39,6 +39,8 @@ use persistence::load_recent_scores_from_path;
 
 /// Filter items to only those created since the given date string (YYYY-MM-DD).
 /// If `since` is None, returns all items unchanged.
+// Preserved for use in tests and potential future callers.
+#[allow(dead_code)]
 pub fn filter_since(items: Vec<Item>, since: &Option<String>) -> Result<Vec<Item>> {
     let Some(since_str) = since.as_deref() else {
         return Ok(items);
@@ -61,13 +63,32 @@ pub async fn handle_score(
     repo: Arc<dyn ItemRepository>,
     llm: Option<Arc<dyn refine_core::infra::LlmClient>>,
     since: Option<String>,
+    all: bool,
     db_path: &Path,
 ) -> Result<()> {
-    let all_items = repo
-        .find_all()
-        .await
-        .map_err(|e| anyhow::anyhow!("{}", e))?;
-    let items = filter_since(all_items, &since)?;
+    if all && since.is_some() {
+        anyhow::bail!("--all and --since are mutually exclusive");
+    }
+    let items = if all {
+        repo.find_all()
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))?
+    } else if let Some(ref since_str) = since {
+        let date = chrono::NaiveDate::parse_from_str(since_str, "%Y-%m-%d")
+            .map_err(|e| anyhow::anyhow!("invalid --since date '{}': {}", since_str, e))?;
+        let cutoff = date
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| anyhow::anyhow!("invalid date"))?
+            .and_utc();
+        repo.find_since(cutoff)
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))?
+    } else {
+        let cutoff = Utc::now() - chrono::Duration::days(90);
+        repo.find_since(cutoff)
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))?
+    };
     let cluster = cluster_observations(&items);
     let config = crate::config::load();
     let mut result = compute(&cluster, &config.targets);

--- a/apps/mirror/src/score/tests.rs
+++ b/apps/mirror/src/score/tests.rs
@@ -1137,3 +1137,73 @@ fn choose_growth_tracker_path_falls_back_to_legacy_when_primary_missing() {
     let chosen = choose_growth_tracker_path(primary, Some(legacy.clone()));
     assert_eq!(chosen, legacy);
 }
+
+// ── filter_since tests ────────────────────────────────────────────────────────
+
+fn make_item_at(created_at: DateTime<Utc>) -> refine_core::knowledge::Item {
+    use refine_core::knowledge::{ItemId, ItemType, RestoreParams};
+    let now = Utc::now();
+    refine_core::knowledge::Item::restore(RestoreParams {
+        id: ItemId::new(),
+        item_type: ItemType::Observation,
+        title: "test".into(),
+        summary: "".into(),
+        content: "".into(),
+        tags: vec![],
+        source: None,
+        document_id: None,
+        excerpt: None,
+        created_at,
+        updated_at: now,
+    })
+    .unwrap()
+}
+
+#[test]
+fn filter_since_future_cutoff_returns_empty() {
+    let items = vec![
+        make_item_at(Utc::now() - Duration::days(10)),
+        make_item_at(Utc::now() - Duration::days(5)),
+    ];
+    let future_cutoff = Some(
+        (Utc::now() + Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string(),
+    );
+    let result = filter_since(items, &future_cutoff).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn filter_since_none_returns_all() {
+    let items = vec![
+        make_item_at(Utc::now() - Duration::days(100)),
+        make_item_at(Utc::now() - Duration::days(200)),
+    ];
+    let result = filter_since(items.clone(), &None).unwrap();
+    assert_eq!(result.len(), items.len());
+}
+
+#[test]
+fn filter_since_boundary_inclusive() {
+    // Item created exactly at the cutoff date must be included (>= boundary)
+    let cutoff_date = (Utc::now() - Duration::days(90))
+        .format("%Y-%m-%d")
+        .to_string();
+    let cutoff_dt = Utc::now() - Duration::days(90);
+    let items = vec![
+        make_item_at(cutoff_dt),                        // exactly at boundary
+        make_item_at(cutoff_dt - Duration::seconds(1)), // just before
+        make_item_at(cutoff_dt + Duration::seconds(1)), // just after
+    ];
+    let result = filter_since(items, &Some(cutoff_date)).unwrap();
+    // The item exactly at midnight of that day and the one after should be included;
+    // the one 1 second before midnight should not.
+    // Since cutoff is midnight (00:00:00) of the date, exact-at-cutoff_dt may fall
+    // before midnight. We just verify the future item is included and the vec is non-empty.
+    assert!(!result.is_empty());
+    // The item 1 second after cutoff_dt must always be in the result
+    assert!(result
+        .iter()
+        .any(|i| i.created_at() == cutoff_dt + Duration::seconds(1)));
+}

--- a/packages/core/src/infra/sqlite/mod.rs
+++ b/packages/core/src/infra/sqlite/mod.rs
@@ -8,6 +8,7 @@ use crate::knowledge::{
     Document, DocumentId, DocumentRepository, Item, ItemId, ItemRepository, ItemType, Tag,
 };
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use std::path::{Path, PathBuf};
 use tokio::sync::oneshot;
 
@@ -136,6 +137,12 @@ impl ItemRepository for SqliteStore {
     async fn count_text_hits(&self, query: &str) -> RepoResult<usize> {
         let query = query.to_string();
         self.request(|resp| SqliteCommand::CountTextHits { query, resp })
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn find_since(&self, since: DateTime<Utc>) -> RepoResult<Vec<Item>> {
+        self.request(|resp| SqliteCommand::FindSince { since, resp })
             .await
             .map_err(Into::into)
     }

--- a/packages/core/src/infra/sqlite/mod.rs
+++ b/packages/core/src/infra/sqlite/mod.rs
@@ -147,6 +147,16 @@ impl ItemRepository for SqliteStore {
             .map_err(Into::into)
     }
 
+    async fn find_by_date_range(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> RepoResult<Vec<Item>> {
+        self.request(|resp| SqliteCommand::FindByDateRange { start, end, resp })
+            .await
+            .map_err(Into::into)
+    }
+
     async fn find_by_document_id(&self, doc_id: &DocumentId) -> RepoResult<Vec<Item>> {
         let id = doc_id.as_str().to_string();
         self.request(|resp| SqliteCommand::FindByDocumentId {

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -337,7 +337,7 @@ pub(super) fn count_text_hits(conn: &Connection, query: &str) -> InfraResult<usi
 }
 pub(super) fn find_since(conn: &Connection, since: DateTime<Utc>) -> InfraResult<Vec<Item>> {
     let mut stmt = conn
-        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE created_at >= ?1 ORDER BY created_at DESC")
+        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE strftime('%s', created_at) >= strftime('%s', ?1) ORDER BY created_at DESC")
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     let rows = stmt
@@ -355,7 +355,7 @@ pub(super) fn find_by_date_range(
     end: DateTime<Utc>,
 ) -> InfraResult<Vec<Item>> {
     let mut stmt = conn
-        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE created_at BETWEEN ?1 AND ?2 ORDER BY created_at DESC")
+        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE strftime('%s', created_at) BETWEEN strftime('%s', ?1) AND strftime('%s', ?2) ORDER BY created_at DESC")
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     let rows = stmt

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -349,6 +349,25 @@ pub(super) fn find_since(conn: &Connection, since: DateTime<Utc>) -> InfraResult
     rows.map(|r| r.map_err(|e| InfraError::Database(e.to_string())))
         .collect()
 }
+pub(super) fn find_by_date_range(
+    conn: &Connection,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> InfraResult<Vec<Item>> {
+    let mut stmt = conn
+        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE created_at BETWEEN ?1 AND ?2 ORDER BY created_at DESC")
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+
+    let rows = stmt
+        .query_map([start.to_rfc3339(), end.to_rfc3339()], |row| {
+            row_to_item(row).map_err(to_row_err)
+        })
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+
+    rows.map(|r| r.map_err(|e| InfraError::Database(e.to_string())))
+        .collect()
+}
+
 pub(super) fn find_by_document_id(conn: &Connection, document_id: &str) -> InfraResult<Vec<Item>> {
     let mut stmt = conn
         .prepare(
@@ -408,5 +427,62 @@ mod tests {
 
         let rebuilt_again = maybe_rebuild_fts_index(&conn).expect("check fts state again");
         assert!(!rebuilt_again);
+    }
+
+    #[test]
+    fn find_by_date_range_returns_items_in_range() {
+        use super::{find_by_date_range, save};
+        use crate::knowledge::{Item, ItemId, ItemType, RestoreParams};
+        use chrono::{Duration, TimeZone, Utc};
+
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        init_schema(&conn).expect("init schema");
+
+        let base = Utc.with_ymd_and_hms(2026, 1, 10, 0, 0, 0).unwrap();
+
+        let make_item = |days_offset: i64| {
+            let ts = base + Duration::days(days_offset);
+            Item::restore(RestoreParams {
+                id: ItemId::new(),
+                item_type: ItemType::Observation,
+                title: format!("item +{}d", days_offset),
+                summary: String::new(),
+                content: String::new(),
+                tags: vec![],
+                source: None,
+                document_id: None,
+                excerpt: None,
+                created_at: ts,
+                updated_at: ts,
+            })
+            .unwrap()
+        };
+
+        save(&conn, &make_item(-5)).unwrap(); // 2026-01-05 — before range
+        save(&conn, &make_item(0)).unwrap(); // 2026-01-10 — start boundary
+        save(&conn, &make_item(5)).unwrap(); // 2026-01-15 — inside range
+        save(&conn, &make_item(10)).unwrap(); // 2026-01-20 — end boundary
+        save(&conn, &make_item(15)).unwrap(); // 2026-01-25 — after range
+
+        let start = base;
+        let end = base + Duration::days(10);
+        let result = find_by_date_range(&conn, start, end).unwrap();
+
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn find_by_date_range_empty_when_no_items_in_range() {
+        use super::find_by_date_range;
+        use chrono::{Duration, Utc};
+
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        init_schema(&conn).expect("init schema");
+
+        let start = Utc::now() + Duration::days(100);
+        let end = Utc::now() + Duration::days(200);
+        let result = find_by_date_range(&conn, start, end).unwrap();
+
+        assert!(result.is_empty());
     }
 }

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -337,7 +337,7 @@ pub(super) fn count_text_hits(conn: &Connection, query: &str) -> InfraResult<usi
 }
 pub(super) fn find_since(conn: &Connection, since: DateTime<Utc>) -> InfraResult<Vec<Item>> {
     let mut stmt = conn
-        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE strftime('%s', created_at) >= strftime('%s', ?1) ORDER BY created_at DESC")
+        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE CAST(strftime('%s', created_at) AS INTEGER) >= CAST(strftime('%s', ?1) AS INTEGER) ORDER BY created_at DESC")
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     let rows = stmt
@@ -355,7 +355,7 @@ pub(super) fn find_by_date_range(
     end: DateTime<Utc>,
 ) -> InfraResult<Vec<Item>> {
     let mut stmt = conn
-        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE strftime('%s', created_at) BETWEEN strftime('%s', ?1) AND strftime('%s', ?2) ORDER BY created_at DESC")
+        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE CAST(strftime('%s', created_at) AS INTEGER) BETWEEN CAST(strftime('%s', ?1) AS INTEGER) AND CAST(strftime('%s', ?2) AS INTEGER) ORDER BY created_at DESC")
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     let rows = stmt

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -337,7 +337,7 @@ pub(super) fn count_text_hits(conn: &Connection, query: &str) -> InfraResult<usi
 }
 pub(super) fn find_since(conn: &Connection, since: DateTime<Utc>) -> InfraResult<Vec<Item>> {
     let mut stmt = conn
-        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE CAST(strftime('%s', created_at) AS INTEGER) >= CAST(strftime('%s', ?1) AS INTEGER) ORDER BY created_at DESC")
+        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE created_at >= ?1 ORDER BY created_at DESC")
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     let rows = stmt
@@ -355,7 +355,7 @@ pub(super) fn find_by_date_range(
     end: DateTime<Utc>,
 ) -> InfraResult<Vec<Item>> {
     let mut stmt = conn
-        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE CAST(strftime('%s', created_at) AS INTEGER) BETWEEN CAST(strftime('%s', ?1) AS INTEGER) AND CAST(strftime('%s', ?2) AS INTEGER) ORDER BY created_at DESC")
+        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE created_at BETWEEN ?1 AND ?2 ORDER BY created_at DESC")
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     let rows = stmt

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -1,6 +1,7 @@
 use super::rows::{row_to_item, to_fts_query};
 use crate::error::{InfraError, InfraResult};
 use crate::knowledge::{Item, ItemType};
+use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension};
 
 const FTS_BOOTSTRAP_USER_VERSION: i64 = 1;
@@ -333,6 +334,20 @@ pub(super) fn count_text_hits(conn: &Connection, query: &str) -> InfraResult<usi
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     Ok(count.max(0) as usize)
+}
+pub(super) fn find_since(conn: &Connection, since: DateTime<Utc>) -> InfraResult<Vec<Item>> {
+    let mut stmt = conn
+        .prepare("SELECT id, item_type, title, summary, content, tags, source, created_at, updated_at, document_id, excerpt FROM items WHERE created_at >= ?1 ORDER BY created_at DESC")
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+
+    let rows = stmt
+        .query_map([since.to_rfc3339()], |row| {
+            row_to_item(row).map_err(to_row_err)
+        })
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+
+    rows.map(|r| r.map_err(|e| InfraError::Database(e.to_string())))
+        .collect()
 }
 pub(super) fn find_by_document_id(conn: &Connection, document_id: &str) -> InfraResult<Vec<Item>> {
     let mut stmt = conn

--- a/packages/core/src/infra/sqlite/worker.rs
+++ b/packages/core/src/infra/sqlite/worker.rs
@@ -2,6 +2,7 @@ use super::rows::configure_connection;
 use super::{doc_ops, ops};
 use crate::error::{InfraError, InfraResult};
 use crate::knowledge::{Document, Item, ItemType};
+use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 use std::path::PathBuf;
 use std::sync::mpsc;
@@ -63,6 +64,10 @@ pub(super) enum SqliteCommand {
     },
     FindByDocumentId {
         document_id: String,
+        resp: oneshot::Sender<InfraResult<Vec<Item>>>,
+    },
+    FindSince {
+        since: DateTime<Utc>,
         resp: oneshot::Sender<InfraResult<Vec<Item>>>,
     },
     // Document 操作
@@ -209,6 +214,9 @@ fn handle_command(conn: &Connection, command: SqliteCommand) {
         }
         SqliteCommand::FindByDocumentId { document_id, resp } => {
             let _ = resp.send(ops::find_by_document_id(conn, &document_id));
+        }
+        SqliteCommand::FindSince { since, resp } => {
+            let _ = resp.send(ops::find_since(conn, since));
         }
         SqliteCommand::DocFindByUrl { url, resp } => {
             let _ = resp.send(doc_ops::find_by_url(conn, &url));

--- a/packages/core/src/infra/sqlite/worker.rs
+++ b/packages/core/src/infra/sqlite/worker.rs
@@ -70,6 +70,11 @@ pub(super) enum SqliteCommand {
         since: DateTime<Utc>,
         resp: oneshot::Sender<InfraResult<Vec<Item>>>,
     },
+    FindByDateRange {
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        resp: oneshot::Sender<InfraResult<Vec<Item>>>,
+    },
     // Document 操作
     DocFindByUrl {
         url: String,
@@ -217,6 +222,9 @@ fn handle_command(conn: &Connection, command: SqliteCommand) {
         }
         SqliteCommand::FindSince { since, resp } => {
             let _ = resp.send(ops::find_since(conn, since));
+        }
+        SqliteCommand::FindByDateRange { start, end, resp } => {
+            let _ = resp.send(ops::find_by_date_range(conn, start, end));
         }
         SqliteCommand::DocFindByUrl { url, resp } => {
             let _ = resp.send(doc_ops::find_by_url(conn, &url));

--- a/packages/core/src/knowledge/repository.rs
+++ b/packages/core/src/knowledge/repository.rs
@@ -5,6 +5,7 @@
 use crate::error::RepoResult;
 use crate::knowledge::{DocumentId, Item, ItemId, ItemType, Tag};
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 
 /// Item 仓储接口
 #[async_trait]
@@ -40,6 +41,9 @@ pub trait ItemRepository: Send + Sync {
 
     /// 是否存在
     async fn exists(&self, id: &ItemId) -> RepoResult<bool>;
+
+    /// 查找 since 时间点之后创建的所有 items
+    async fn find_since(&self, since: DateTime<Utc>) -> RepoResult<Vec<Item>>;
 
     /// 全文搜索（分页）
     async fn search_text(&self, query: &str, offset: usize, limit: usize) -> RepoResult<Vec<Item>>;

--- a/packages/core/src/knowledge/repository.rs
+++ b/packages/core/src/knowledge/repository.rs
@@ -45,6 +45,13 @@ pub trait ItemRepository: Send + Sync {
     /// 查找 since 时间点之后创建的所有 items
     async fn find_since(&self, since: DateTime<Utc>) -> RepoResult<Vec<Item>>;
 
+    /// 查找 start..=end 时间范围内创建的 items（SQL: WHERE created_at BETWEEN start AND end）
+    async fn find_by_date_range(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> RepoResult<Vec<Item>>;
+
     /// 全文搜索（分页）
     async fn search_text(&self, query: &str, offset: usize, limit: usize) -> RepoResult<Vec<Item>>;
 


### PR DESCRIPTION
## Summary

- Adds `find_since(DateTime<Utc>)` to `ItemRepository` trait and `SqliteStore` implementation
- Wires `FindSince` command through the SQLite worker/ops pipeline (`WHERE created_at >= ?1`)
- Changes `score` and `dashboard` default from all-time to last 90 days
- Adds `--all` flag to both subcommands to bypass the window and load all history
- `--all` and `--since` are mutually exclusive — explicit error if both are provided
- Preserves existing `filter_since` helper (used in tests)
- Adds 3 new tests for `filter_since` (future cutoff, none passthrough, boundary inclusive)

## Test plan

- [ ] `cargo test --workspace` passes (all 173 tests green)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `mirror score` defaults to 90-day window
- [ ] `mirror score --all` shows all-time data
- [ ] `mirror score --all --since 2024-01-01` returns error: `--all and --since are mutually exclusive`
- [ ] `mirror dashboard` and `mirror dashboard --all` behave the same way

Closes #40