### PR TITLE
feat(core): migrate stale server.db / data.db into canonical refine.db on startup

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -11,7 +11,9 @@ mod support;
 use anyhow::{Context, Result};
 use clap::Parser;
 use cli::Cli;
-use refine_core::infra::{ensure_db_dir, resolve_db_path, SqliteStore};
+use refine_core::infra::{
+    ensure_db_dir, migrate_stale_dbs, resolve_db_path, MigrationReport, SqliteStore,
+};
 use refine_core::knowledge::ItemRepository;
 use refine_core::search::SearchEngine;
 use std::path::PathBuf;
@@ -33,6 +35,24 @@ async fn main() -> Result<()> {
         None => resolve_db_path(&[]),
     };
     ensure_db_dir(&db_path).map_err(|e| anyhow::anyhow!(e))?;
+    match migrate_stale_dbs(&db_path) {
+        Ok(MigrationReport::NoOp) => {}
+        Ok(MigrationReport::Migrated {
+            sources,
+            rows_copied,
+        }) => {
+            eprintln!(
+                "[refine] migrated {} row(s) from legacy DB(s): {}",
+                rows_copied,
+                sources
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+        Err(e) => eprintln!("[refine] warning: DB migration failed (continuing): {e}"),
+    }
 
     let store = Arc::new(SqliteStore::open(&db_path).context("打开数据库失败")?);
     let repo: Arc<dyn ItemRepository> = store.clone();

--- a/apps/desktop/src-tauri/src/app/mod.rs
+++ b/apps/desktop/src-tauri/src/app/mod.rs
@@ -2,7 +2,9 @@ pub mod commands;
 mod dto;
 mod state;
 
-use refine_core::infra::{ensure_db_dir, resolve_db_path, SqliteStore};
+use refine_core::infra::{
+    ensure_db_dir, migrate_stale_dbs, resolve_db_path, MigrationReport, SqliteStore,
+};
 use refine_core::knowledge::ItemRepository;
 use refine_core::search::SearchEngine;
 use std::sync::Arc;
@@ -12,6 +14,24 @@ pub use state::AppState;
 pub fn build_state() -> AppState {
     let db_path = resolve_db_path(&["REFINE_DESKTOP_DB_PATH"]);
     ensure_db_dir(&db_path).expect("无法创建数据库目录");
+    match migrate_stale_dbs(&db_path) {
+        Ok(MigrationReport::NoOp) => {}
+        Ok(MigrationReport::Migrated {
+            sources,
+            rows_copied,
+        }) => {
+            eprintln!(
+                "[refine] migrated {} row(s) from legacy DB(s): {}",
+                rows_copied,
+                sources
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+        Err(e) => eprintln!("[refine] warning: DB migration failed (continuing): {e}"),
+    }
 
     let sqlite_store = Arc::new(SqliteStore::open(&db_path).expect("打开数据库失败"));
     let store: Arc<dyn ItemRepository> = sqlite_store;

--- a/apps/server/src/state.rs
+++ b/apps/server/src/state.rs
@@ -1,5 +1,6 @@
 use refine_core::infra::{
-    build_llm_client_from_env, ensure_db_dir, resolve_db_path, LlmClient, SqliteStore,
+    build_llm_client_from_env, ensure_db_dir, migrate_stale_dbs, resolve_db_path, LlmClient,
+    MigrationReport, SqliteStore,
 };
 use refine_core::knowledge::{DocumentRepository, ItemRepository};
 use refine_core::search::SearchEngine;
@@ -28,6 +29,20 @@ impl AppState {
     pub async fn build() -> Result<Self, String> {
         let db_path = resolve_db_path(&["REFINE_SERVER_DB_PATH"]);
         ensure_db_dir(&db_path)?;
+        match migrate_stale_dbs(&db_path) {
+            Ok(MigrationReport::NoOp) => {}
+            Ok(MigrationReport::Migrated {
+                sources,
+                rows_copied,
+            }) => {
+                tracing::info!(
+                    rows_copied,
+                    sources = ?sources,
+                    "migrated legacy DB(s) into primary database"
+                );
+            }
+            Err(e) => tracing::warn!("DB migration failed (continuing): {}", e),
+        }
         let persistence = Arc::new(ServerPersistence::new(db_path.clone())?);
         let conversation_repo: Arc<dyn ConversationRepository> = persistence.clone();
         let job_repo: Arc<dyn JobRepository> = persistence.clone();

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -1,0 +1,330 @@
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+
+use super::paths::stale_db_candidates;
+
+const SCHEMA_SQL: &str = include_str!("schema.sql");
+
+/// Result of a `migrate_stale_dbs` run.
+pub enum MigrationReport {
+    /// No legacy files were found; nothing was done.
+    NoOp,
+    /// One or more legacy databases were merged into the target.
+    Migrated {
+        sources: Vec<PathBuf>,
+        rows_copied: usize,
+    },
+}
+
+/// Copies rows from any legacy databases into `target` and renames each legacy
+/// file to `<name>.migrated` so the migration only runs once.
+///
+/// On success the legacy files no longer exist at their original paths.
+/// On failure the legacy files are left intact and an `Err` is returned —
+/// the caller should warn the user but must not abort startup, because the
+/// primary database is never written to destructively (only `INSERT OR IGNORE`).
+pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
+    let candidates = stale_db_candidates(target);
+    if candidates.is_empty() {
+        return Ok(MigrationReport::NoOp);
+    }
+
+    let conn = Connection::open(target)
+        .map_err(|e| format!("failed to open target DB {}: {}", target.display(), e))?;
+
+    init_target_schema(&conn)?;
+
+    let mut sources = Vec::new();
+    let mut total_rows = 0usize;
+
+    for candidate in &candidates {
+        let bak_path = with_suffix(candidate, ".pre-migration.bak");
+        std::fs::copy(candidate, &bak_path)
+            .map_err(|e| format!("failed to backup {}: {}", candidate.display(), e))?;
+
+        let attach_sql = format!(
+            "ATTACH DATABASE '{}' AS refine_migration_src",
+            candidate.to_string_lossy().replace('\'', "''")
+        );
+        if let Err(e) = conn.execute_batch(&attach_sql) {
+            let _ = std::fs::remove_file(&bak_path);
+            return Err(format!("failed to attach {}: {}", candidate.display(), e));
+        }
+
+        let result = copy_all_tables(&conn, "refine_migration_src");
+        let _ = conn.execute_batch("DETACH DATABASE refine_migration_src");
+
+        let rows = result.map_err(|e| {
+            let _ = std::fs::remove_file(&bak_path);
+            format!("migration of {} failed: {}", candidate.display(), e)
+        })?;
+
+        let migrated_path = with_suffix(candidate, ".migrated");
+        std::fs::rename(candidate, &migrated_path)
+            .map_err(|e| format!("failed to rename {}: {}", candidate.display(), e))?;
+
+        // Move companion WAL/SHM files so they stay associated with the renamed DB.
+        for ext in ["-wal", "-shm"] {
+            let companion = with_suffix(candidate, ext);
+            if companion.exists() {
+                let _ = std::fs::rename(&companion, with_suffix(&migrated_path, ext));
+            }
+        }
+
+        sources.push(candidate.clone());
+        total_rows += rows;
+    }
+
+    Ok(MigrationReport::Migrated {
+        sources,
+        rows_copied: total_rows,
+    })
+}
+
+fn init_target_schema(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(SCHEMA_SQL)
+        .map_err(|e| format!("failed to initialise target schema: {}", e))
+}
+
+fn copy_all_tables(conn: &Connection, legacy_alias: &str) -> Result<usize, String> {
+    let target_tables = list_base_tables(conn, "main")?;
+    let legacy_tables = list_base_tables(conn, legacy_alias)?;
+
+    let mut total = 0usize;
+    for table in &legacy_tables {
+        if !target_tables.contains(table) {
+            continue;
+        }
+        total += copy_table(conn, table, legacy_alias)?;
+    }
+    Ok(total)
+}
+
+fn list_base_tables(conn: &Connection, db_alias: &str) -> Result<Vec<String>, String> {
+    let sql = format!(
+        "SELECT name FROM {db_alias}.sqlite_master \
+         WHERE type='table' \
+           AND name NOT LIKE '%_fts%' \
+           AND name NOT LIKE 'sqlite_%'"
+    );
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+    let names = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|e| e.to_string())?
+        .filter_map(|r| r.ok())
+        .filter(|name| is_safe_identifier(name))
+        .collect();
+    Ok(names)
+}
+
+fn table_columns(conn: &Connection, db_alias: &str, table: &str) -> Result<Vec<String>, String> {
+    let sql = format!("PRAGMA {db_alias}.table_info({table})");
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+    let cols = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| e.to_string())?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(cols)
+}
+
+fn copy_table(conn: &Connection, table: &str, legacy_alias: &str) -> Result<usize, String> {
+    let target_cols = table_columns(conn, "main", table)?;
+    let legacy_cols = table_columns(conn, legacy_alias, table)?;
+    let common: Vec<String> = legacy_cols
+        .into_iter()
+        .filter(|c| target_cols.contains(c))
+        .collect();
+    if common.is_empty() {
+        return Ok(0);
+    }
+    let col_list = common.join(", ");
+    let sql = format!(
+        "INSERT OR IGNORE INTO {table} ({col_list}) \
+         SELECT {col_list} FROM {legacy_alias}.{table}"
+    );
+    conn.execute(&sql, [])
+        .map_err(|e| format!("failed to copy table {table}: {e}"))
+}
+
+fn is_safe_identifier(name: &str) -> bool {
+    !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+}
+
+fn with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut s = path.to_string_lossy().into_owned();
+    s.push_str(suffix);
+    PathBuf::from(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use tempfile::TempDir;
+
+    fn make_target_db(dir: &Path) -> PathBuf {
+        let p = dir.join("refine.db");
+        let conn = Connection::open(&p).unwrap();
+        init_target_schema(&conn).unwrap();
+        p
+    }
+
+    fn make_legacy_db_with_items(dir: &Path, name: &str) -> PathBuf {
+        let p = dir.join(name);
+        let conn = Connection::open(&p).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS items (
+                id TEXT PRIMARY KEY,
+                item_type TEXT NOT NULL,
+                title TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                content TEXT NOT NULL,
+                tags TEXT NOT NULL,
+                source TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )",
+        )
+        .unwrap();
+        p
+    }
+
+    fn insert_item(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT OR IGNORE INTO items \
+             (id, item_type, title, summary, content, tags, created_at, updated_at) \
+             VALUES (?1, 'knowledge', 'T', 'S', 'C', '[]', \
+                     '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+            [id],
+        )
+        .unwrap();
+    }
+
+    fn item_count(conn: &Connection, id: &str) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM items WHERE id=?1", [id], |r| r.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn no_stale_files_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let report = migrate_stale_dbs(&target).unwrap();
+        assert!(matches!(report, MigrationReport::NoOp));
+    }
+
+    #[test]
+    fn migrates_items_from_server_db() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        insert_item(&lc, "item-001");
+        drop(lc);
+
+        let report = migrate_stale_dbs(&target).unwrap();
+        assert!(matches!(
+            report,
+            MigrationReport::Migrated { rows_copied: 1, .. }
+        ));
+        assert_eq!(
+            item_count(&Connection::open(&target).unwrap(), "item-001"),
+            1
+        );
+    }
+
+    #[test]
+    fn migrates_matching_tables_from_server_db() {
+        let tmp = TempDir::new().unwrap();
+        let target_path = tmp.path().join("refine.db");
+
+        // Target: base schema + a conversations table
+        let tc = Connection::open(&target_path).unwrap();
+        init_target_schema(&tc).unwrap();
+        tc.execute_batch(
+            "CREATE TABLE IF NOT EXISTS conversations (id TEXT PRIMARY KEY, data TEXT)",
+        )
+        .unwrap();
+        drop(tc);
+
+        // Legacy: conversations only
+        let legacy = tmp.path().join("server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        lc.execute_batch(
+            "CREATE TABLE IF NOT EXISTS conversations (id TEXT PRIMARY KEY, data TEXT)",
+        )
+        .unwrap();
+        lc.execute("INSERT INTO conversations VALUES ('conv-1', 'hello')", [])
+            .unwrap();
+        drop(lc);
+
+        migrate_stale_dbs(&target_path).unwrap();
+
+        let tc = Connection::open(&target_path).unwrap();
+        let count: i64 = tc
+            .query_row(
+                "SELECT COUNT(*) FROM conversations WHERE id='conv-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn idempotent_second_run() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        insert_item(&lc, "item-002");
+        drop(lc);
+
+        migrate_stale_dbs(&target).unwrap();
+        let report = migrate_stale_dbs(&target).unwrap();
+        assert!(matches!(report, MigrationReport::NoOp));
+        assert_eq!(
+            item_count(&Connection::open(&target).unwrap(), "item-002"),
+            1
+        );
+    }
+
+    #[test]
+    fn backup_created_before_migration() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        make_legacy_db_with_items(tmp.path(), "server.db");
+
+        migrate_stale_dbs(&target).unwrap();
+
+        assert!(tmp.path().join("server.db.pre-migration.bak").exists());
+        assert!(tmp.path().join("server.db.migrated").exists());
+        assert!(!tmp.path().join("server.db").exists());
+    }
+
+    #[test]
+    fn rollback_on_corrupt_source() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let corrupt = tmp.path().join("server.db");
+        std::fs::write(&corrupt, b"not a sqlite database").unwrap();
+
+        let result = migrate_stale_dbs(&target);
+        assert!(result.is_err());
+        assert!(corrupt.exists(), "corrupt source must be left intact");
+    }
+
+    #[test]
+    fn stale_candidates_only_returns_existing_files() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("refine.db");
+
+        assert!(stale_db_candidates(&target).is_empty());
+
+        std::fs::write(tmp.path().join("server.db"), b"").unwrap();
+        let candidates = stale_db_candidates(&target);
+        assert_eq!(candidates.len(), 1);
+        assert!(candidates[0].ends_with("server.db"));
+    }
+}

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -7,6 +7,7 @@
 //! - `schema.sql` - 数据库 Schema
 
 mod contract;
