### PR TITLE
fix(clippy): use sort_by_key with Reverse to satisfy Rust 1.95 lint

### DIFF
--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -49,7 +49,7 @@ pub async fn handle_ingest_sessions(
 
     // --latest: sort by mtime descending, keep N most recent
     if let Some(n) = options.latest {
-        discovered.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+        discovered.sort_by_key(|d| std::cmp::Reverse(d.modified_at));
         discovered.truncate(n);
     }
 

--- a/apps/mirror/src/profile.rs
+++ b/apps/mirror/src/profile.rs
@@ -76,7 +76,7 @@ fn extract_profile_data(
             }
         })
         .collect();
-    stats.sort_by(|a, b| b.sessions.cmp(&a.sessions));
+    stats.sort_by_key(|s| std::cmp::Reverse(s.sessions));
     stats.truncate(10);
 
     // Session complexity: count observations per document_id

--- a/packages/core/src/session/clustering.rs
+++ b/packages/core/src/session/clustering.rs
@@ -224,7 +224,7 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
         .iter()
         .map(|(name, c)| (name.clone(), c.session_count))
         .collect();
-    project_ranking.sort_by(|a, b| b.1.cmp(&a.1));
+    project_ranking.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     ClusterResult {
         projects,


### PR DESCRIPTION
## Summary

- Replace `sort_by(|a,b| b.1.cmp(&a.1))` with `sort_by_key(|b| std::cmp::Reverse(b.1))` in `packages/core/src/session/clustering.rs:227`.
- Rust 1.95 added `clippy::unnecessary_sort_by` to the default set; CI runs with `-D warnings`, so this lint blocks every PR.

## Why this matters

`main` is currently red on clippy under the CI toolchain (Rust 1.95). Six open PRs (#65, #71, #72, #73, #74, #75) all hit the same lint with no relation to their own changes. Fixing main turns them all green automatically.

## Test plan

- [x] `cargo check -p refine-core` passes
- [x] `cargo clippy -p refine-core --all-targets -- -D warnings` passes locally on Rust 1.94
- [ ] CI clippy turns green (Rust 1.95)