### PR TITLE
fix(sec): validate table name in column_exists to prevent SQL injection

### DIFF
--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -158,7 +158,10 @@ async fn resolve_bind_addr(host: &str, preferred: u16) -> SocketAddr {
         }
 
         // Not us — log and try next
-        eprintln!("Port {} is occupied by another process, trying next...", port);
+        eprintln!(
+            "Port {} is occupied by another process, trying next...",
+            port
+        );
     }
 
     eprintln!(
@@ -180,7 +183,7 @@ async fn is_refine_server(addr: &SocketAddr) -> bool {
         Ok(resp) => resp
             .text()
             .await
-            .map_or(false, |body| body.contains("Refine cloud API")),
+            .is_ok_and(|body| body.contains("Refine cloud API")),
         Err(_) => false,
     }
 }

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -60,16 +60,17 @@ fn migrate_documents_url_unique(conn: &Connection) -> InfraResult<()> {
     conn.execute_batch("DROP INDEX IF EXISTS idx_documents_url")
         .map_err(|e| InfraError::Database(e.to_string()))?;
     // Create unique index so concurrent inserts of the same URL fail fast.
-    conn.execute_batch(
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_url ON documents(url)",
-    )
-    .map_err(|e| InfraError::Database(e.to_string()))?;
+    conn.execute_batch("CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_url ON documents(url)")
+        .map_err(|e| InfraError::Database(e.to_string()))?;
     Ok(())
 }
 
 fn column_exists(conn: &Connection, table: &str, column: &str) -> InfraResult<bool> {
+    if !table.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return Err(InfraError::Database(format!("invalid table name: {table}")));
+    }
     let mut stmt = conn
-        .prepare(&format!("PRAGMA table_info({})", table))
+        .prepare(&format!("PRAGMA table_info({table})"))
         .map_err(|e| InfraError::Database(e.to_string()))?;
     let names: Vec<String> = stmt
         .query_map([], |row| row.get::<_, String>(1))


### PR DESCRIPTION
## Summary
- Add input validation in `column_exists` (private fn, `packages/core/src/infra/sqlite/ops.rs`) to reject table names containing characters outside `[a-zA-Z0-9_]` before interpolating into `PRAGMA table_info({})`
- This closes the latent SQL injection risk identified in SEC-01: even though the function is currently private and only called with the literal `"items"`, the `&str` signature would allow injection if ever widened
- Also fixes a pre-existing Clippy lint (`map_or(false, …)` → `is_ok_and`) in `apps/server/src/main.rs` to keep CI green

## Test plan
- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all 38 tests pass
- [x] Existing migration callers (`"items"`) are unaffected (alphanumeric + underscore only)