### PR TITLE
feat(core): add progress_items, question_items, code_artifacts to ProjectCluster

### DIFF
--- a/apps/mirror/src/profile.rs
+++ b/apps/mirror/src/profile.rs
@@ -125,7 +125,17 @@ fn extract_profile_data(
     }
 }
 
-fn build_profile_prompt(data: &ProfileData) -> String {
+fn dedup_top(items: &[String], limit: usize) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    items
+        .iter()
+        .filter(|s| seen.insert(s.as_str()))
+        .take(limit)
+        .cloned()
+        .collect()
+}
+
+fn build_profile_prompt(data: &ProfileData, cluster: &ClusterResult) -> String {
     let mut lines = Vec::new();
     lines.push(format!(
         "Total: {} sessions across {} projects",
@@ -156,6 +166,30 @@ fn build_profile_prompt(data: &ProfileData) -> String {
     ));
     lines.push(String::new());
     lines.push(format!("Current signal lights: {}", data.score_summary));
+
+    // Per-project facet dimensions
+    for p in &data.project_stats {
+        if let Some(c) = cluster.projects.get(&p.name) {
+            let progress = dedup_top(&c.progress_items, 5);
+            let questions = dedup_top(&c.question_items, 5);
+            let artifacts = dedup_top(&c.code_artifacts, 10);
+            if progress.is_empty() && questions.is_empty() && artifacts.is_empty() {
+                continue;
+            }
+            lines.push(String::new());
+            lines.push(format!("{}:", p.name));
+            if !progress.is_empty() {
+                lines.push(format!("  进展: {}", progress.join(" / ")));
+            }
+            if !questions.is_empty() {
+                lines.push(format!("  问题: {}", questions.join(" / ")));
+            }
+            if !artifacts.is_empty() {
+                lines.push(format!("  代码产出: {}", artifacts.join(" / ")));
+            }
+        }
+    }
+
     lines.join("\n")
 }
 
@@ -233,7 +267,7 @@ pub async fn handle_profile(
     let score_summary = format_score_summary(&score_result);
 
     let data = extract_profile_data(&cluster, &score_summary, &items);
-    let prompt = build_profile_prompt(&data);
+    let prompt = build_profile_prompt(&data, &cluster);
 
     println!(
         "{}\n",
@@ -294,6 +328,9 @@ mod tests {
                 architectures: Vec::new(),
                 knowledge_gained: Vec::new(),
                 patterns: Vec::new(),
+                progress_items: Vec::new(),
+                question_items: Vec::new(),
+                code_artifacts: Vec::new(),
             },
         );
 
@@ -320,6 +357,9 @@ mod tests {
                 architectures: Vec::new(),
                 knowledge_gained: Vec::new(),
                 patterns: Vec::new(),
+                progress_items: Vec::new(),
+                question_items: Vec::new(),
+                code_artifacts: Vec::new(),
             },
         );
 
@@ -378,11 +418,62 @@ mod tests {
     fn test_build_profile_prompt() {
         let cluster = make_cluster();
         let data = extract_profile_data(&cluster, "Depth G, Breadth Y", &[]);
-        let prompt = build_profile_prompt(&data);
+        let prompt = build_profile_prompt(&data, &cluster);
 
         assert!(prompt.contains("70 sessions across 2 projects"));
         assert!(prompt.contains("proj-a"));
         assert!(prompt.contains("100 decisions vs 50 bugfixes"));
         assert!(prompt.contains("Depth G, Breadth Y"));
+    }
+
+    #[test]
+    fn test_build_profile_prompt_includes_progress() {
+        let mut cluster = make_cluster();
+        cluster
+            .projects
+            .entry("proj-a".to_string())
+            .and_modify(|p| {
+                p.progress_items = vec!["step1".to_string(), "step2".to_string()];
+            });
+
+        let data = extract_profile_data(&cluster, "G", &[]);
+        let prompt = build_profile_prompt(&data, &cluster);
+
+        assert!(prompt.contains("进展:"));
+        assert!(prompt.contains("step1"));
+        assert!(prompt.contains("step2"));
+    }
+
+    #[test]
+    fn test_build_profile_prompt_empty_progress() {
+        let cluster = make_cluster();
+        let data = extract_profile_data(&cluster, "G", &[]);
+        let prompt = build_profile_prompt(&data, &cluster);
+
+        // No facet sections emitted when all are empty
+        assert!(!prompt.contains("进展:"));
+        assert!(!prompt.contains("问题:"));
+        assert!(!prompt.contains("代码产出:"));
+    }
+
+    #[test]
+    fn test_code_artifacts_truncated() {
+        let mut cluster = make_cluster();
+        cluster
+            .projects
+            .entry("proj-a".to_string())
+            .and_modify(|p| {
+                p.code_artifacts = (0..30).map(|i| format!("artifact_{}", i)).collect();
+            });
+
+        let data = extract_profile_data(&cluster, "G", &[]);
+        let prompt = build_profile_prompt(&data, &cluster);
+
+        assert!(prompt.contains("代码产出:"));
+        // At most 10 unique artifacts should appear
+        let artifact_count = (0..30)
+            .filter(|i| prompt.contains(&format!("artifact_{}", i)))
+            .count();
+        assert!(artifact_count <= 10);
     }
 }

--- a/apps/mirror/src/profile.rs
+++ b/apps/mirror/src/profile.rs
@@ -125,13 +125,22 @@ fn extract_profile_data(
     }
 }
 
