### PR TITLE
fix: replace hardcoded developer paths with portable equivalents

### DIFF
--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -158,7 +158,10 @@ async fn resolve_bind_addr(host: &str, preferred: u16) -> SocketAddr {
         }
 
         // Not us — log and try next
-        eprintln!("Port {} is occupied by another process, trying next...", port);
+        eprintln!(
+            "Port {} is occupied by another process, trying next...",
+            port
+        );
     }
 
     eprintln!(
@@ -180,7 +183,7 @@ async fn is_refine_server(addr: &SocketAddr) -> bool {
         Ok(resp) => resp
             .text()
             .await
-            .map_or(false, |body| body.contains("Refine cloud API")),
+            .is_ok_and(|body| body.contains("Refine cloud API")),
         Err(_) => false,
     }
 }

--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -2,8 +2,9 @@
 # Daily refresh: ingest new sessions → update mirror score + advice
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/Users/lifcc/.cargo/bin:$PATH"
-cd /Users/lifcc/Desktop/code/AI/tools/refine
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${HOME}/.cargo/bin:${PATH}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/.."
 
 # Load .env for LLM API keys
 if [ -f .env ]; then

--- a/scripts/weekly-insights.sh
+++ b/scripts/weekly-insights.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REFINE_BIN="/Users/lifcc/.cargo/bin/refine"
-PROJECT_DIR="/Users/lifcc/Desktop/code/AI/tools/refine"
+REFINE_BIN="${HOME}/.cargo/bin/refine"
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENV_FILE="${PROJECT_DIR}/.env"
 LOG_PREFIX="[refine-weekly]"
 


### PR DESCRIPTION
## Summary
- Replace `/Users/lifcc/.cargo/bin` with `${HOME}/.cargo/bin` in `daily-refresh.sh`
- Replace `cd /Users/lifcc/...` with `SCRIPT_DIR`-based `cd` in `daily-refresh.sh`
- Replace hardcoded `REFINE_BIN` and `PROJECT_DIR` paths with `${HOME}` and `BASH_SOURCE`-based detection in `weekly-insights.sh`
- Fix pre-existing clippy lint (`map_or` → `is_ok_and`) in `apps/server/src/main.rs` to satisfy `-D warnings`

Closes #53

## Test plan
- [ ] `cargo fmt --all` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes (38 tests)
- [ ] Scripts run without path errors on any machine (no `/Users/lifcc/` references remain)