### PR TITLE
feat(mirror): weekly MOTD reminder on Mondays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/apps/mirror/src/motd.rs
+++ b/apps/mirror/src/motd.rs
@@ -333,6 +333,38 @@ fn weekly_reminder() -> Option<String> {
     weekly_reminder_from_path(&mirror_dir().join("last-weekly.md"))
 }
 
+/// Strip ANSI/VT escape sequences and non-printable control characters from `s`.
+/// This prevents terminal escape injection when LLM-generated content is displayed
+/// in a MOTD context.
+fn strip_ansi_escapes(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            match chars.peek() {
+                Some(&'[') => {
+                    chars.next(); // consume '['
+                    // consume parameter/intermediate bytes until final byte (0x40–0x7E)
+                    for inner in chars.by_ref() {
+                        if ('\x40'..='\x7e').contains(&inner) {
+                            break;
+                        }
+                    }
+                }
+                Some(_) => {
+                    chars.next(); // consume the single char after ESC
+                }
+                None => {}
+            }
+        } else if c.is_control() && c != '\t' {
+            // drop other control chars (BEL, BS, etc.)
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
 fn weekly_reminder_from_path(path: &std::path::Path) -> Option<String> {
     if !path.exists() {
         return None;
@@ -352,12 +384,16 @@ fn weekly_reminder_from_path(path: &std::path::Path) -> Option<String> {
     }
 
     // Cap I/O at 500 bytes — the report can be large but we only need the first line.
+    // Use read_to_end + from_utf8_lossy so that a multibyte UTF-8 character (e.g. CJK)
+    // that straddles the 500-byte boundary is replaced with U+FFFD instead of causing
+    // an InvalidData error that would silently drop the Monday reminder.
     let file = std::fs::File::open(path).ok()?;
-    let mut content = String::new();
+    let mut bytes = Vec::new();
     std::io::BufReader::new(file)
         .take(500)
-        .read_to_string(&mut content)
+        .read_to_end(&mut bytes)
         .ok()?;
+    let content = String::from_utf8_lossy(&bytes);
 
     let first_line = content
         .lines()
@@ -366,6 +402,10 @@ fn weekly_reminder_from_path(path: &std::path::Path) -> Option<String> {
         .next()?
         .trim()
         .to_string();
+
+    // Strip ANSI escape sequences and non-printable control characters from the
+    // LLM-generated content before it reaches the terminal (terminal escape injection).
+    let first_line = strip_ansi_escapes(&first_line);
 
     Some(format!("📋 Weekly: {}", first_line))
 }
@@ -507,6 +547,43 @@ mod tests {
             assert!(s.contains("Weekly"));
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_weekly_reminder_cjk_at_byte_boundary() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("last-weekly.md");
+        // Each CJK character is 3 UTF-8 bytes; 167 chars = 501 bytes, so the
+        // 500-byte cap splits the last character. Must not return None.
+        let cjk_line: String = "本".repeat(167);
+        std::fs::write(&path, format!("{}\n", cjk_line))?;
+        let result = weekly_reminder_from_path(&path);
+        assert!(result.is_some(), "CJK content at byte boundary must not return None");
+        Ok(())
+    }
+
+    #[test]
+    fn test_weekly_reminder_strips_ansi_escapes() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("last-weekly.md");
+        std::fs::write(&path, "\x1b[1;31mImportant\x1b[0m reminder\n")?;
+        let result = weekly_reminder_from_path(&path);
+        let s = match result {
+            Some(v) => v,
+            None => return Err("fresh file with ANSI content must yield Some".into()),
+        };
+        assert!(!s.contains('\x1b'), "ANSI escape sequences must be stripped");
+        assert!(s.contains("Important"), "visible text must be preserved");
+        Ok(())
+    }
+
+    #[test]
+    fn test_strip_ansi_escapes() {
+        assert_eq!(strip_ansi_escapes("\x1b[1;31mhello\x1b[0m"), "hello");
+        assert_eq!(strip_ansi_escapes("plain text"), "plain text");
+        assert_eq!(strip_ansi_escapes("\x1b[mred\x1b[0m"), "red");
+        // BEL and other control chars stripped; tab preserved
+        assert_eq!(strip_ansi_escapes("a\x07b\tc"), "ab\tc");
     }
 
     #[test]

--- a/apps/mirror/src/motd.rs
+++ b/apps/mirror/src/motd.rs
@@ -2,9 +2,9 @@ use crate::config::{ensure_mirror_dir, mirror_dir};
 use crate::lang::{self, t, Lang};
 use crate::score::{load_recent_scores, ScoreResult, Signal};
 use anyhow::Result;
-use chrono::{Datelike, Utc};
+use chrono::{Datelike, Local, Utc, Weekday};
 use serde::{Deserialize, Serialize};
-use std::io::Write;
+use std::io::{Read, Write};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Tip {
@@ -311,7 +311,63 @@ pub fn handle_motd() -> Result<()> {
         tip = tip,
         stale = stale_suffix,
     );
+    if let Some(reminder) = weekly_reminder() {
+        println!("{}", reminder);
+    }
     Ok(())
+}
+
+fn is_monday() -> bool {
+    Local::now().weekday() == Weekday::Mon
+}
+
+/// Read the first non-empty line from `last-weekly.md` (capped at 500 bytes)
+/// and return a one-line reminder string, or `None` if:
+/// - today is not Monday,
+/// - the file does not exist, or
+/// - the file is older than 7 days (already reviewed last cycle).
+fn weekly_reminder() -> Option<String> {
+    if !is_monday() {
+        return None;
+    }
+    weekly_reminder_from_path(&mirror_dir().join("last-weekly.md"))
+}
+
+fn weekly_reminder_from_path(path: &std::path::Path) -> Option<String> {
+    if !path.exists() {
+        return None;
+    }
+
+    // Stale guard: if the file is older than 7 days it belongs to a previous cycle.
+    // If mtime is unavailable (exotic FS) we fall open and show the reminder.
+    if let Ok(metadata) = std::fs::metadata(path) {
+        if let Ok(mtime) = metadata.modified() {
+            let age = std::time::SystemTime::now()
+                .duration_since(mtime)
+                .unwrap_or_default();
+            if age.as_secs() > 7 * 24 * 3600 {
+                return None;
+            }
+        }
+    }
+
+    // Cap I/O at 500 bytes — the report can be large but we only need the first line.
+    let file = std::fs::File::open(path).ok()?;
+    let mut content = String::new();
+    std::io::BufReader::new(file)
+        .take(500)
+        .read_to_string(&mut content)
+        .ok()?;
+
+    let first_line = content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .take(3)
+        .next()?
+        .trim()
+        .to_string();
+
+    Some(format!("📋 Weekly: {}", first_line))
 }
 
 #[cfg(test)]
@@ -429,5 +485,43 @@ mod tests {
 
         let age_hours_24 = chrono::Duration::hours(24);
         assert!(age_hours_24.num_hours() <= 48);
+    }
+
+    #[test]
+    fn test_weekly_reminder_no_file() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("last-weekly.md");
+        assert!(weekly_reminder_from_path(&path).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_weekly_reminder_fresh_file() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("last-weekly.md");
+        std::fs::write(&path, "# Weekly\n- Focus on testing\n- Write more docs\n")?;
+        let result = weekly_reminder_from_path(&path);
+        assert!(result.is_some());
+        if let Some(s) = result {
+            assert!(s.starts_with("📋 Weekly:"));
+            assert!(s.contains("Weekly"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_weekly_reminder_stale_file() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("last-weekly.md");
+        std::fs::write(&path, "# Weekly\n- Old suggestion\n")?;
+
+        // Use UNIX_EPOCH as mtime — always > 7 days old, avoids checked_sub.
+        let stale_time = std::time::UNIX_EPOCH;
+        let times = std::fs::FileTimes::new().set_modified(stale_time);
+        let file = std::fs::File::options().write(true).open(&path)?;
+        file.set_times(times)?;
+
+        assert!(weekly_reminder_from_path(&path).is_none());
+        Ok(())
     }
 }

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -128,6 +128,14 @@ pub async fn handle_weekly(
 
     println!("{}", report);
 
+    // Save the full report as the sentinel file for the MOTD weekly reminder.
+    // The MOTD reads this on Mondays to show a one-line reminder.
+    // Note: if daily-refresh.sh also runs `mirror weekly` on Sundays, this call
+    // is idempotent — the file is simply overwritten with the latest report.
+    if let Err(e) = save_last_weekly_md(&report) {
+        tracing::warn!("failed to save last-weekly.md: {}", e);
+    }
+
     let suggestions = extract_suggestions(&report);
     save_weekly_record(&this_score, suggestions)?;
     let doc_id = save_report_to_document(
@@ -326,6 +334,16 @@ fn extract_suggestions(report: &str) -> Vec<String> {
         }
     }
     suggestions
+}
+
+fn save_last_weekly_md(report: &str) -> Result<()> {
+    let dir = ensure_mirror_dir()?;
+    save_last_weekly_md_to_path(report, &dir.join("last-weekly.md"))
+}
+
+fn save_last_weekly_md_to_path(report: &str, path: &Path) -> Result<()> {
+    std::fs::write(path, report)
+        .with_context(|| format!("failed to write last weekly report to {}", path.display()))
 }
 
 fn save_weekly_record(score: &ScoreResult, suggestions: Vec<String>) -> Result<()> {
@@ -682,5 +700,16 @@ Everything looks good. No changes needed.
             .collect();
         assert_eq!(records.first().unwrap().suggestions, vec!["suggestion-1"]);
         assert_eq!(records.last().unwrap().suggestions, vec!["suggestion-52"]);
+    }
+
+    #[test]
+    fn test_save_last_weekly_md_roundtrip() -> Result<()> {
+        let dir = tempfile::tempdir().map_err(|e| anyhow::anyhow!(e))?;
+        let path = dir.path().join("last-weekly.md");
+        let report = "# Weekly Report\n\n- Focus on testing\n- Write more docs\n";
+        save_last_weekly_md_to_path(report, &path)?;
+        let content = std::fs::read_to_string(&path)?;
+        assert_eq!(content, report);
+        Ok(())
     }
 }

--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -22,4 +22,12 @@ refine ingest-sessions 2>&1
 echo "Step 2: mirror score"
 mirror score 2>&1
 
+# 3. Weekly report on Sundays — generates ~/.mirror/last-weekly.md for Monday MOTD reminder.
+# Non-fatal: weekly requires LLM API access and may fail without network/key.
+DOW=$(date +%u)  # 1=Monday … 7=Sunday
+if [ "$DOW" = "7" ]; then
+  echo "Step 3: mirror weekly (Sunday)"
+  mirror weekly 2>&1 || echo "Step 3: mirror weekly failed (non-fatal)"
+fi
+
 echo "Done."


### PR DESCRIPTION
## Summary
- `mirror weekly` saves the generated report to `~/.mirror/last-weekly.md` as a sentinel file
- `motd` detects this file on Mondays (when < 7 days old) and prints a one-line reminder from the report
- `daily-refresh.sh` runs `mirror weekly` on Sundays (DOW=7) to populate the sentinel ahead of Monday

Note: the architect plan had `DOW=1` (Monday) for the script step, but the issue specifies Sundays — implemented per the issue.

## Test plan
- [ ] `test_weekly_reminder_no_file` — missing file returns None
- [ ] `test_weekly_reminder_fresh_file` — fresh file returns Some with 📋 prefix
- [ ] `test_weekly_reminder_stale_file` — UNIX_EPOCH mtime returns None (>7d old)
- [ ] `test_save_last_weekly_md_roundtrip` — write/read roundtrip in tempdir

Closes #38