### PR TITLE
perf(ingest): mtime-based incremental scan — skip ~99% of already-seen files

### DIFF
--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -11,7 +11,7 @@ use refine_core::session::{
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use tokio::sync::Semaphore;
 
 const MAX_RETRIES: usize = 5;
@@ -38,14 +38,53 @@ struct PendingSession {
     chunks: Vec<String>,
 }
 
+/// Read the Unix-second timestamp from `~/.refine/last-ingest-mtime`.
+fn read_last_ingest_mtime() -> Option<SystemTime> {
+    let path = dirs::home_dir()?.join(".refine").join("last-ingest-mtime");
+    let secs: u64 = std::fs::read_to_string(path).ok()?.trim().parse().ok()?;
+    Some(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
+}
+
+/// Persist the Unix-second timestamp to `~/.refine/last-ingest-mtime`.
+fn write_last_ingest_mtime(t: SystemTime) {
+    let Some(home) = dirs::home_dir() else { return };
+    let dir = home.join(".refine");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!("failed to create ~/.refine: {}", e);
+        return;
+    }
+    if let Ok(dur) = t.duration_since(SystemTime::UNIX_EPOCH) {
+        if let Err(e) = std::fs::write(dir.join("last-ingest-mtime"), dur.as_secs().to_string()) {
+            tracing::warn!("failed to write last-ingest-mtime: {}", e);
+        }
+    }
+}
+
 pub async fn handle_ingest_sessions(
     options: IngestOptions,
     item_store: Arc<dyn ItemRepository>,
     doc_store: Arc<dyn DocumentRepository>,
     llm_client: Option<Arc<dyn LlmClient>>,
 ) -> Result<()> {
-    let mut discovered = discover_sessions(options.source);
-    println!("发现 {} 个会话文件", discovered.len());
+    // Incremental scan: only active for full (no --limit/--latest) non-dry-run runs.
+    // 1-hour overlap on the cutoff absorbs clock skew and files modified near the boundary.
+    let incremental = options.limit.is_none() && options.latest.is_none() && !options.dry_run;
+    let scan_start = SystemTime::now();
+    let mtime_after = if incremental {
+        read_last_ingest_mtime().map(|last| {
+            last.checked_sub(Duration::from_secs(3600))
+                .unwrap_or(SystemTime::UNIX_EPOCH)
+        })
+    } else {
+        None
+    };
+
+    let mut discovered = discover_sessions(options.source, mtime_after);
+    if mtime_after.is_some() {
+        println!("增量扫描：发现 {} 个会话文件", discovered.len());
+    } else {
+        println!("发现 {} 个会话文件", discovered.len());
+    }
 
     // --latest: sort by mtime descending, keep N most recent
     if let Some(n) = options.latest {
@@ -193,6 +232,11 @@ pub async fn handle_ingest_sessions(
     if failed > 0 {
         eprintln!("提示: 重新运行即可续传失败的会话");
         return Err(anyhow::anyhow!("{} 个会话提取失败", failed));
+    }
+
+    // Advance the incremental scan cursor so the next run only sees newer files.
+    if incremental {
+        write_last_ingest_mtime(scan_start);
     }
 
     Ok(())

--- a/packages/core/src/session/discovery.rs
+++ b/packages/core/src/session/discovery.rs
@@ -21,18 +21,24 @@ pub struct DiscoveredSession {
 ///
 /// Claude Code: `~/.claude/projects/*/*.jsonl`
 /// Codex:       `~/.codex/sessions/**/*.jsonl`
-pub fn discover_sessions(source_filter: Option<SessionSource>) -> Vec<DiscoveredSession> {
+///
+/// `mtime_after`: 仅返回 `modified_at >= mtime_after` 的文件；`None` 返回全部。
+pub fn discover_sessions(
+    source_filter: Option<SessionSource>,
+    mtime_after: Option<SystemTime>,
+) -> Vec<DiscoveredSession> {
     let home = match dirs::home_dir() {
         Some(h) => h,
         None => return Vec::new(),
     };
-    discover_sessions_in(&home, source_filter)
+    discover_sessions_in(&home, source_filter, mtime_after)
 }
 
 /// 可测试版本：指定 home 目录
 pub fn discover_sessions_in(
     home: &Path,
     source_filter: Option<SessionSource>,
+    mtime_after: Option<SystemTime>,
 ) -> Vec<DiscoveredSession> {
     let mut results = Vec::new();
 
@@ -40,20 +46,24 @@ pub fn discover_sessions_in(
         .as_ref()
         .map_or(true, |s| *s == SessionSource::ClaudeCode)
     {
-        discover_claude_code(home, &mut results);
+        discover_claude_code(home, &mut results, mtime_after);
     }
     if source_filter
         .as_ref()
         .map_or(true, |s| *s == SessionSource::Codex)
     {
-        discover_codex(home, &mut results);
+        discover_codex(home, &mut results, mtime_after);
     }
 
     results.sort_by(|a, b| a.path.cmp(&b.path));
     results
 }
 
-fn discover_claude_code(home: &Path, results: &mut Vec<DiscoveredSession>) {
+fn discover_claude_code(
+    home: &Path,
+    results: &mut Vec<DiscoveredSession>,
+    mtime_after: Option<SystemTime>,
+) {
     let projects_dir = home.join(".claude").join("projects");
     let entries = match std::fs::read_dir(&projects_dir) {
         Ok(e) => e,
@@ -99,6 +109,9 @@ fn discover_claude_code(home: &Path, results: &mut Vec<DiscoveredSession>) {
                         warn!(path = %path.display(), error = %e, "failed to read mtime; file treated as oldest for --latest");
                         SystemTime::UNIX_EPOCH
                     });
+                if mtime_after.is_some_and(|cutoff| modified_at < cutoff) {
+                    continue;
+                }
                 results.push(DiscoveredSession {
                     path,
                     source: SessionSource::ClaudeCode,
@@ -110,12 +123,21 @@ fn discover_claude_code(home: &Path, results: &mut Vec<DiscoveredSession>) {
     }
 }
 
-fn discover_codex(home: &Path, results: &mut Vec<DiscoveredSession>) {
+fn discover_codex(
+    home: &Path,
+    results: &mut Vec<DiscoveredSession>,
+    mtime_after: Option<SystemTime>,
+) {
     let sessions_dir = home.join(".codex").join("sessions");
-    walk_jsonl_recursive(&sessions_dir, SessionSource::Codex, results);
+    walk_jsonl_recursive(&sessions_dir, SessionSource::Codex, results, mtime_after);
 }
 
-fn walk_jsonl_recursive(dir: &Path, source: SessionSource, results: &mut Vec<DiscoveredSession>) {
+fn walk_jsonl_recursive(
+    dir: &Path,
+    source: SessionSource,
+    results: &mut Vec<DiscoveredSession>,
+    mtime_after: Option<SystemTime>,
+) {
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(_) => return,
@@ -128,7 +150,7 @@ fn walk_jsonl_recursive(dir: &Path, source: SessionSource, results: &mut Vec<Dis
             if path.file_name().is_some_and(|n| n == "subagents") {
                 continue;
             }
-            walk_jsonl_recursive(&path, source.clone(), results);
+            walk_jsonl_recursive(&path, source.clone(), results, mtime_after);
         } else if is_session_jsonl(&path) && !is_subagent_file(&path) {
             let modified_at = entry
                 .metadata()
@@ -137,6 +159,9 @@ fn walk_jsonl_recursive(dir: &Path, source: SessionSource, results: &mut Vec<Dis
                     warn!(path = %path.display(), error = %e, "failed to read mtime; file treated as oldest for --latest");
                     SystemTime::UNIX_EPOCH
                 });
+            if mtime_after.is_some_and(|cutoff| modified_at < cutoff) {
+                continue;
+            }
             results.push(DiscoveredSession {
                 path,
                 source: source.clone(),
@@ -182,7 +207,7 @@ mod tests {
         fs::write(project_dir.join("agent-sub.jsonl"), "{}").unwrap();
         fs::write(project_dir.join("notes.txt"), "not a session").unwrap();
 
-        let results = discover_sessions_in(home, Some(SessionSource::ClaudeCode));
+        let results = discover_sessions_in(home, Some(SessionSource::ClaudeCode), None);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].source, SessionSource::ClaudeCode);
         assert_eq!(results[0].project.as_deref(), Some("my-project"));
@@ -203,7 +228,7 @@ mod tests {
         fs::create_dir_all(&sub_dir).unwrap();
         fs::write(sub_dir.join("sub.jsonl"), "{}").unwrap();
 
-        let results = discover_sessions_in(home, Some(SessionSource::Codex));
+        let results = discover_sessions_in(home, Some(SessionSource::Codex), None);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].source, SessionSource::Codex);
     }
@@ -221,10 +246,10 @@ mod tests {
         fs::create_dir_all(&codex_dir).unwrap();
         fs::write(codex_dir.join("s2.jsonl"), "{}").unwrap();
 
-        let claude_only = discover_sessions_in(home, Some(SessionSource::ClaudeCode));
+        let claude_only = discover_sessions_in(home, Some(SessionSource::ClaudeCode), None);
         assert_eq!(claude_only.len(), 1);
 
-        let all = discover_sessions_in(home, None);
+        let all = discover_sessions_in(home, None, None);
         assert_eq!(all.len(), 2);
     }
 
@@ -237,7 +262,7 @@ mod tests {
         fs::create_dir_all(&project_dir).unwrap();
         fs::write(project_dir.join("sess.jsonl"), "{}").unwrap();
 
-        let results = discover_sessions_in(home, Some(SessionSource::ClaudeCode));
+        let results = discover_sessions_in(home, Some(SessionSource::ClaudeCode), None);
         assert_eq!(results.len(), 1);
         // A freshly-created file must have mtime > UNIX_EPOCH
         assert!(results[0].modified_at > SystemTime::UNIX_EPOCH);
@@ -261,7 +286,7 @@ mod tests {
             filetime::set_file_mtime(&p, t).unwrap();
         }
 
-        let mut discovered = discover_sessions_in(home, Some(SessionSource::ClaudeCode));
+        let mut discovered = discover_sessions_in(home, Some(SessionSource::ClaudeCode), None);
         assert_eq!(discovered.len(), 5);
 
         // Simulate --latest 3
@@ -287,7 +312,7 @@ mod tests {
             fs::write(project_dir.join(name), "{}").unwrap();
         }
 
-        let mut discovered = discover_sessions_in(home, Some(SessionSource::ClaudeCode));
+        let mut discovered = discover_sessions_in(home, Some(SessionSource::ClaudeCode), None);
         // --latest 100 on 3 files
         discovered.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
         discovered.truncate(100);
@@ -306,7 +331,7 @@ mod tests {
         }
 
         // discover_sessions_in already sorts by path
-        let discovered = discover_sessions_in(home, Some(SessionSource::ClaudeCode));
+        let discovered = discover_sessions_in(home, Some(SessionSource::ClaudeCode), None);
         let limited: Vec<_> = discovered.into_iter().take(2).collect();
         assert_eq!(limited.len(), 2);
         let names: Vec<&str> = limited
@@ -314,5 +339,29 @@ mod tests {
             .map(|s| s.path.file_name().unwrap().to_str().unwrap())
             .collect();
         assert_eq!(names, vec!["a.jsonl", "b.jsonl"]);
+    }
+
+    #[test]
+    fn mtime_after_filters_old_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        let project_dir = home.join(".claude/projects/proj");
+        fs::create_dir_all(&project_dir).unwrap();
+
+        // old.jsonl: mtime = epoch + 1000 s (definitely old)
+        // new.jsonl: mtime = epoch + 9000 s (newer)
+        let old_path = project_dir.join("old.jsonl");
+        let new_path = project_dir.join("new.jsonl");
+        fs::write(&old_path, "{}").unwrap();
+        fs::write(&new_path, "{}").unwrap();
+        filetime::set_file_mtime(&old_path, filetime::FileTime::from_unix_time(1000, 0)).unwrap();
+        filetime::set_file_mtime(&new_path, filetime::FileTime::from_unix_time(9000, 0)).unwrap();
+
+        // cutoff = epoch + 5000 s — only new.jsonl should pass
+        let cutoff = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(5000);
+        let results = discover_sessions_in(home, Some(SessionSource::ClaudeCode), Some(cutoff));
+        assert_eq!(results.len(), 1);
+        assert!(results[0].path.file_name().unwrap() == "new.jsonl");
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `discover_sessions` walked the entire `~/.claude/projects/**/*.jsonl` tree (~7 495 files) on every daily run, then performed a DB duplicate-check for each file. Only ~53 files were new (~0.7% hit rate).
- **Fix**: add `mtime_after: Option<SystemTime>` to `discover_sessions` / `discover_sessions_in`. The CLI reads `~/.refine/last-ingest-mtime`, subtracts a 1-hour clock-skew buffer, and passes the cutoff into the directory walk — files older than the cutoff are skipped before any DB query.
- **Cursor update**: after a successful full ingest the marker is written; subsequent runs are incremental. `--limit`, `--latest`, and `--dry-run` bypass the incremental path so their behaviour is unchanged.

## Changed files

| File | Change |
|------|--------|
| `packages/core/src/session/discovery.rs` | Add `mtime_after` param to public + private fns; apply filter in both Claude Code and Codex walks; add `mtime_after_filters_old_files` test |
| `apps/cli/src/ingest_sessions.rs` | Add `read_last_ingest_mtime` / `write_last_ingest_mtime` helpers; wire incremental logic into `handle_ingest_sessions` |

## Test plan

- [ ] `cargo test --workspace` — all 203 tests pass, including new `mtime_after_filters_old_files`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] First run (no marker): full scan, marker written to `~/.refine/last-ingest-mtime`
- [ ] Second run: log shows `增量扫描：发现 N 个会话文件` where N ≪ 7 495
- [ ] `refine ingest-sessions --latest 10` and `--limit 5`: marker not used/updated (scope explicit)

Closes #68