+const ITEM_MAX_CHARS: usize = 120;
+const FACET_BUDGET_CHARS: usize = 4000;
+
 fn dedup_top(items: &[String], limit: usize) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
     items
         .iter()
         .filter(|s| seen.insert(s.as_str()))
         .take(limit)
-        .cloned()
+        .map(|s| {
+            if s.chars().count() > ITEM_MAX_CHARS {
+                s.chars().take(ITEM_MAX_CHARS).collect::<String>() + "…"
+            } else {
+                s.clone()
+            }
+        })
         .collect()
 }
 
@@ -167,8 +176,12 @@ fn build_profile_prompt(data: &ProfileData, cluster: &ClusterResult) -> String {
     lines.push(String::new());
     lines.push(format!("Current signal lights: {}", data.score_summary));
 
-    // Per-project facet dimensions
+    // Per-project facet dimensions (total budget capped to avoid LLM context overflow)
+    let mut facet_chars_used: usize = 0;
     for p in &data.project_stats {
+        if facet_chars_used >= FACET_BUDGET_CHARS {
+            break;
+        }
         if let Some(c) = cluster.projects.get(&p.name) {
             let progress = dedup_top(&c.progress_items, 5);
             let questions = dedup_top(&c.question_items, 5);
@@ -176,17 +189,21 @@ fn build_profile_prompt(data: &ProfileData, cluster: &ClusterResult) -> String {
             if progress.is_empty() && questions.is_empty() && artifacts.is_empty() {
                 continue;
             }
-            lines.push(String::new());
-            lines.push(format!("{}:", p.name));
+            let mut block = Vec::new();
+            block.push(String::new());
+            block.push(format!("{}:", p.name));
             if !progress.is_empty() {
-                lines.push(format!("  进展: {}", progress.join(" / ")));
+                block.push(format!("  进展: {}", progress.join(" / ")));
             }
             if !questions.is_empty() {
-                lines.push(format!("  问题: {}", questions.join(" / ")));
+                block.push(format!("  问题: {}", questions.join(" / ")));
             }
             if !artifacts.is_empty() {
-                lines.push(format!("  代码产出: {}", artifacts.join(" / ")));
+                block.push(format!("  代码产出: {}", artifacts.join(" / ")));
             }
+            let block_str = block.join("\n");
+            facet_chars_used += block_str.len();
+            lines.push(block_str);
         }
     }
 

--- a/apps/mirror/src/profile.rs
+++ b/apps/mirror/src/profile.rs
@@ -202,6 +202,9 @@ fn build_profile_prompt(data: &ProfileData, cluster: &ClusterResult) -> String {
                 block.push(format!("  代码产出: {}", artifacts.join(" / ")));
             }
             let block_str = block.join("\n");
+            if facet_chars_used + block_str.len() > FACET_BUDGET_CHARS {
+                break;
+            }
             facet_chars_used += block_str.len();
             lines.push(block_str);
         }

--- a/apps/mirror/src/score/tests.rs
+++ b/apps/mirror/src/score/tests.rs
@@ -32,6 +32,9 @@ fn make_cluster(
                 architectures: Vec::new(),
                 knowledge_gained: Vec::new(),
                 patterns: Vec::new(),
+                progress_items: Vec::new(),
+                question_items: Vec::new(),
+                code_artifacts: Vec::new(),
             },
         );
     }
