### PR TITLE
feat: move cognitive-portrait skill into version control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  skill-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify skill files present
+        run: |
+          for f in skills/cognitive-portrait/SKILL.md \
+                    skills/cognitive-portrait/prompts/l1_cognitive_evolution.md \
+                    skills/cognitive-portrait/prompts/l2_strategic_positioning.md \
+                    skills/cognitive-portrait/prompts/l3_work_health.md \
+                    skills/cognitive-portrait/prompts/l4_growth_prescription.md; do
+            test -f "$f" || { echo "Missing: $f"; exit 1; }
+          done
+
   check:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ REFINE_OPENAI_BASE_URL=https://api.openai.com
 REFINE_OPENAI_MODEL=gpt-4o
 EOF
 
+# Set up Claude Code skills (one-time symlink)
+ln -s "$(pwd)/skills/cognitive-portrait" ~/.claude/skills/cognitive-portrait
+# If ~/.claude/skills/cognitive-portrait already exists as a directory (old copy),
+# delete it first: rm -rf ~/.claude/skills/cognitive-portrait
+
 # Import your AI coding sessions
 refine ingest-sessions
 

--- a/docs/cognitive-portraits/SPEC.md
+++ b/docs/cognitive-portraits/SPEC.md
@@ -109,12 +109,17 @@ docs/cognitive-portraits/cognitive-portrait-{date}-v3.md
 
 ### 4.2 新增 prompt 模板
 
-- `~/.claude/skills/cognitive-portrait/prompts/l1_cognitive_evolution.md`
-- `~/.claude/skills/cognitive-portrait/prompts/l2_strategic_positioning.md`
-- `~/.claude/skills/cognitive-portrait/prompts/l3_work_health.md`
-- `~/.claude/skills/cognitive-portrait/prompts/l4_growth_prescription.md`
+代码位置（版本控制内）：
+
+- `skills/cognitive-portrait/SKILL.md` — Dispatcher 主 prompt
+- `skills/cognitive-portrait/prompts/l1_cognitive_evolution.md`
+- `skills/cognitive-portrait/prompts/l2_strategic_positioning.md`
+- `skills/cognitive-portrait/prompts/l3_work_health.md`
+- `skills/cognitive-portrait/prompts/l4_growth_prescription.md`
 
 每个模板包含：数据源列表 + 强制约束 + 章节大纲 + 风格参考 + 输出路径。
+
+Claude Code 通过 `~/.claude/skills/cognitive-portrait` 发现技能，该路径应是指向本仓库 `skills/cognitive-portrait/` 的符号链接（见 `docs/setup-skills.md`）。
 
 ### 4.3 合并阶段
 

--- a/docs/cognitive-portraits/refine-data-pipelines.md
+++ b/docs/cognitive-portraits/refine-data-pipelines.md
@@ -14,7 +14,7 @@
 - 1 条核心 LLM 聚合链路（`refine insights --prescription`，~10+1 次 LLM 并发）
 - 4 条 mirror 子命令（`score` / `motd` / `dashboard` / `weekly` / `profile`）
 - 2 条由 launchd 调度的 shell 脚本（daily/weekly）
-- 1 条外部 skill（`cognitive-portrait`，不在 Rust 代码，但读 refine.db）
+- 1 条 in-repo skill（`cognitive-portrait`，在 `skills/` 目录，通过符号链接接入 Claude Code，读 refine.db）
 
 **核心结论**：除 `ingest-sessions` 外，所有链路都是对已经落库的 Observation 数据做聚合加工。`refine insights --prescription` 是 LLM 调用最重、耗时最长的链路（~11 次 LLM，10 并发）；`mirror score` 在原始职责"纯 SQL 聚合"之外，实际上也会调用 LLM 生成 advice（单次，带 72h 缓存）。
 
@@ -226,12 +226,12 @@ AI IDE JSONL 文件
 
 ---
 