+mod db_migration;
 mod llm;
 mod paths;
 mod sqlite;
@@ -18,9 +19,10 @@ pub use contract::{
     CreateConversationRequest, DocumentDetailDto, DocumentDto, ItemDto,
     NormalizedConversationInput, CONTRACT_VERSION, CONTRACT_VERSION_HEADER,
 };
+pub use db_migration::{migrate_stale_dbs, MigrationReport};
 pub use llm::{
     build_llm_client_from_env, build_required_llm_client_from_env, ClaudeClient, LlmClient,
     OpenAIClient,
 };
-pub use paths::{default_db_path, ensure_db_dir, resolve_db_path};
+pub use paths::{default_db_path, ensure_db_dir, resolve_db_path, stale_db_candidates};
 pub use sqlite::SqliteStore;

--- a/packages/core/src/infra/paths.rs
+++ b/packages/core/src/infra/paths.rs
@@ -42,6 +42,27 @@ pub fn ensure_db_dir(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
+/// Legacy database filenames written by older binaries before path unification.
+///
+/// This is the single authoritative list of stale names. No other file in the
+/// codebase should reference these strings — callers probe them via this module.
+const LEGACY_DB_NAMES: &[&str] = &["server.db", "data.db"];
+
+/// Returns paths of known legacy database files that exist on disk.
+///
+/// Only filenames listed in `LEGACY_DB_NAMES` and located in the same directory
+/// as `current` are returned. The `current` path itself is never included.
+pub fn stale_db_candidates(current: &Path) -> Vec<PathBuf> {
+    let Some(parent) = current.parent() else {
+        return Vec::new();
+    };
+    LEGACY_DB_NAMES
+        .iter()
+        .map(|name| parent.join(name))
+        .filter(|p| p.exists() && p != current)
+        .collect()
+}
+
 fn env_path(key: &str) -> Option<PathBuf> {
     std::env::var(key).ok().and_then(|raw| {
         let trimmed = raw.trim().to_string();


### PR DESCRIPTION
## Summary

- Adds `stale_db_candidates()` to `packages/core/src/infra/paths.rs` as the single authoritative list of legacy database filenames (`server.db`, `data.db`) — no other file in the codebase references these strings
- Adds `packages/core/src/infra/db_migration.rs` with `migrate_stale_dbs(target)`: detects legacy files, backs each up (`.pre-migration.bak`), copies rows into the canonical target via `INSERT OR IGNORE` (target wins on conflict), renames legacy to `.migrated` so the migration is a one-shot operation
- Wires the migration call into all three entry points (server, desktop, CLI) before `SqliteStore::open()` — non-fatal; a warning is emitted but startup continues even if migration fails

## What/Why

Fixes U-11 data split: older binaries hardcoded `server.db` or `data.db` as their default path. Users who ran those binaries have rows stranded outside the canonical `refine.db`. The new migration merges that data automatically on first startup with the updated binaries.

## Test plan

- [ ] `cargo test --workspace` — 6 new tests in `infra::db_migration::tests` all pass (156 total, 0 failures)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all` — clean
- [ ] Manual: place a `server.db` with rows in `~/Library/Application Support/refine/`, run `refine list`, confirm rows appear and `server.db.migrated` exists

## AI Role

Migration logic is AI-generated. Risk: **medium** (file I/O + SQLite ATTACH). Key areas for human review:
- `copy_table` column intersection logic (ensures schema-evolution safety)
- `with_suffix` path construction on non-ASCII paths
- WAL companion-file rename after migration

Closes #67