### PR TITLE
fix: replace hardcoded developer paths with portable equivalents in scripts

### DIFF
--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -158,7 +158,10 @@ async fn resolve_bind_addr(host: &str, preferred: u16) -> SocketAddr {
         }
 
         // Not us — log and try next
-        eprintln!("Port {} is occupied by another process, trying next...", port);
+        eprintln!(
+            "Port {} is occupied by another process, trying next...",
+            port
+        );
     }
 
     eprintln!(
@@ -180,7 +183,7 @@ async fn is_refine_server(addr: &SocketAddr) -> bool {
         Ok(resp) => resp
             .text()
             .await
-            .map_or(false, |body| body.contains("Refine cloud API")),
+            .is_ok_and(|body| body.contains("Refine cloud API")),
         Err(_) => false,
     }
 }

--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -2,8 +2,9 @@
 # Daily refresh: ingest new sessions → update mirror score + advice
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/Users/lifcc/.cargo/bin:$PATH"
-cd /Users/lifcc/Desktop/code/AI/tools/refine
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${HOME}/.cargo/bin:$PATH"
+cd "${SCRIPT_DIR}/.."
 
 # Load .env for LLM API keys
 if [ -f .env ]; then

--- a/scripts/weekly-insights.sh
+++ b/scripts/weekly-insights.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REFINE_BIN="/Users/lifcc/.cargo/bin/refine"
-PROJECT_DIR="/Users/lifcc/Desktop/code/AI/tools/refine"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REFINE_BIN="${HOME}/.cargo/bin/refine"
+PROJECT_DIR="${SCRIPT_DIR}/.."
 ENV_FILE="${PROJECT_DIR}/.env"
 LOG_PREFIX="[refine-weekly]"
 


### PR DESCRIPTION
## Summary
- `scripts/daily-refresh.sh`: Replace `/Users/lifcc/.cargo/bin` with `${HOME}/.cargo/bin` and `cd /Users/lifcc/Desktop/code/AI/tools/refine` with `SCRIPT_DIR`-based portable `cd`
- `scripts/weekly-insights.sh`: Same treatment — `REFINE_BIN` and `PROJECT_DIR` now derived from `${HOME}` and `BASH_SOURCE[0]`
- `apps/server/src/main.rs`: Fix pre-existing `clippy::unnecessary_map_or` warning to keep CI clean

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (0 errors)
- [x] `cargo test --workspace` passes (38 tests, 0 failures)
- [ ] Manual: verify `daily-refresh.sh` and `weekly-insights.sh` run on a machine without `/Users/lifcc/` path