-### 链路 9: cognitive-portrait skill（外部 Claude Code skill）
+### 链路 9: cognitive-portrait skill（in-repo Claude Code skill）
 
 | 字段 | 内容 |
 |---|---|
 | 命令入口 | Claude Code skill 触发词："认知画像" / "cognitive portrait" / "认知分析" / "分析我的成长" |
-| 代码位置 | `~/.claude/skills/cognitive-portrait/SKILL.md` + `prompts/`（**不在 refine 代码库中**） |
+| 代码位置 | `skills/cognitive-portrait/SKILL.md` + `prompts/`（在 refine 代码库中；`~/.claude/skills/cognitive-portrait` 为符号链接，见 `docs/setup-skills.md`）|
 | 触发方式 | 用户在 Claude Code 对话中触发 |
 | 数据来源 | 直接用 `sqlite3` 读 refine.db + 调 `mirror score` 命令 |
 | 处理步骤 | 1) Dispatcher 跑 SQL 采集 8 个数据文件到 `/tmp/cp_data_*.txt`；2) 派发 4 个 Task sub-agent 并行（W-14 文件所有权隔离），分别写 L1/L2/L3/L4 markdown；3) Dispatcher 合并写盘 |

--- a/docs/setup-skills.md
+++ b/docs/setup-skills.md
@@ -1,0 +1,40 @@
+# Setting Up Claude Code Skills
+
+This repo ships Claude Code skills under `skills/`. They must be symlinked into
+`~/.claude/skills/` before Claude Code can discover them.
+
+## cognitive-portrait
+
+### One-time setup
+
+```bash
+# 1. If you have an old external copy, remove it first
+[ -d ~/.claude/skills/cognitive-portrait ] && \
+  [ ! -L ~/.claude/skills/cognitive-portrait ] && \
+  rm -rf ~/.claude/skills/cognitive-portrait
+
+# 2. Create the symlink (replace <repo-path> with the absolute path to this repo)
+ln -s <repo-path>/skills/cognitive-portrait ~/.claude/skills/cognitive-portrait
+```
+
+Example with a typical clone location:
+
+```bash
+ln -s ~/Desktop/code/AI/tool/refine/skills/cognitive-portrait \
+      ~/.claude/skills/cognitive-portrait
+```
+
+### Verify
+
+```bash
+ls -la ~/.claude/skills/cognitive-portrait
+# Should show: ... -> /path/to/repo/skills/cognitive-portrait
+```
+
+If it shows a plain directory instead of a symlink (`->` arrow), you still have
+the old external copy. Delete it and re-run step 2 above.
+
+### Pattern
+
+This follows the `~/.claude/skills/SYMLINKS.md` convention already in use.
+Skills live in version control; `~/.claude/skills/` holds symlinks only.

