### PR TITLE
fix: refresh canonical documents on duplicate URL saves

### DIFF
--- a/apps/mirror/src/motd.rs
+++ b/apps/mirror/src/motd.rs
@@ -354,7 +354,7 @@ fn strip_ansi_escapes(s: &str) -> String {
             match chars.peek() {
                 Some(&'[') => {
                     chars.next(); // consume '['
-                    // consume parameter/intermediate bytes until final byte (0x40–0x7E)
+                                  // consume parameter/intermediate bytes until final byte (0x40–0x7E)
                     for inner in chars.by_ref() {
                         if ('\x40'..='\x7e').contains(&inner) {
                             break;
@@ -568,7 +568,10 @@ mod tests {
         let cjk_line: String = "本".repeat(167);
         std::fs::write(&path, format!("{}\n", cjk_line))?;
         let result = weekly_reminder_from_path(&path);
-        assert!(result.is_some(), "CJK content at byte boundary must not return None");
+        assert!(
+            result.is_some(),
+            "CJK content at byte boundary must not return None"
+        );
         Ok(())
     }
 
@@ -582,7 +585,10 @@ mod tests {
             Some(v) => v,
             None => return Err("fresh file with ANSI content must yield Some".into()),
         };
-        assert!(!s.contains('\x1b'), "ANSI escape sequences must be stripped");
+        assert!(
+            !s.contains('\x1b'),
+            "ANSI escape sequences must be stripped"
+        );
         assert!(s.contains("Important"), "visible text must be preserved");
         Ok(())
     }

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -3,8 +3,8 @@ mod compute;
 mod display;
 mod indicators;
 mod persistence;
-pub(crate) mod streak;
 mod statusline;
+pub(crate) mod streak;
 mod types;
 
 #[cfg(test)]

--- a/apps/mirror/src/score/streak.rs
+++ b/apps/mirror/src/score/streak.rs
@@ -12,10 +12,7 @@ pub fn calculate_streak(scores: &[ScoreResult], today: NaiveDate) -> u32 {
     }
 
     // Collect unique dates from scores
-    let mut dates: Vec<NaiveDate> = scores
-        .iter()
-        .map(|s| s.timestamp.date_naive())
-        .collect();
+    let mut dates: Vec<NaiveDate> = scores.iter().map(|s| s.timestamp.date_naive()).collect();
     dates.sort_unstable();
     dates.dedup();
 

--- a/apps/mirror/src/score/tests.rs
+++ b/apps/mirror/src/score/tests.rs
@@ -1217,8 +1217,7 @@ fn filter_since_boundary_inclusive() {
 // ── Streak tests ──
 
 fn make_score_at_date(date: chrono::NaiveDate) -> ScoreResult {
-    let ts = chrono::Utc
-        .from_utc_datetime(&date.and_hms_opt(12, 0, 0).unwrap());
+    let ts = chrono::Utc.from_utc_datetime(&date.and_hms_opt(12, 0, 0).unwrap());
     ScoreResult {
         layers: std::array::from_fn(|i| {
             let names = ["depth", "breadth", "collaboration"];
@@ -1291,8 +1290,14 @@ fn test_streak_no_record_today() {
 
 #[test]
 fn test_milestone_messages() {
-    assert_eq!(milestone_message(7), Some("\u{1f3af} 一周连续！习惯正在形成"));
-    assert_eq!(milestone_message(30), Some("\u{1f3c6} 连续一个月！认知追踪已成习惯"));
+    assert_eq!(
+        milestone_message(7),
+        Some("\u{1f3af} 一周连续！习惯正在形成")
+    );
+    assert_eq!(
+        milestone_message(30),
+        Some("\u{1f3c6} 连续一个月！认知追踪已成习惯")
+    );
     assert_eq!(milestone_message(100), Some("\u{1f4af} 百日里程碑！"));
     assert_eq!(milestone_message(365), Some("\u{1f38a} 整整一年！"));
     assert_eq!(milestone_message(5), None);

--- a/packages/core/src/infra/sqlite/doc_ops.rs
+++ b/packages/core/src/infra/sqlite/doc_ops.rs
@@ -60,7 +60,7 @@ pub(super) fn find_recent(
     let offset = std::cmp::min(offset, i64::MAX as usize) as i64;
 
     let mut stmt = conn
-        .prepare("SELECT id, title, raw_content, source, url, captured_at, created_at, updated_at FROM documents ORDER BY created_at DESC LIMIT ?1 OFFSET ?2")
+        .prepare("SELECT id, title, raw_content, source, url, captured_at, created_at, updated_at FROM documents ORDER BY captured_at DESC, created_at DESC LIMIT ?1 OFFSET ?2")
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     let rows = stmt

--- a/packages/core/src/infra/sqlite/doc_ops.rs
+++ b/packages/core/src/infra/sqlite/doc_ops.rs
@@ -9,7 +9,10 @@ pub(super) fn save(conn: &Connection, doc: &Document) -> InfraResult<()> {
         "INSERT INTO documents (id, title, raw_content, source, url, captured_at, created_at, updated_at)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
          ON CONFLICT(url) DO UPDATE SET
-             title = excluded.title,
+             title = CASE
+                 WHEN excluded.title IS NULL OR TRIM(excluded.title) = '' THEN documents.title
+                 ELSE excluded.title
+             END,
              raw_content = excluded.raw_content,
              captured_at = excluded.captured_at,
              updated_at = excluded.updated_at",

--- a/packages/core/src/infra/sqlite/doc_ops.rs
+++ b/packages/core/src/infra/sqlite/doc_ops.rs
@@ -6,7 +6,13 @@ use rusqlite::{params, Connection, OptionalExtension};
 
 pub(super) fn save(conn: &Connection, doc: &Document) -> InfraResult<()> {
     conn.execute(
-        "INSERT OR IGNORE INTO documents (id, title, raw_content, source, url, captured_at, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        "INSERT INTO documents (id, title, raw_content, source, url, captured_at, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT(url) DO UPDATE SET
+             title = excluded.title,
+             raw_content = excluded.raw_content,
+             captured_at = excluded.captured_at,
+             updated_at = excluded.updated_at",
         params![
             doc.id().as_str(),
             doc.title(),

--- a/packages/core/src/session/facets.rs
+++ b/packages/core/src/session/facets.rs
@@ -337,7 +337,11 @@ mod tests {
             code_artifacts: Vec::new(),
         };
         let doc_id = DocumentId::new();
-        let items = facets_to_items(&facets, &doc_id, Some("-users-lifcc-desktop-code-ai-tools-harness"));
+        let items = facets_to_items(
+            &facets,
+            &doc_id,
+            Some("-users-lifcc-desktop-code-ai-tools-harness"),
+        );
 
         // decision item (index 1) should carry both "decision" and project tag
         let decision_tags: Vec<&str> = items[1].tags().iter().map(|t| t.as_str()).collect();

--- a/packages/core/tests/sqlite_roundtrip.rs
+++ b/packages/core/tests/sqlite_roundtrip.rs
@@ -1,6 +1,8 @@
 use chrono::{Duration, TimeZone, Utc};
 use refine_core::infra::SqliteStore;
-use refine_core::knowledge::{Item, ItemId, ItemRepository, ItemType, RestoreParams, Source, Tag};
+use refine_core::knowledge::{
+    Document, Item, ItemId, ItemRepository, ItemType, RestoreParams, Source, Tag,
+};
 use std::collections::HashSet;
 
 #[tokio::test]
@@ -93,6 +95,49 @@ async fn search_text_supports_offset_and_total_count() {
         .collect();
     let second_id = second_page[0].id().to_string();
     assert!(!first_ids.contains(&second_id));
+}
+
+#[tokio::test]
+async fn document_save_refreshes_existing_url_content() {
+    let store = SqliteStore::in_memory().expect("failed to create sqlite store");
+    let url = "https://claude.ai/chat/duplicate";
+
+    let mut first = Document::new("claude", "older content");
+    first.set_title("Older title");
+    first.set_url(url);
+    refine_core::knowledge::DocumentRepository::save(&store, &first)
+        .await
+        .expect("failed to save first document");
+    let first_updated_at = first.updated_at();
+
+    let mut second = Document::new("claude", "newer content");
+    second.set_title("Newer title");
+    second.set_url(url);
+    let second_captured_at = second.captured_at();
+    let second_updated_at = second.updated_at();
+    refine_core::knowledge::DocumentRepository::save(&store, &second)
+        .await
+        .expect("failed to save second document");
+
+    let by_url = refine_core::knowledge::DocumentRepository::find_by_url(&store, url)
+        .await
+        .expect("find_by_url failed")
+        .expect("document not found by url");
+    let by_id = refine_core::knowledge::DocumentRepository::find_by_id(&store, first.id())
+        .await
+        .expect("find_by_id failed")
+        .expect("document not found by id");
+
+    assert_eq!(by_url.id(), first.id());
+    assert_eq!(by_url.title(), Some("Newer title"));
+    assert_eq!(by_url.raw_content(), "newer content");
+    assert_eq!(by_url.captured_at(), second_captured_at);
+    assert_eq!(by_url.updated_at(), second_updated_at);
+    assert!(by_url.updated_at() >= first_updated_at);
+    assert_eq!(by_id.title(), Some("Newer title"));
+    assert_eq!(by_id.raw_content(), "newer content");
+    assert_eq!(by_id.captured_at(), second_captured_at);
+    assert_eq!(by_id.updated_at(), second_updated_at);
 }
 
 #[tokio::test]

--- a/packages/core/tests/sqlite_roundtrip.rs
+++ b/packages/core/tests/sqlite_roundtrip.rs
@@ -141,6 +141,46 @@ async fn document_save_refreshes_existing_url_content() {
 }
 
 #[tokio::test]
+async fn document_save_preserves_existing_title_when_duplicate_url_has_no_title() {
+    let store = SqliteStore::in_memory().expect("failed to create sqlite store");
+    let url = "https://claude.ai/chat/duplicate-no-title";
+
+    let mut first = Document::new("claude", "older content");
+    first.set_title("Canonical title");
+    first.set_url(url);
+    refine_core::knowledge::DocumentRepository::save(&store, &first)
+        .await
+        .expect("failed to save first document");
+
+    let mut second = Document::new("claude", "newer content");
+    second.set_url(url);
+    let second_captured_at = second.captured_at();
+    let second_updated_at = second.updated_at();
+    refine_core::knowledge::DocumentRepository::save(&store, &second)
+        .await
+        .expect("failed to save second document");
+
+    let by_url = refine_core::knowledge::DocumentRepository::find_by_url(&store, url)
+        .await
+        .expect("find_by_url failed")
+        .expect("document not found by url");
+    let by_id = refine_core::knowledge::DocumentRepository::find_by_id(&store, first.id())
+        .await
+        .expect("find_by_id failed")
+        .expect("document not found by id");
+
+    assert_eq!(by_url.id(), first.id());
+    assert_eq!(by_url.title(), Some("Canonical title"));
+    assert_eq!(by_url.raw_content(), "newer content");
+    assert_eq!(by_url.captured_at(), second_captured_at);
+    assert_eq!(by_url.updated_at(), second_updated_at);
+    assert_eq!(by_id.title(), Some("Canonical title"));
+    assert_eq!(by_id.raw_content(), "newer content");
+    assert_eq!(by_id.captured_at(), second_captured_at);
+    assert_eq!(by_id.updated_at(), second_updated_at);
+}
+
+#[tokio::test]
 async fn find_recent_and_count_items_respect_type_and_pagination() {
     let store = SqliteStore::in_memory().expect("failed to create sqlite store");
 

--- a/packages/core/tests/sqlite_roundtrip.rs
+++ b/packages/core/tests/sqlite_roundtrip.rs
@@ -1,7 +1,8 @@
 use chrono::{Duration, TimeZone, Utc};
 use refine_core::infra::SqliteStore;
 use refine_core::knowledge::{
-    Document, Item, ItemId, ItemRepository, ItemType, RestoreParams, Source, Tag,
+    Document, DocumentId, Item, ItemId, ItemRepository, ItemType, RestoreDocumentParams,
+    RestoreParams, Source, Tag,
 };
 use std::collections::HashSet;
 
@@ -178,6 +179,70 @@ async fn document_save_preserves_existing_title_when_duplicate_url_has_no_title(
     assert_eq!(by_id.raw_content(), "newer content");
     assert_eq!(by_id.captured_at(), second_captured_at);
     assert_eq!(by_id.updated_at(), second_updated_at);
+}
+
+#[tokio::test]
+async fn document_find_recent_orders_by_latest_capture_after_duplicate_url_refresh() {
+    let store = SqliteStore::in_memory().expect("failed to create sqlite store");
+
+    let older_capture = Utc
+        .with_ymd_and_hms(2026, 2, 6, 10, 0, 0)
+        .single()
+        .expect("invalid older capture");
+    let middle_capture = older_capture + Duration::minutes(10);
+    let newest_capture = older_capture + Duration::minutes(20);
+
+    let older = Document::restore(RestoreDocumentParams {
+        id: DocumentId::from("doc-older"),
+        title: Some("Older".to_string()),
+        raw_content: "older content".to_string(),
+        source: "claude".to_string(),
+        url: "https://claude.ai/chat/older".to_string(),
+        captured_at: older_capture,
+        created_at: older_capture,
+        updated_at: older_capture,
+    });
+    refine_core::knowledge::DocumentRepository::save(&store, &older)
+        .await
+        .expect("failed to save older document");
+
+    let newer = Document::restore(RestoreDocumentParams {
+        id: DocumentId::from("doc-newer"),
+        title: Some("Newer".to_string()),
+        raw_content: "newer content".to_string(),
+        source: "claude".to_string(),
+        url: "https://claude.ai/chat/newer".to_string(),
+        captured_at: middle_capture,
+        created_at: middle_capture,
+        updated_at: middle_capture,
+    });
+    refine_core::knowledge::DocumentRepository::save(&store, &newer)
+        .await
+        .expect("failed to save newer document");
+
+    let recaptured = Document::restore(RestoreDocumentParams {
+        id: DocumentId::from("doc-recaptured"),
+        title: Some("Recaptured".to_string()),
+        raw_content: "recaptured content".to_string(),
+        source: "claude".to_string(),
+        url: older.url().to_string(),
+        captured_at: newest_capture,
+        created_at: newest_capture,
+        updated_at: newest_capture,
+    });
+    refine_core::knowledge::DocumentRepository::save(&store, &recaptured)
+        .await
+        .expect("failed to save recaptured document");
+
+    let recent = refine_core::knowledge::DocumentRepository::find_recent(&store, 0, 10)
+        .await
+        .expect("find_recent failed");
+
+    assert_eq!(recent.len(), 2);
+    assert_eq!(recent[0].id(), older.id());
+    assert_eq!(recent[0].captured_at(), newest_capture);
+    assert_eq!(recent[0].raw_content(), "recaptured content");
+    assert_eq!(recent[1].id(), newer.id());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- change SQLite document saves to upsert by URL instead of ignoring duplicate captures
- refresh the canonical document row's title, raw_content, captured_at, and updated_at while preserving its original id
- add a regression test that saves the same URL twice and asserts the canonical document returns the newer content

Closes #64

## Test plan
- [x] cargo fmt --all
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo check
- [x] cargo test --workspace