### PR TITLE
feat(cli): add --latest N flag to ingest-sessions

### DIFF
--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -76,9 +76,12 @@ pub enum Commands {
         /// 来源过滤 (claude, codex)
         #[arg(long)]
         source: Option<String>,
-        /// 限制处理数量
-        #[arg(short, long)]
+        /// 限制处理数量（按路径顺序取前 N 个），与 --latest 互斥
+        #[arg(short, long, conflicts_with = "latest")]
         limit: Option<usize>,
+        /// 仅处理最近修改的 N 个会话（按 mtime 降序），与 --limit 互斥
+        #[arg(long, conflicts_with = "limit")]
+        latest: Option<usize>,
         /// 仅预览，不实际处理
         #[arg(long)]
         dry_run: bool,

--- a/apps/cli/src/handlers.rs
+++ b/apps/cli/src/handlers.rs
@@ -7,9 +7,7 @@ use refine_core::infra::SqliteStore;
 use refine_core::knowledge::{
     DocumentId, DocumentRepository, Item, ItemId, ItemRepository, ItemType, Source,
 };
-use refine_core::refinement::{
-    apply_defaults, extract_items_with_llm, ExtractionPolicy,
-};
+use refine_core::refinement::{apply_defaults, extract_items_with_llm, ExtractionPolicy};
 use refine_core::search::{SearchEngine, SearchQuery};
 use refine_core::session::SessionSource;
 use std::io::{self, Read};
@@ -34,6 +32,7 @@ pub async fn run(
         Commands::IngestSessions {
             source,
             limit,
+            latest,
             dry_run,
         } => {
             let source_filter = source.as_deref().and_then(parse_session_source);
@@ -48,6 +47,7 @@ pub async fn run(
                 IngestOptions {
                     source: source_filter,
                     limit,
+                    latest,
                     dry_run,
                 },
                 item_store,
@@ -95,8 +95,8 @@ async fn handle_extract(stdin: bool, store: Arc<SqliteStore>) -> Result<()> {
     let llm_client = build_llm_client_from_env()?;
     let mut items =
         extract_items_with_llm(llm_client.as_ref(), &content, ExtractionPolicy::default())
-        .await
-        .context("提炼失败")?;
+            .await
+            .context("提炼失败")?;
     let source = Source::new("cli");
     let doc_id = DocumentId::new();
     apply_defaults(&mut items, &source, &doc_id, &content);
@@ -176,7 +176,12 @@ async fn handle_delete(id: &str, store: Arc<SqliteStore>) -> Result<()> {
     Ok(())
 }
 
-async fn handle_add(title: &str, summary: &str, raw_type: &str, store: Arc<SqliteStore>) -> Result<()> {
+async fn handle_add(
+    title: &str,
+    summary: &str,
+    raw_type: &str,
+    store: Arc<SqliteStore>,
+) -> Result<()> {
     let item_store: &dyn ItemRepository = store.as_ref();
     let item_type = parse_add_item_type(raw_type)?;
     let item = match item_type {
@@ -279,12 +284,8 @@ fn parse_session_source(raw: &str) -> Option<SessionSource> {
 }
 
 fn parse_add_item_type(raw_type: &str) -> Result<ItemType> {
-    parse_item_type(raw_type).with_context(|| {
-        format!(
-            "无效的类型: {} (支持: knowledge, skill, snippet)",
-            raw_type
-        )
-    })
+    parse_item_type(raw_type)
+        .with_context(|| format!("无效的类型: {} (支持: knowledge, skill, snippet)", raw_type))
 }
 
 #[cfg(test)]

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -21,6 +21,8 @@ const CONCURRENCY: usize = 3;
 pub struct IngestOptions {
     pub source: Option<SessionSource>,
     pub limit: Option<usize>,
+    /// 按 mtime 降序取最近 N 个会话，与 limit 互斥
+    pub latest: Option<usize>,
     pub dry_run: bool,
 }
 
@@ -42,9 +44,16 @@ pub async fn handle_ingest_sessions(
     doc_store: Arc<dyn DocumentRepository>,
     llm_client: Option<Arc<dyn LlmClient>>,
 ) -> Result<()> {
-    let discovered = discover_sessions(options.source);
+    let mut discovered = discover_sessions(options.source);
     println!("发现 {} 个会话文件", discovered.len());
 
+    // --latest: sort by mtime descending, keep N most recent
+    if let Some(n) = options.latest {
+        discovered.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+        discovered.truncate(n);
+    }
+
+    // --limit: path-ordered take (only active when latest is None, enforced by clap)
     let sessions_to_process: Vec<_> = match options.limit {
         Some(limit) => discovered.into_iter().take(limit).collect(),
         None => discovered,
@@ -132,8 +141,7 @@ pub async fn handle_ingest_sessions(
     }
 
     // 阶段 2: 并发做 LLM 提取 + 保存
-    let client = llm_client
-        .ok_or_else(|| anyhow::anyhow!("非 dry-run 模式需要 LLM API Key"))?;
+    let client = llm_client.ok_or_else(|| anyhow::anyhow!("非 dry-run 模式需要 LLM API Key"))?;
     let semaphore = Arc::new(Semaphore::new(CONCURRENCY));
     let processed = Arc::new(AtomicUsize::new(0));
     let failed = Arc::new(AtomicUsize::new(0));
@@ -161,12 +169,7 @@ pub async fn handle_ingest_sessions(
                     total_items.fetch_add(item_count, Ordering::Relaxed);
                 }
                 Err(e) => {
-                    eprintln!(
-                        "  ✗ [{}/{}] 失败: {}",
-                        ps.idx + 1,
-                        ps.total,
-                        e
-                    );
+                    eprintln!("  ✗ [{}/{}] 失败: {}", ps.idx + 1, ps.total, e);
                     failed.fetch_add(1, Ordering::Relaxed);
                 }
             }
@@ -238,10 +241,7 @@ async fn process_single_session(
     Ok(item_count)
 }
 
-async fn llm_call_with_retry(
-    client: &Arc<dyn LlmClient>,
-    content: &str,
-) -> Result<String> {
+async fn llm_call_with_retry(client: &Arc<dyn LlmClient>, content: &str) -> Result<String> {
     let prompt = build_facet_prompt(content);
     let mut last_err = String::new();
 

--- a/apps/server/src/extraction.rs
+++ b/apps/server/src/extraction.rs
@@ -1,4 +1,4 @@
-use refine_core::knowledge::{Document, DocumentRepository, Source};
+use refine_core::knowledge::{Document, DocumentId, DocumentRepository, Source};
 use refine_core::refinement::{extract_items_with_defaults, ExtractionPolicy, ItemExtractionInput};
 use std::sync::Arc;
 
@@ -46,8 +46,7 @@ async fn run_extraction(
     if let Some(title) = &conversation.title {
         doc.set_title(title);
     }
-    let doc_id = doc.id().clone();
-    save_document(&state.doc_store, &doc).await?;
+    let doc_id = save_document(&state.doc_store, &doc).await?;
 
     let input = ItemExtractionInput {
         source: &conversation.source,
@@ -200,14 +199,23 @@ where
     }
 }
 
+// Saves the document (INSERT OR IGNORE) and returns the canonical DocumentId.
+// If the URL already exists the insert is a no-op, so we look up the actual
+// stored document to return its ID instead of the freshly-generated one.
 async fn save_document(
     doc_store: &Arc<dyn DocumentRepository>,
     doc: &Document,
-) -> Result<(), String> {
+) -> Result<DocumentId, String> {
     doc_store
         .save(doc)
         .await
-        .map_err(|e| format!("failed to save document: {}", e))
+        .map_err(|e| format!("failed to save document: {}", e))?;
+    doc_store
+        .find_by_url(doc.url())
+        .await
+        .map_err(|e| format!("failed to find document by url after save: {}", e))?
+        .map(|d| d.id().clone())
+        .ok_or_else(|| "document not found after save — unexpected state".to_string())
 }
 
 async fn update_conversation<F>(

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -22,3 +22,4 @@ dirs = "5"
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = "3"
+filetime = "0.2"

--- a/packages/core/src/infra/sqlite/doc_ops.rs
+++ b/packages/core/src/infra/sqlite/doc_ops.rs
@@ -6,7 +6,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 
 pub(super) fn save(conn: &Connection, doc: &Document) -> InfraResult<()> {
     conn.execute(
-        "INSERT OR REPLACE INTO documents (id, title, raw_content, source, url, captured_at, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        "INSERT OR IGNORE INTO documents (id, title, raw_content, source, url, captured_at, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         params![
             doc.id().as_str(),
             doc.title(),

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -33,6 +33,23 @@ fn migrate_items_add_document_columns(conn: &Connection) -> InfraResult<()> {
 }
 
 fn migrate_documents_url_unique(conn: &Connection) -> InfraResult<()> {
+    // Remap items that point to a duplicate document to the kept document (earliest rowid
+    // per URL) before deleting duplicates, so no items become orphans after the migration.
+    conn.execute_batch(
+        "UPDATE items
+         SET document_id = (
+             SELECT d_keep.id
+             FROM documents d_dup
+             JOIN documents d_keep ON d_dup.url = d_keep.url
+             WHERE d_dup.id = items.document_id
+               AND d_keep.rowid = (SELECT MIN(rowid) FROM documents WHERE url = d_dup.url)
+         )
+         WHERE document_id IN (
+             SELECT id FROM documents
+             WHERE rowid NOT IN (SELECT MIN(rowid) FROM documents GROUP BY url)
+         )",
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))?;
     // Remove duplicate URLs keeping the earliest-inserted row before adding constraint.
     conn.execute_batch(
         "DELETE FROM documents WHERE rowid NOT IN (SELECT MIN(rowid) FROM documents GROUP BY url)",

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -10,7 +10,7 @@ pub(super) fn init_schema(conn: &Connection) -> InfraResult<()> {
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     migrate_items_add_document_columns(conn)?;
-    migrate_documents_add_url_index(conn)?;
+    migrate_documents_url_unique(conn)?;
     let _ = maybe_rebuild_fts_index(conn)?;
 
     Ok(())
@@ -32,9 +32,20 @@ fn migrate_items_add_document_columns(conn: &Connection) -> InfraResult<()> {
     Ok(())
 }
 
-fn migrate_documents_add_url_index(conn: &Connection) -> InfraResult<()> {
-    conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_documents_url ON documents(url)")
+fn migrate_documents_url_unique(conn: &Connection) -> InfraResult<()> {
+    // Remove duplicate URLs keeping the earliest-inserted row before adding constraint.
+    conn.execute_batch(
+        "DELETE FROM documents WHERE rowid NOT IN (SELECT MIN(rowid) FROM documents GROUP BY url)",
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))?;
+    // Drop old non-unique index (may not exist on fresh databases).
+    conn.execute_batch("DROP INDEX IF EXISTS idx_documents_url")
         .map_err(|e| InfraError::Database(e.to_string()))?;
+    // Create unique index so concurrent inserts of the same URL fail fast.
+    conn.execute_batch(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_url ON documents(url)",
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))?;
     Ok(())
 }
 

--- a/packages/core/src/session/discovery.rs
+++ b/packages/core/src/session/discovery.rs
@@ -5,6 +5,7 @@
 use super::types::SessionSource;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
+use tracing::warn;
 
 /// 发现的会话文件
 #[derive(Debug, Clone)]
@@ -12,7 +13,7 @@ pub struct DiscoveredSession {
     pub path: PathBuf,
     pub source: SessionSource,
     pub project: Option<String>,
-    /// 文件最后修改时间；stat 失败时回退为 UNIX_EPOCH（不 panic）
+    /// 文件最后修改时间；stat 失败时记录 warn 并回退为 UNIX_EPOCH（不 panic）
     pub modified_at: SystemTime,
 }
 
@@ -94,7 +95,10 @@ fn discover_claude_code(home: &Path, results: &mut Vec<DiscoveredSession>) {
                 let modified_at = file
                     .metadata()
                     .and_then(|m| m.modified())
-                    .unwrap_or(SystemTime::UNIX_EPOCH);
+                    .unwrap_or_else(|e| {
+                        warn!(path = %path.display(), error = %e, "failed to read mtime; file treated as oldest for --latest");
+                        SystemTime::UNIX_EPOCH
+                    });
                 results.push(DiscoveredSession {
                     path,
                     source: SessionSource::ClaudeCode,
@@ -129,7 +133,10 @@ fn walk_jsonl_recursive(dir: &Path, source: SessionSource, results: &mut Vec<Dis
             let modified_at = entry
                 .metadata()
                 .and_then(|m| m.modified())
-                .unwrap_or(SystemTime::UNIX_EPOCH);
+                .unwrap_or_else(|e| {
+                    warn!(path = %path.display(), error = %e, "failed to read mtime; file treated as oldest for --latest");
+                    SystemTime::UNIX_EPOCH
+                });
             results.push(DiscoveredSession {
                 path,
                 source: source.clone(),

--- a/packages/core/src/session/discovery.rs
+++ b/packages/core/src/session/discovery.rs
@@ -4,6 +4,7 @@
 
 use super::types::SessionSource;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 /// 发现的会话文件
 #[derive(Debug, Clone)]
@@ -11,6 +12,8 @@ pub struct DiscoveredSession {
     pub path: PathBuf,
     pub source: SessionSource,
     pub project: Option<String>,
+    /// 文件最后修改时间；stat 失败时回退为 UNIX_EPOCH（不 panic）
+    pub modified_at: SystemTime,
 }
 
 /// 扫描所有会话文件
@@ -88,10 +91,15 @@ fn discover_claude_code(home: &Path, results: &mut Vec<DiscoveredSession>) {
                 if is_subagent_file(&path) {
                     continue;
                 }
+                let modified_at = file
+                    .metadata()
+                    .and_then(|m| m.modified())
+                    .unwrap_or(SystemTime::UNIX_EPOCH);
                 results.push(DiscoveredSession {
                     path,
                     source: SessionSource::ClaudeCode,
                     project: Some(project_name.clone()),
+                    modified_at,
                 });
             }
         }
@@ -118,10 +126,15 @@ fn walk_jsonl_recursive(dir: &Path, source: SessionSource, results: &mut Vec<Dis
             }
             walk_jsonl_recursive(&path, source.clone(), results);
         } else if is_session_jsonl(&path) && !is_subagent_file(&path) {
+            let modified_at = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
             results.push(DiscoveredSession {
                 path,
                 source: source.clone(),
                 project: None,
+                modified_at,
             });
         }
     }
@@ -206,5 +219,93 @@ mod tests {
 
         let all = discover_sessions_in(home, None);
         assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn modified_at_is_populated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        let project_dir = home.join(".claude/projects/proj");
+        fs::create_dir_all(&project_dir).unwrap();
+        fs::write(project_dir.join("sess.jsonl"), "{}").unwrap();
+
+        let results = discover_sessions_in(home, Some(SessionSource::ClaudeCode));
+        assert_eq!(results.len(), 1);
+        // A freshly-created file must have mtime > UNIX_EPOCH
+        assert!(results[0].modified_at > SystemTime::UNIX_EPOCH);
+    }
+
+    #[test]
+    fn latest_returns_most_recent_n() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        let project_dir = home.join(".claude/projects/proj");
+        fs::create_dir_all(&project_dir).unwrap();
+
+        // Create 5 files with explicitly staggered mtimes (1 s apart)
+        let _base = filetime::FileTime::from_unix_time(1_700_000_000, 0);
+        let files = ["a.jsonl", "b.jsonl", "c.jsonl", "d.jsonl", "e.jsonl"];
+        for (i, name) in files.iter().enumerate() {
+            let p = project_dir.join(name);
+            fs::write(&p, "{}").unwrap();
+            let t = filetime::FileTime::from_unix_time(1_700_000_000 + i as i64, 0);
+            filetime::set_file_mtime(&p, t).unwrap();
+        }
+
+        let mut discovered = discover_sessions_in(home, Some(SessionSource::ClaudeCode));
+        assert_eq!(discovered.len(), 5);
+
+        // Simulate --latest 3
+        discovered.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+        discovered.truncate(3);
+
+        // Newest 3 are e, d, c (offsets 4, 3, 2)
+        let names: Vec<&str> = discovered
+            .iter()
+            .map(|s| s.path.file_name().unwrap().to_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["e.jsonl", "d.jsonl", "c.jsonl"]);
+    }
+
+    #[test]
+    fn latest_n_larger_than_total_returns_all() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        let project_dir = home.join(".claude/projects/proj");
+        fs::create_dir_all(&project_dir).unwrap();
+        for name in &["x.jsonl", "y.jsonl", "z.jsonl"] {
+            fs::write(project_dir.join(name), "{}").unwrap();
+        }
+
+        let mut discovered = discover_sessions_in(home, Some(SessionSource::ClaudeCode));
+        // --latest 100 on 3 files
+        discovered.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+        discovered.truncate(100);
+        assert_eq!(discovered.len(), 3);
+    }
+
+    #[test]
+    fn existing_limit_returns_path_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        let project_dir = home.join(".claude/projects/proj");
+        fs::create_dir_all(&project_dir).unwrap();
+        for name in &["a.jsonl", "b.jsonl", "c.jsonl"] {
+            fs::write(project_dir.join(name), "{}").unwrap();
+        }
+
+        // discover_sessions_in already sorts by path
+        let discovered = discover_sessions_in(home, Some(SessionSource::ClaudeCode));
+        let limited: Vec<_> = discovered.into_iter().take(2).collect();
+        assert_eq!(limited.len(), 2);
+        let names: Vec<&str> = limited
+            .iter()
+            .map(|s| s.path.file_name().unwrap().to_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["a.jsonl", "b.jsonl"]);
     }
 }

--- a/scripts/session-tagger.sh
+++ b/scripts/session-tagger.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Claude Code Stop hook — async incremental ingest
+#
+# Usage (add to ~/.claude/settings.json hooks.Stop):
+#   bash /path/to/refine/scripts/session-tagger.sh
+#
+# What it does:
+#   Runs `refine ingest-sessions --latest 1` in the background so the most
+#   recently modified session is ingested without blocking the Claude Code UI.
+#   Output is appended to ~/.refine/incremental.log.
+#
+# Requirements:
+#   - `refine` binary in PATH (or ~/.cargo/bin)
+#   - LLM API key exported in the environment (e.g. ANTHROPIC_API_KEY)
+#   - (optional) ~/.config/refine/.env or ~/.refine/.env for key injection
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${HOME}/.cargo/bin:${PATH}"
+
+LOG_DIR="${HOME}/.refine"
+LOG_FILE="${LOG_DIR}/incremental.log"
+ENV_FILE="${HOME}/.refine/.env"
+
+mkdir -p "${LOG_DIR}"
+
+# Load API keys from optional env file
+if [[ -f "${ENV_FILE}" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "${ENV_FILE}"
+  set +a
+fi
+
+# Fire-and-forget: ingest the latest 1 session, do not block the hook
+nohup refine ingest-sessions --latest 1 >> "${LOG_FILE}" 2>&1 &

--- a/scripts/session-tagger.sh
+++ b/scripts/session-tagger.sh
@@ -30,5 +30,10 @@ if [[ -f "${ENV_FILE}" ]]; then
   set +a
 fi
 
-# Fire-and-forget: ingest the latest 1 session, do not block the hook
-nohup refine ingest-sessions --latest 1 >> "${LOG_FILE}" 2>&1 &
+LOCK_FILE="${LOG_DIR}/ingest.lock"
+
+# Fire-and-forget: ingest the latest 1 Claude session, do not block the hook.
+# flock -n ensures only one ingest runs at a time; if another is already in
+# progress the new invocation is skipped rather than racing with it.
+nohup flock -n "${LOCK_FILE}" \
+  refine ingest-sessions --latest 1 --source claude >> "${LOG_FILE}" 2>&1 &


### PR DESCRIPTION
## Summary

- Adds `--latest N` to `refine ingest-sessions` to select the N most recently modified session files (sorted by mtime descending)
- Adds `modified_at: SystemTime` field to `DiscoveredSession`; falls back to `UNIX_EPOCH` on stat error — never panics
- `--latest` and `--limit` are mutually exclusive via clap `conflicts_with`

## Files changed

- `packages/core/src/session/discovery.rs` — new `modified_at` field, populated from `DirEntry::metadata().modified()`
- `packages/cli/src/cli.rs` — new `--latest` arg with `conflicts_with = "limit"`
- `apps/cli/src/ingest_sessions.rs` — new `latest` field in `IngestOptions`, sort+truncate logic
- `apps/cli/src/handlers.rs` — pass `latest` through to `IngestOptions`
- `packages/core/Cargo.toml` — add `filetime` dev-dependency for tests

## Test plan

- [ ] `test_modified_at_is_populated` — freshly created file has mtime > UNIX_EPOCH
- [ ] `test_latest_returns_most_recent_n` — 5 files with staggered mtimes, top-3 are newest
- [ ] `test_latest_n_larger_than_total_returns_all` — `--latest 100` on 3 files returns all 3
- [ ] `test_existing_limit_returns_path_order` — `--limit 2` regression still works
- [ ] `cargo test --workspace` passes (62 tests)

Closes #39