--- a/skills/cognitive-portrait/SKILL.md
+++ b/skills/cognitive-portrait/SKILL.md
@@ -1,0 +1,224 @@
+# Authoritative spec: docs/cognitive-portraits/SPEC.md
+
+# Cognitive Portrait v3 — Dispatcher
+
+Trigger keywords: 认知画像 / cognitive portrait / 认知分析 / 分析我的成长
+
+---
+
+## Overview
+
+This is the **Dispatcher** skill. It orchestrates v3 multi-agent parallel architecture:
+
+1. **Stage 1** — SQL data collection: run 8 queries against `refine.db`, write results to `/tmp/cp_data_*.txt`
+2. **Stage 2** — Dispatch 4 Task agents in parallel, each writing one layer with explicit file ownership (W-14)
+3. **Stage 3** — Load temp files, run acceptance checks, merge, write final report
+
+---
+
+## Stage 1: Data Collection
+
+Determine the report version number N (count existing `docs/cognitive-portraits/cognitive-portrait-*-v3.md` files + 1, minimum 1).
+
+Run the following 8 SQL queries against `refine.db` using `sqlite3`. Write each result to the corresponding `/tmp/cp_data_N.txt` file, where N matches the query number.
+
+```bash
+# Set DB path
+DB=$(ls ~/.local/share/refine/refine.db ~/.refine/refine.db 2>/dev/null | head -1)
+[ -z "$DB" ] && { echo "ERROR: refine.db not found"; exit 1; }
+
+# Query 1: Recent observations overview (last 90 days)
+sqlite3 "$DB" "
+SELECT i.cognitive_level, i.collaboration_mode, i.tool,
+       substr(i.created_at,1,10) as date, i.title
+FROM items i
+WHERE i.item_type='observation'
+  AND i.created_at >= date('now','-90 days')
+ORDER BY i.created_at DESC
+LIMIT 200
+" > /tmp/cp_data_1.txt
+
+# Query 2: Decision patterns
+sqlite3 "$DB" "
+SELECT i.title, i.content, substr(i.created_at,1,10) as date
+FROM items i
+WHERE i.item_type='observation'
+  AND i.decision IS NOT NULL AND i.decision != ''
+  AND i.created_at >= date('now','-90 days')
+ORDER BY i.created_at DESC
+LIMIT 100
+" > /tmp/cp_data_2.txt
+
+# Query 3: Bug fix patterns
+sqlite3 "$DB" "
+SELECT i.title, i.content, substr(i.created_at,1,10) as date
+FROM items i
+WHERE i.item_type='observation'
+  AND i.bugfix IS NOT NULL AND i.bugfix != ''
+  AND i.created_at >= date('now','-90 days')
+ORDER BY i.created_at DESC
+LIMIT 100
+" > /tmp/cp_data_3.txt
+
+# Query 4: Knowledge and patterns acquired
+sqlite3 "$DB" "
+SELECT i.title, i.knowledge, i.pattern, i.architecture,
+       substr(i.created_at,1,10) as date
+FROM items i
+WHERE i.item_type='observation'
+  AND (i.knowledge IS NOT NULL OR i.pattern IS NOT NULL)
+  AND i.created_at >= date('now','-90 days')
+ORDER BY i.created_at DESC
+LIMIT 100
+" > /tmp/cp_data_4.txt
+
+# Query 5: Friction and collaboration mode
+sqlite3 "$DB" "
+SELECT i.collaboration_mode, i.friction, i.tool,
+       substr(i.created_at,1,10) as date, i.title
+FROM items i
+WHERE i.item_type='observation'
+  AND i.created_at >= date('now','-90 days')
+ORDER BY i.created_at DESC
+LIMIT 150
+" > /tmp/cp_data_5.txt
+
+# Query 6: Project distribution
+sqlite3 "$DB" "
+SELECT d.url, count(*) as obs_count,
+       min(substr(i.created_at,1,10)) as first_seen,
+       max(substr(i.created_at,1,10)) as last_seen
+FROM items i
+JOIN documents d ON i.document_id = d.id
+WHERE i.item_type='observation'
+  AND i.created_at >= date('now','-90 days')
+GROUP BY d.url
+ORDER BY obs_count DESC
+LIMIT 50
+" > /tmp/cp_data_6.txt
+
+# Query 7: Cognitive level distribution over time
+sqlite3 "$DB" "
+SELECT substr(i.created_at,1,7) as month,
+       i.cognitive_level,
+       count(*) as cnt
+FROM items i
+WHERE i.item_type='observation'
+  AND i.created_at >= date('now','-180 days')
+GROUP BY month, i.cognitive_level
+ORDER BY month, i.cognitive_level
+" > /tmp/cp_data_7.txt
+
+# Query 8: Recent session insights documents
+sqlite3 "$DB" "
+SELECT d.title, d.raw_content, substr(d.created_at,1,10) as date
+FROM documents d
+WHERE d.source IN ('session-insights-v2','mirror-weekly','mirror-profile')
+  AND d.created_at >= date('now','-30 days')
+ORDER BY d.created_at DESC
+LIMIT 5
+" > /tmp/cp_data_8.txt
+```
+
+Also run `mirror score` and capture output to `/tmp/cp_mirror_score.txt`.
+
+Verify all 8 data files are non-empty. If any are empty, log a warning but continue.
+
+---
+
+## Stage 2: Dispatch 4 Parallel Sub-agents
+
+Use the Task tool to dispatch 4 sub-agents in parallel. Each agent receives:
+- The path to its prompt template (in this repo under `skills/cognitive-portrait/prompts/`)
+- Its explicit file ownership declaration
+- The paths to all 8 data files (read-only)
+- The version number N
+
+**File ownership declarations (W-14 — no agent may write another agent's file):**
+
+```
+Agent L1 owns: /tmp/cp_v{N}_l1.md ONLY — do not create or modify any other file
+Agent L2 owns: /tmp/cp_v{N}_l2.md ONLY — do not create or modify any other file
+Agent L3 owns: /tmp/cp_v{N}_l3.md ONLY — do not create or modify any other file
+Agent L4 owns: /tmp/cp_v{N}_l4.md ONLY — do not create or modify any other file
+```
+
+Load each prompt template from `skills/cognitive-portrait/prompts/l{N}_*.md` and pass it verbatim to the corresponding sub-agent, appending the data file paths and the file ownership declaration.
+
+---
+
+## Stage 3: Merge and Write Final Report
+
+After all 4 sub-agents complete:
+
+### 3.1 Acceptance Checks
+
+```bash
+for layer in 1 2 3 4; do
+  file="/tmp/cp_v${N}_l${layer}.md"
+  lines=$(wc -l < "$file" 2>/dev/null || echo 0)
+  if [ "$layer" -le 3 ] && [ "$lines" -lt 250 ]; then
+    echo "WARNING: L${layer} has ${lines} lines (minimum 250)"
+  fi
+  if [ "$layer" -eq 4 ] && [ "$lines" -lt 280 ]; then
+    echo "WARNING: L4 has ${lines} lines (minimum 280)"
+  fi
+done
+```
+
+If any layer fails the line count check, log the warning but continue with the merge (do not abort).
+
+### 3.2 Style Unification Pass
+
+Before merging, scan all 4 layer files and ensure:
+- All confidence labels use format: `[推断，置信度：高/中/低]`
+- All fact labels use: `[事实]`
+- All suggestion labels use: `[建议]`
+- Tables use consistent `|---|` separator style
+
+### 3.3 Build Header
+
+```markdown
+---
+date: {YYYY-MM-DD}
+version: v3
+sessions_analyzed: {count from data file 1}
+total_lines: {will fill after merge}
+---
+
+# 认知画像 v3 — {YYYY-MM-DD}
+
+> 生成架构：Dispatcher + 4 并行 Sub-agent（L1/L2/L3/L4）
+> 数据范围：最近 90 天观测 + 180 天认知等级时序
+> 版本对比基准：2026-03-21 v0（978 行）
+
+## 总体判断
+
+[Dispatcher 根据 mirror score 和数据文件写 2-3 段总体判断，包含三分离标签]
+```
+
+### 3.4 Concatenate and Write
+
+Concatenate: header + L1 content + L2 content + L3 content + L4 content
+
+Write to: `docs/cognitive-portraits/cognitive-portrait-{date}-v3.md`
+
+### 3.5 Update INDEX.md
+
+Append a row to `docs/cognitive-portraits/INDEX.md`:
+
+```
+| {date} | {sessions_count} | {total_lines} | {L1_lines} | {L2_lines} | {L3_lines} | {L4_lines} | {pass/fail} |
+```
+
+---
+
+## Preflight Checks
+
+Before Stage 1, verify:
+1. `refine.db` exists and is readable
+2. `mirror` binary is available (`which mirror`)
+3. `docs/cognitive-portraits/` directory exists
+4. If `~/.claude/skills/cognitive-portrait` is a symlink pointing to this repo's `skills/cognitive-portrait/` — log the path for traceability
+
+If preflight fails, report the specific failure and stop.

--- a/skills/cognitive-portrait/prompts/l1_cognitive_evolution.md
+++ b/skills/cognitive-portrait/prompts/l1_cognitive_evolution.md
@@ -1,0 +1,76 @@
+# L1 Sub-agent: 认知演进分析
+
+## File Ownership (W-14)
+
+**You own ONLY: `/tmp/cp_v{N}_l1.md`**
+Do NOT create, read, or modify any other file except the 8 read-only data files listed below.
+
+## Data Sources (read-only)
+
+- `/tmp/cp_data_1.txt` — Recent observations overview (last 90 days)
+- `/tmp/cp_data_2.txt` — Decision patterns
+- `/tmp/cp_data_3.txt` — Bug fix patterns
+- `/tmp/cp_data_4.txt` — Knowledge and patterns acquired
+- `/tmp/cp_data_5.txt` — Friction and collaboration mode
+- `/tmp/cp_data_6.txt` — Project distribution
+- `/tmp/cp_data_7.txt` — Cognitive level distribution over time
+- `/tmp/cp_data_8.txt` — Recent session insights documents
+
+## Mandatory Constraints
+
+1. **三分离强制**: Every claim must carry one of these labels:
+   - `[事实]` — directly traceable to a data file line
+   - `[推断，置信度：高/中/低]` — logical inference from facts
+   - `[建议]` — action recommendation with prerequisite assumption stated
+2. **精确数值**: All numbers in `N/M(百分比%)` format where applicable
+3. **矩阵化优先**: Use tables over bullet lists when 3+ items can be compared
+4. **行数硬下限**: This file MUST be ≥ 250 lines when complete
+5. **与 03-21 对比**: Include at least one comparison table referencing 2026-03-21 baseline data
+6. **范围隔离**: Write ONLY L1 content (认知演进). Do NOT write L2 (战略定位), L3 (工作方式), or L4 (成长处方) content.
+
+## Output Path
+
+Write your complete analysis to: `/tmp/cp_v{N}_l1.md`
+
+## Section Outline
+
+Your output must follow this exact structure (H2 + H3 hierarchy):
+
+```
+## L1：认知演进
+
+### 1.1 认知等级时序分析
+
+[Time series table: month × cognitive_level × count from data_7.txt]
+[Trend analysis with [事实] labels]
+[Inference about trajectory with confidence]
+
+### 1.2 决策质量演进
+
+[Analysis of decision patterns from data_2.txt]
+[Comparison: current vs 2026-03-21 baseline]
+[Table: decision category × frequency × quality signal]
+
+### 1.3 知识积累与模式识别
+
+[Analysis from data_4.txt: knowledge types, pattern density]
+[Table: knowledge domain × sessions × depth signal]
+[Inferences about learning velocity]
+
+### 1.4 认知瓶颈识别
+
+[What is NOT progressing? What cognitive levels are stagnant?]
+[Table: bottleneck × evidence × confidence × impact]
+[Suggestions with prerequisite assumptions]
+```
+
+## Style Reference
+
+Minimum density targets:
+- Section 1.1: ≥ 60 lines (time series data + analysis)
+- Section 1.2: ≥ 60 lines (decision analysis + comparison table)
+- Section 1.3: ≥ 60 lines (knowledge analysis + tables)
+- Section 1.4: ≥ 70 lines (bottleneck analysis + suggestions)
+
+Every paragraph must end with a labeled claim or labeled table row.
+Do not use vague phrases like "this seems to indicate" — use explicit confidence labels instead.

--- a/skills/cognitive-portrait/prompts/l2_strategic_positioning.md
+++ b/skills/cognitive-portrait/prompts/l2_strategic_positioning.md
@@ -1,0 +1,76 @@
+# L2 Sub-agent: 战略定位分析
+
+## File Ownership (W-14)
+
+**You own ONLY: `/tmp/cp_v{N}_l2.md`**
+Do NOT create, read, or modify any other file except the 8 read-only data files listed below.
+
+## Data Sources (read-only)
+
+- `/tmp/cp_data_1.txt` — Recent observations overview (last 90 days)
+- `/tmp/cp_data_2.txt` — Decision patterns
+- `/tmp/cp_data_3.txt` — Bug fix patterns
+- `/tmp/cp_data_4.txt` — Knowledge and patterns acquired
+- `/tmp/cp_data_5.txt` — Friction and collaboration mode
+- `/tmp/cp_data_6.txt` — Project distribution
+- `/tmp/cp_data_7.txt` — Cognitive level distribution over time
+- `/tmp/cp_data_8.txt` — Recent session insights documents
+
+## Mandatory Constraints
+
+1. **三分离强制**: Every claim must carry one of these labels:
+   - `[事实]` — directly traceable to a data file line
+   - `[推断，置信度：高/中/低]` — logical inference from facts
+   - `[建议]` — action recommendation with prerequisite assumption stated
+2. **精确数值**: All numbers in `N/M(百分比%)` format where applicable
+3. **矩阵化优先**: Use tables over bullet lists when 3+ items can be compared
+4. **行数硬下限**: This file MUST be ≥ 250 lines when complete
+5. **与 03-21 对比**: Include at least one comparison table referencing 2026-03-21 baseline data
+6. **范围隔离**: Write ONLY L2 content (战略定位). Do NOT write L1 (认知演进), L3 (工作方式), or L4 (成长处方) content.
+
+## Output Path
+
+Write your complete analysis to: `/tmp/cp_v{N}_l2.md`
+
+## Section Outline
+
+Your output must follow this exact structure (H2 + H3 hierarchy):
+
+```
+## L2：战略定位
+
+### 2.1 项目投入分布与战略对齐
+
+[Table from data_6.txt: project × obs_count × first_seen × last_seen × strategic_signal]
+[Analysis: which projects are getting disproportionate vs insufficient attention]
+[Comparison with 2026-03-21 project distribution]
+
+### 2.2 技术栈演化路径
+
+[From data_1.txt + data_4.txt: what tools and technologies appear most frequently]
+[Table: technology × frequency × trend (growing/stable/declining)]
+[Inference about tech bet concentration risk]
+
+### 2.3 AI 协作模式战略评估
+
+[From data_5.txt: collaboration_mode distribution]
+[Table: collaboration_mode × count × percentage × strategic_implication]
+[Are you leveraging AI at the right level for strategic work?]
+
+### 2.4 战略盲区与机会窗口
+
+[What is missing from the data? Which domains are under-invested?]
+[Table: opportunity × evidence_for × evidence_against × confidence × suggested_action]
+[Suggestions with prerequisite assumptions and alternatives]
+```
+
+## Style Reference
+
+Minimum density targets:
+- Section 2.1: ≥ 65 lines (project analysis + tables + comparison)
+- Section 2.2: ≥ 60 lines (tech stack analysis + trend table)
+- Section 2.3: ≥ 55 lines (collaboration mode analysis)
+- Section 2.4: ≥ 70 lines (opportunity/gap analysis + suggestions)
+
+Every paragraph must end with a labeled claim or labeled table row.
+Do not use vague phrases like "it appears that" — use explicit confidence labels instead.

--- a/skills/cognitive-portrait/prompts/l3_work_health.md
+++ b/skills/cognitive-portrait/prompts/l3_work_health.md
@@ -1,0 +1,78 @@
+# L3 Sub-agent: 工作方式健康度分析
+
+## File Ownership (W-14)
+
+**You own ONLY: `/tmp/cp_v{N}_l3.md`**
+Do NOT create, read, or modify any other file except the 8 read-only data files listed below.
+
+## Data Sources (read-only)
+
+- `/tmp/cp_data_1.txt` — Recent observations overview (last 90 days)
+- `/tmp/cp_data_2.txt` — Decision patterns
+- `/tmp/cp_data_3.txt` — Bug fix patterns
+- `/tmp/cp_data_4.txt` — Knowledge and patterns acquired
+- `/tmp/cp_data_5.txt` — Friction and collaboration mode
+- `/tmp/cp_data_6.txt` — Project distribution
+- `/tmp/cp_data_7.txt` — Cognitive level distribution over time
+- `/tmp/cp_data_8.txt` — Recent session insights documents
+
+## Mandatory Constraints
+
+1. **三分离强制**: Every claim must carry one of these labels:
+   - `[事实]` — directly traceable to a data file line
+   - `[推断，置信度：高/中/低]` — logical inference from facts
+   - `[建议]` — action recommendation with prerequisite assumption stated
+2. **精确数值**: All numbers in `N/M(百分比%)` format where applicable
+3. **矩阵化优先**: Use tables over bullet lists when 3+ items can be compared
+4. **行数硬下限**: This file MUST be ≥ 250 lines when complete
+5. **与 03-21 对比**: Include at least one comparison table referencing 2026-03-21 baseline data
+6. **范围隔离**: Write ONLY L3 content (工作方式健康度). Do NOT write L1 (认知演进), L2 (战略定位), or L4 (成长处方) content.
+
+## Output Path
+
+Write your complete analysis to: `/tmp/cp_v{N}_l3.md`
+
+## Section Outline
+
+Your output must follow this exact structure (H2 + H3 hierarchy):
+
+```
+## L3：工作方式健康度
+
+### 3.1 摩擦密度与阻力分析
+
+[From data_5.txt: friction field analysis]
+[Table: friction_type × frequency × sessions_affected × severity]
+[Comparison with 2026-03-21 friction baseline]
+[Inferences about systemic vs accidental friction]
+
+### 3.2 Bug/Decision 比率健康度
+
+[From data_2.txt + data_3.txt: decision count vs bug count]
+[Table: month × decision_count × bugfix_count × ratio × signal]
+[Trend: is the ratio improving? What does it mean?]
+
+### 3.3 工具使用模式与效率
+
+[From data_1.txt + data_5.txt: tool field analysis]
+[Table: tool × frequency × associated_friction × efficiency_signal]
+[Are high-friction tools being overused?]
+
+### 3.4 工作节奏与可持续性
+
+[From data_6.txt + data_1.txt: session frequency, project switching]
+[Table: week × session_count × projects_touched × focus_signal]
+[Inferences about cognitive load and sustainability]
+[Suggestions with prerequisite assumptions and risk/cost]
+```
+
+## Style Reference
+
+Minimum density targets:
+- Section 3.1: ≥ 65 lines (friction analysis + tables + comparison)
+- Section 3.2: ≥ 55 lines (bug/decision ratio trend)
+- Section 3.3: ≥ 60 lines (tool analysis + efficiency table)
+- Section 3.4: ≥ 70 lines (rhythm analysis + sustainability suggestions)
+
+Every paragraph must end with a labeled claim or labeled table row.
+Avoid hedging without labels — if uncertain, use `[推断，置信度：低]` explicitly.

--- a/skills/cognitive-portrait/prompts/l4_growth_prescription.md
+++ b/skills/cognitive-portrait/prompts/l4_growth_prescription.md
@@ -1,0 +1,96 @@
+# L4 Sub-agent: 成长处方
+
+## File Ownership (W-14)
+
+**You own ONLY: `/tmp/cp_v{N}_l4.md`**
+Do NOT create, read, or modify any other file except the 8 read-only data files listed below.
+
+## Data Sources (read-only)
+
+- `/tmp/cp_data_1.txt` — Recent observations overview (last 90 days)
+- `/tmp/cp_data_2.txt` — Decision patterns
+- `/tmp/cp_data_3.txt` — Bug fix patterns
+- `/tmp/cp_data_4.txt` — Knowledge and patterns acquired
+- `/tmp/cp_data_5.txt` — Friction and collaboration mode
+- `/tmp/cp_data_6.txt` — Project distribution
+- `/tmp/cp_data_7.txt` — Cognitive level distribution over time
+- `/tmp/cp_data_8.txt` — Recent session insights documents
+
+## Mandatory Constraints
+
+1. **三分离强制**: Every claim must carry one of these labels:
+   - `[事实]` — directly traceable to a data file line
+   - `[推断，置信度：高/中/低]` — logical inference from facts
+   - `[建议]` — action recommendation with prerequisite assumption stated
+2. **精确数值**: All numbers in `N/M(百分比%)` format where applicable
+3. **矩阵化优先**: Use tables over bullet lists when 3+ items can be compared
+4. **行数硬下限**: This file MUST be ≥ 280 lines when complete
+5. **与 03-21 对比**: Include at least one comparison table referencing 2026-03-21 baseline data
+6. **范围隔离**: Write ONLY L4 content (成长处方). Do NOT write L1, L2, or L3 content.
+7. **处方四件套**: Every prescription must include all 4 components:
+   - 触发条件 (trigger): when to apply this prescription
+   - 行动步骤 (action): concrete 1-3 step sequence
+   - 验证方法 (verification): how to know it worked
+   - 完成定义 (done-when): objective measurable completion criteria
+
+## Output Path
+
+Write your complete analysis to: `/tmp/cp_v{N}_l4.md`
+
+## Section Outline
+
+Your output must follow this exact structure (H2 + H3 hierarchy, 6 subsections):
+
+```
+## L4：成长处方
+
+### 4.1 核心处方清单（5 条）
+
+[Exactly 5 prescriptions, each with 处方四件套]
+[Table: 处方 × 触发条件 × 行动步骤 × 验证方法 × 完成定义 × 优先级]
+[Each prescription grounded in evidence from data files]
+
+### 4.2 决策树：下一步行动选择
+
+[A markdown decision tree (nested bullet or ASCII) for choosing between prescriptions]
+[Branches: current signal light status → prescription to activate]
+[Must handle: all-green, mixed, all-red scenarios]
+
+### 4.3 90 天成长路线图
+
+[Table: week_range × focus_area × milestone × success_metric]
+[Grounded in current baseline from data]
+[Comparison: where this trajectory should land vs 2026-03-21 baseline]
+
+### 4.4 风险兜底方案
+
+[Table: risk × probability × impact × mitigation × fallback]
+[At least 5 risks identified]
+[Each mitigation must be actionable, not vague]
+
+### 4.5 与上版本对比（时间序列）
+
+[Mandatory comparison table: metric × 2026-03-21 v0 × current × delta × trend]
+[At least 8 metrics compared]
+[Inferences about whether growth is on track]
+
+### 4.6 执行优先级矩阵
+
+[2×2 matrix: impact (high/low) × effort (high/low)]
+[Place all 5 prescriptions and 3+ other actions in the matrix]
+[Recommendations: which quadrant to tackle first and why]
+[Suggestions with prerequisite assumptions and alternatives]
+```
+
+## Style Reference
+
+Minimum density targets:
+- Section 4.1: ≥ 70 lines (5 prescriptions × 4 components each + table)
+- Section 4.2: ≥ 40 lines (decision tree with all branches)
+- Section 4.3: ≥ 40 lines (90-day roadmap table)
+- Section 4.4: ≥ 45 lines (risk table with mitigations)
+- Section 4.5: ≥ 40 lines (comparison table with 8+ metrics)
+- Section 4.6: ≥ 45 lines (priority matrix + reasoning)
+
+This is the most important section — it must be actionable and evidence-grounded.
+Every suggestion must state its prerequisite assumption and offer at least one alternative.


### PR DESCRIPTION
## Summary

- Add `skills/cognitive-portrait/` to the repo: `SKILL.md` (Dispatcher) + 4 sub-agent prompt templates (`l1`–`l4`)
- Add `docs/setup-skills.md`: one-time `ln -s` symlink guide with migration note for users who had the old external copy
- Add CI `skill-check` job: pure bash `test -f` assertions for all 5 required files — no Rust toolchain needed, runs before other jobs
- Update `docs/cognitive-portraits/SPEC.md` §4.2 and `refine-data-pipelines.md` pipeline-9 annotation to reflect in-repo location
- Update README Quick Start with the symlink setup step

## Test plan

- [ ] CI `skill-check` job passes (verifies all 5 skill files present after every commit)
- [ ] Fresh clone: run `ln -s $(pwd)/skills/cognitive-portrait ~/.claude/skills/cognitive-portrait`, open Claude Code, trigger `/cognitive-portrait` — skill loads and Dispatcher begins Stage 1
- [ ] Migration: if `~/.claude/skills/cognitive-portrait` was a plain directory, delete it, re-run symlink, verify skill works

Closes #70