### PR TITLE
fix: add shellcheck source directive in daily-refresh.sh for consistency

### DIFF
--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -9,6 +9,7 @@ cd "${SCRIPT_DIR}/.."
 # Load .env for LLM API keys
 if [ -f .env ]; then
   set -a
+  # shellcheck source=/dev/null
   source .env
   set +a
 fi


### PR DESCRIPTION
## Summary

- Adds `# shellcheck source=/dev/null` before `source .env` in `scripts/daily-refresh.sh` to match the existing pattern in `scripts/weekly-insights.sh`
- Both scripts now handle dynamic `.env` source locations consistently

The core portability fix (replacing `/Users/lifcc/.cargo/bin` with `${HOME}/.cargo/bin` and the hardcoded `cd` with `SCRIPT_DIR` from `BASH_SOURCE[0]`) was already implemented in #55. This PR formally closes #58 by making the two scripts consistent in their shellcheck annotations.

## Validation

- `cargo fmt --all` — passes (no Rust changes)
- `cargo clippy --workspace --all-targets -- -D warnings` — passes (no Rust changes)
- `cargo test --workspace` — passes (38 tests, 0 failures)

Closes #58