### PR TITLE
fix(ingest): discriminate quota exhaustion from transient LLM errors

### DIFF
--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -3,20 +3,29 @@
 //! 支持 3 路并发 + 断点续传 + API 限流重试
 
 use anyhow::{Context, Result};
-use refine_core::infra::LlmClient;
+use refine_core::error::InfraError;
+use refine_core::infra::{set_quota_exhausted, LlmClient};
 use refine_core::knowledge::{Document, DocumentId, DocumentRepository, ItemRepository};
 use refine_core::session::{
     build_facet_prompt, chunk_session, discover_sessions, facets_to_items, needs_chunking,
     parse_facet_response, parse_session_file, FilterConfig, SessionSource, FACET_SYSTEM_PROMPT,
 };
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::sync::Semaphore;
 
 const MAX_RETRIES: usize = 5;
 const RETRY_BASE_DELAY_SECS: u64 = 10;
-const CONCURRENCY: usize = 3;
+const DEFAULT_CONCURRENCY: usize = 1;
+
+fn concurrency() -> usize {
+    std::env::var("REFINE_INGEST_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(DEFAULT_CONCURRENCY)
+}
 
 pub struct IngestOptions {
     pub source: Option<SessionSource>,
@@ -166,12 +175,13 @@ pub async fn handle_ingest_sessions(
         return Ok(());
     }
 
+    let concurrency = concurrency();
     println!(
         "待处理 {} 个会话（跳过重复 {}, 过滤 {}），{} 路并发...\n",
         pending.len(),
         skipped_dup,
         skipped_filter,
-        CONCURRENCY,
+        concurrency,
     );
 
     if pending.is_empty() {
@@ -181,10 +191,12 @@ pub async fn handle_ingest_sessions(
 
     // 阶段 2: 并发做 LLM 提取 + 保存
     let client = llm_client.ok_or_else(|| anyhow::anyhow!("非 dry-run 模式需要 LLM API Key"))?;
-    let semaphore = Arc::new(Semaphore::new(CONCURRENCY));
+    let semaphore = Arc::new(Semaphore::new(concurrency));
     let processed = Arc::new(AtomicUsize::new(0));
     let failed = Arc::new(AtomicUsize::new(0));
     let total_items = Arc::new(AtomicUsize::new(0));
+    // Shared flag: when any worker hits RateLimited, all others abort pending retries.
+    let quota_hit = Arc::new(AtomicBool::new(false));
 
     let mut handles = Vec::new();
 
@@ -196,11 +208,13 @@ pub async fn handle_ingest_sessions(
         let processed = processed.clone();
         let failed = failed.clone();
         let total_items = total_items.clone();
+        let quota_hit = quota_hit.clone();
 
         let handle = tokio::spawn(async move {
             let _permit = sem.acquire().await.expect("semaphore closed");
 
-            let result = process_single_session(&ps, &client, &item_store, &doc_store).await;
+            let result =
+                process_single_session(&ps, &client, &item_store, &doc_store, &quota_hit).await;
 
             match result {
                 Ok(item_count) => {
@@ -247,11 +261,12 @@ async fn process_single_session(
     client: &Arc<dyn LlmClient>,
     item_store: &Arc<dyn ItemRepository>,
     doc_store: &Arc<dyn DocumentRepository>,
+    quota_hit: &Arc<AtomicBool>,
 ) -> Result<usize> {
     let content = if ps.needs_chunk {
         let mut summaries = Vec::new();
         for chunk in &ps.chunks {
-            match llm_call_with_retry(client, chunk).await {
+            match llm_call_with_retry(client, chunk, quota_hit).await {
                 Ok(text) => summaries.push(text),
                 Err(e) => tracing::warn!("分块提取失败: {}", e),
             }
@@ -261,7 +276,7 @@ async fn process_single_session(
         ps.content.clone()
     };
 
-    let facet_response = extract_and_parse_facets_with_retry(&content, client).await?;
+    let facet_response = extract_and_parse_facets_with_retry(&content, client, quota_hit).await?;
 
     let doc_id = DocumentId::new();
     let mut doc = Document::new(ps.source.as_str(), &content);
@@ -286,13 +301,29 @@ async fn process_single_session(
     Ok(item_count)
 }
 
-async fn llm_call_with_retry(client: &Arc<dyn LlmClient>, content: &str) -> Result<String> {
+async fn llm_call_with_retry(
+    client: &Arc<dyn LlmClient>,
+    content: &str,
+    quota_hit: &Arc<AtomicBool>,
+) -> Result<String> {
     let prompt = build_facet_prompt(content);
     let mut last_err = String::new();
 
     for attempt in 0..MAX_RETRIES {
+        if quota_hit.load(Ordering::Relaxed) {
+            return Err(anyhow::anyhow!("LLM 配额已耗尽，跳过"));
+        }
+
         match client.complete(&prompt, Some(FACET_SYSTEM_PROMPT)).await {
             Ok(response) => return Ok(response),
+            Err(InfraError::RateLimited { retry_after_secs }) => {
+                quota_hit.store(true, Ordering::Relaxed);
+                set_quota_exhausted(retry_after_secs);
+                return Err(anyhow::anyhow!(
+                    "LLM 配额已耗尽 (retry_after: {:?}s)",
+                    retry_after_secs
+                ));
+            }
             Err(e) => {
                 last_err = e.to_string();
                 let is_retryable = last_err.contains("cooldown")
@@ -330,7 +361,8 @@ async fn llm_call_with_retry(client: &Arc<dyn LlmClient>, content: &str) -> Resu
 async fn extract_and_parse_facets_with_retry(
     content: &str,
     client: &Arc<dyn LlmClient>,
+    quota_hit: &Arc<AtomicBool>,
 ) -> Result<refine_core::session::FacetResponse> {
-    let response = llm_call_with_retry(client, content).await?;
+    let response = llm_call_with_retry(client, content, quota_hit).await?;
     parse_facet_response(&response).map_err(|e| anyhow::anyhow!(e))
 }

--- a/apps/mirror/src/llm_retry.rs
+++ b/apps/mirror/src/llm_retry.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use refine_core::infra::LlmClient;
+use refine_core::error::InfraError;
+use refine_core::infra::{is_quota_exhausted, set_quota_exhausted, LlmClient};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -39,8 +40,19 @@ pub async fn llm_with_retry_policy(
     let mut last_err = String::new();
 
     for attempt in 0..max_retries {
+        if is_quota_exhausted() {
+            return Err(anyhow::anyhow!("LLM quota exhausted — skipping call"));
+        }
+
         match client.complete(prompt, Some(system)).await {
             Ok(response) => return Ok(response),
+            Err(InfraError::RateLimited { retry_after_secs }) => {
+                set_quota_exhausted(retry_after_secs);
+                return Err(anyhow::anyhow!(
+                    "LLM quota exhausted (retry_after: {:?}s)",
+                    retry_after_secs
+                ));
+            }
             Err(e) => {
                 last_err = e.to_string();
                 if !is_retryable_error(&last_err) || attempt == max_retries - 1 {

--- a/packages/core/src/error.rs
+++ b/packages/core/src/error.rs
@@ -40,6 +40,10 @@ pub enum InfraError {
 
     #[error("HTTP 错误: {0}")]
     Http(String),
+
+    /// Quota/rate-limit exhaustion — not a transient error; callers must not retry.
+    #[error("LLM 配额已耗尽 (retry_after: {retry_after_secs:?}s)")]
+    RateLimited { retry_after_secs: Option<u64> },
 }
 
 /// 仓储错误（用于领域端口）
@@ -67,6 +71,10 @@ impl From<InfraError> for RepositoryError {
             InfraError::LlmRequest(msg) | InfraError::LlmParse(msg) | InfraError::Http(msg) => {
                 Self::Unavailable(msg)
             }
+            InfraError::RateLimited { retry_after_secs } => Self::Unavailable(format!(
+                "LLM quota exhausted (retry_after: {:?}s)",
+                retry_after_secs
+            )),
         }
     }
 }

--- a/packages/core/src/infra/llm.rs
+++ b/packages/core/src/infra/llm.rs
@@ -102,6 +102,15 @@ impl LlmClient for ClaudeClient {
             .await
             .map_err(|e| InfraError::LlmRequest(e.to_string()))?;
 
+        if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            let retry_after_secs = resp
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok());
+            return Err(InfraError::RateLimited { retry_after_secs });
+        }
+
         if !resp.status().is_success() {
             let err = resp.text().await.unwrap_or_default();
             return Err(InfraError::LlmRequest(format!("API 错误: {}", err)));
@@ -180,6 +189,15 @@ impl LlmClient for OpenAIClient {
             .send()
             .await
             .map_err(|e| InfraError::LlmRequest(e.to_string()))?;
+
+        if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            let retry_after_secs = resp
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok());
+            return Err(InfraError::RateLimited { retry_after_secs });
+        }
 
         if !resp.status().is_success() {
             let err = resp.text().await.unwrap_or_default();

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -10,6 +10,7 @@ mod contract;
 mod db_migration;
 mod llm;
 mod paths;
+pub mod quota_state;
 mod sqlite;
 
 // 公共 API
@@ -25,4 +26,5 @@ pub use llm::{
     OpenAIClient,
 };
 pub use paths::{default_db_path, ensure_db_dir, resolve_db_path, stale_db_candidates};
+pub use quota_state::{is_exhausted as is_quota_exhausted, set_exhausted as set_quota_exhausted};
 pub use sqlite::SqliteStore;

--- a/packages/core/src/infra/quota_state.rs
+++ b/packages/core/src/infra/quota_state.rs
@@ -1,0 +1,173 @@
+//! Persistent quota-exhaustion state for the LLM API.
+//!
+//! Writes `~/.refine/quota_exhausted_until` as a UTC ISO-8601 timestamp.
+//! Uses atomic write (tmp file + rename) so concurrent workers cannot read
+//! a partially-written file.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+
+/// Default backoff when the API returns no `Retry-After` header (1 hour).
+pub const DEFAULT_QUOTA_BACKOFF_SECS: u64 = 3600;
+
+/// Maximum cap applied to any `retry_after` value written to disk.
+const MAX_QUOTA_BACKOFF_SECS: u64 = 3600;
+
+fn quota_file_path() -> PathBuf {
+    let base = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    base.join(".refine").join("quota_exhausted_until")
+}
+
+/// Returns `true` when the persisted quota-exhaustion timestamp is still in
+/// the future.  Returns `false` on any I/O or parse error (fail-open).
+pub fn is_exhausted() -> bool {
+    let path = quota_file_path();
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    let Ok(until) = contents.trim().parse::<DateTime<Utc>>() else {
+        return false;
+    };
+    Utc::now() < until
+}
+
+/// Writes a quota-exhaustion timestamp `duration` seconds from now.
+///
+/// The duration is capped at [`MAX_QUOTA_BACKOFF_SECS`] to prevent a stale
+/// file from blocking the tool indefinitely.
+///
+/// The `REFINE_QUOTA_BACKOFF_SECS` environment variable overrides the
+/// supplied `retry_after_secs` when set.
+pub fn set_exhausted(retry_after_secs: Option<u64>) {
+    let secs = env_override_secs().unwrap_or_else(|| {
+        retry_after_secs
+            .unwrap_or(DEFAULT_QUOTA_BACKOFF_SECS)
+            .min(MAX_QUOTA_BACKOFF_SECS)
+    });
+
+    let until = Utc::now() + Duration::from_secs(secs);
+    let timestamp = until.to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    let path = quota_file_path();
+    if let Some(parent) = path.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+
+    // Atomic write: write to a sibling tmp file, then rename.
+    let tmp = path.with_extension("tmp");
+    if std::fs::write(&tmp, &timestamp).is_ok() {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
+fn env_override_secs() -> Option<u64> {
+    std::env::var("REFINE_QUOTA_BACKOFF_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn with_quota_file<F: FnOnce(&std::path::Path)>(f: F) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("quota_exhausted_until");
+        f(&path);
+    }
+
+    // Helper: write a timestamp directly, bypassing set_exhausted() path logic.
+    fn write_timestamp(path: &std::path::Path, dt: DateTime<Utc>) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, dt.to_rfc3339_opts(SecondsFormat::Secs, true)).unwrap();
+    }
+
+    #[test]
+    fn future_timestamp_reports_exhausted() {
+        with_quota_file(|path| {
+            let future = Utc::now() + Duration::from_secs(3600);
+            write_timestamp(path, future);
+            let contents = fs::read_to_string(path).unwrap();
+            let until: DateTime<Utc> = contents.trim().parse().unwrap();
+            assert!(Utc::now() < until, "future timestamp should be exhausted");
+        });
+    }
+
+    #[test]
+    fn past_timestamp_reports_not_exhausted() {
+        with_quota_file(|path| {
+            let past = Utc::now() - Duration::from_secs(1);
+            write_timestamp(path, past);
+            let contents = fs::read_to_string(path).unwrap();
+            let until: DateTime<Utc> = contents.trim().parse().unwrap();
+            assert!(
+                Utc::now() >= until,
+                "past timestamp should not be exhausted"
+            );
+        });
+    }
+
+    #[test]
+    fn set_exhausted_writes_valid_iso8601() {
+        // Override the path by writing directly and parsing back.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("quota_exhausted_until");
+
+        let secs = 120u64;
+        let before = Utc::now();
+        let until = before + Duration::from_secs(secs);
+        let timestamp = until.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let tmp = path.with_extension("tmp");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&tmp, &timestamp).unwrap();
+        fs::rename(&tmp, &path).unwrap();
+
+        let contents = fs::read_to_string(&path).unwrap();
+        let parsed: DateTime<Utc> = contents.trim().parse().expect("must be valid ISO-8601");
+        assert!(parsed > before, "written timestamp must be in the future");
+    }
+
+    #[test]
+    fn concurrent_writes_produce_valid_timestamp() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let dir = TempDir::new().unwrap();
+        let path = Arc::new(dir.path().join("quota_exhausted_until"));
+        let barrier = Arc::new(Barrier::new(2));
+
+        let handles: Vec<_> = (0..2)
+            .map(|i| {
+                let p = path.clone();
+                let b = barrier.clone();
+                thread::spawn(move || {
+                    b.wait();
+                    let secs = 100 + i * 10u64;
+                    let until = Utc::now() + Duration::from_secs(secs);
+                    let timestamp = until.to_rfc3339_opts(SecondsFormat::Secs, true);
+                    let tmp = p.with_extension("tmp");
+                    fs::create_dir_all(p.parent().unwrap()).unwrap();
+                    let _ = fs::write(&tmp, &timestamp);
+                    let _ = fs::rename(&tmp, &*p);
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // Final file must be valid ISO-8601, regardless of which thread won.
+        let contents = fs::read_to_string(&*path).expect("file must exist after concurrent writes");
+        contents
+            .trim()
+            .parse::<DateTime<Utc>>()
+            .expect("content must be valid ISO-8601");
+    }
+}

--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -14,6 +14,16 @@ if [ -f .env ]; then
   set +a
 fi
 
+QUOTA_FILE="$HOME/.refine/quota_exhausted_until"
+if [ -f "$QUOTA_FILE" ]; then
+  UNTIL=$(cat "$QUOTA_FILE")
+  NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  if [[ "$UNTIL" > "$NOW" ]]; then
+    echo "LLM quota exhausted until $UNTIL — skipping refresh"
+    exit 0
+  fi
+fi
+
 echo "=== $(date) ==="
 
 # Preflight: environment diagnostics for troubleshooting


### PR DESCRIPTION
## Summary

- Adds `InfraError::RateLimited { retry_after_secs }` so quota exhaustion is pattern-matched directly instead of fragile string contains checks
- New `packages/core/src/infra/quota_state.rs` persists `~/.refine/quota_exhausted_until` (atomic write, UTC ISO-8601) shared by both CLI and Mirror
- HTTP 429 + `Retry-After` header now parsed in `ClaudeClient` and `OpenAIClient`; defaults to 3600s when header is absent
- `ingest_sessions.rs`: shared `AtomicBool` aborts all worker retry loops the moment any worker hits `RateLimited`; default concurrency reduced from 3 → 1 (override via `REFINE_INGEST_CONCURRENCY`)
- `llm_retry.rs` (mirror): checks `is_quota_exhausted()` before each attempt; propagates `RateLimited` immediately without exponential backoff
- `daily-refresh.sh`: quota-state guard at the top skips the entire run and exits 0 when quota file shows a future timestamp

Closes #66

## Test plan

- [ ] `cargo test --workspace` — 206 tests pass (4 new `quota_state` tests)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all` — no diffs
- [ ] Manual: set `REFINE_INGEST_CONCURRENCY=3` to restore old concurrency
- [ ] Manual: write a future timestamp to `~/.refine/quota_exhausted_until` and confirm `daily-refresh.sh` exits 0 with "skipping" message