@@ -77,6 +80,9 @@ fn make_cluster_with_data(
                 architectures: Vec::new(),
                 knowledge_gained: knowledge.iter().map(|s| s.to_string()).collect(),
                 patterns: Vec::new(),
+                progress_items: Vec::new(),
+                question_items: Vec::new(),
+                code_artifacts: Vec::new(),
             },
         );
     }

--- a/packages/core/src/session/clustering.rs
+++ b/packages/core/src/session/clustering.rs
@@ -51,6 +51,9 @@ pub struct ProjectCluster {
     pub architectures: Vec<String>,
     pub knowledge_gained: Vec<String>,
     pub patterns: Vec<String>,
+    pub progress_items: Vec<String>,
+    pub question_items: Vec<String>,
+    pub code_artifacts: Vec<String>,
 }
 
 /// 全局聚合统计
@@ -135,6 +138,9 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
                 architectures: Vec::new(),
                 knowledge_gained: Vec::new(),
                 patterns: Vec::new(),
+                progress_items: Vec::new(),
+                question_items: Vec::new(),
+                code_artifacts: Vec::new(),
             });
 
         // 跟踪 session 数
@@ -192,6 +198,17 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
             cluster
                 .patterns
                 .extend(extract_section_items(content, "模式"));
+            cluster
+                .progress_items
+                .extend(extract_section_items(content, "进展"));
+            cluster
+                .question_items
+                .extend(extract_section_items(content, "问题"));
+            cluster.code_artifacts.extend(
+                extract_section_items(content, "代码产出")
+                    .into_iter()
+                    .take(20),
+            );
         }
     }
 
@@ -343,5 +360,17 @@ mod tests {
             vec!["cargo", "rustfmt"]
         );
         assert_eq!(extract_section_items(content, "阻力"), vec!["编译太慢"]);
+    }
+
+    #[test]
+    fn cluster_observations_extracts_progress_items() {
+        let content = "认知水平: proficient\n\n进展:\n- step1\n- step2\n\n问题:\n- 如何优化？\n\n代码产出:\n- main.rs";
+        let progress = extract_section_items(content, "进展");
+        let questions = extract_section_items(content, "问题");
+        let artifacts = extract_section_items(content, "代码产出");
+
+        assert_eq!(progress, vec!["step1", "step2"]);
+        assert_eq!(questions, vec!["如何优化？"]);
+        assert_eq!(artifacts, vec!["main.rs"]);
     }
 }

--- a/packages/core/src/session/clustering.rs
+++ b/packages/core/src/session/clustering.rs
@@ -205,9 +205,7 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
                 .question_items
                 .extend(extract_section_items(content, "问题"));
             cluster.code_artifacts.extend(
-                extract_section_items(content, "代码产出")
-                    .into_iter()
-                    .take(20),
+                extract_section_items_capped(content, "代码产出", 20),
             );
         }
     }
@@ -273,9 +271,16 @@ fn dedup_titles(titles: Vec<String>) -> Vec<String> {
 }
 
 fn extract_section_items(content: &str, section_name: &str) -> Vec<String> {
+    extract_section_items_capped(content, section_name, usize::MAX)
+}
+
+fn extract_section_items_capped(content: &str, section_name: &str, limit: usize) -> Vec<String> {
     let mut in_section = false;
     let mut items = Vec::new();
     for line in content.lines() {
+        if items.len() >= limit {
+            break;
+        }
         let trimmed = line.trim();
         if trimmed.ends_with(':') && !trimmed.starts_with('-') {
             in_section = trimmed.trim_end_matches(':') == section_name;

--- a/packages/core/src/session/clustering.rs
+++ b/packages/core/src/session/clustering.rs
@@ -204,9 +204,9 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
             cluster
                 .question_items
                 .extend(extract_section_items(content, "问题"));
-            cluster.code_artifacts.extend(
-                extract_section_items_capped(content, "代码产出", 20),
-            );
+            cluster
+                .code_artifacts
+                .extend(extract_section_items_capped(content, "代码产出", 20));
         }
     }
 


### PR DESCRIPTION
Closes #41

## Summary
- Add `progress_items`, `question_items`, `code_artifacts` fields to `ProjectCluster`
- Populate them in `cluster_observations` from 进展/问题/代码产出 sections (cap code_artifacts at 20 per session)
- Surface per-project facets in mirror profile LLM prompt (top 5/5/10 deduplicated)
- Update all struct constructor sites in tests; add 4 new tests