### PR TITLE
chore(scripts): add pre-commit guard against hardcoded developer paths

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Reject commits that hardcode developer-specific absolute paths.
+# Pattern: /Users/<lowercase-identifier>/ — catches /Users/lifcc/..., etc.
+set -euo pipefail
+
+staged=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null \
+  | grep -E '\.(sh|rs|toml|json|mjs|js|ts)$' || true)
+
+[[ -z "$staged" ]] && exit 0
+
+bad_files=$(echo "$staged" \
+  | xargs grep -lE '/Users/[a-z][a-z0-9_-]+/' -- 2>/dev/null || true)
+
+if [[ -n "$bad_files" ]]; then
+  echo "" >&2
+  echo "ERROR: hardcoded developer path detected (/Users/<name>/...):" >&2
+  while IFS= read -r f; do
+    grep -nE '/Users/[a-z][a-z0-9_-]+/' "$f" | head -5 >&2
+  done <<< "$bad_files"
+  echo "" >&2
+  echo "Use \$HOME, dirs::home_dir(), or an env var instead." >&2
+  exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ Thanks for your interest in contributing!
 git clone https://github.com/majiayu000/refine.git
 cd refine
 
+# Activate project hooks (prevents hardcoded developer paths in commits)
+git config core.hooksPath .githooks
+
 # Build
 cargo build
 


### PR DESCRIPTION
## Summary

- Add `.githooks/pre-commit` that rejects staged commits containing `/Users/<name>/` literals in shell, Rust, TOML, and JS/TS files
- Update `CONTRIBUTING.md` to document `git config core.hooksPath .githooks` so new contributors activate the guard automatically
- Scripts (`daily-refresh.sh`, `weekly-insights.sh`) were already fixed in #55; this guard prevents regressions

## Facts

- `scripts/daily-refresh.sh` and `scripts/weekly-insights.sh` no longer contain hardcoded `/Users/lifcc/…` paths (fixed in #55, `6a31b72`)
- No `/Users/<name>/` literals remain in `scripts/`, `packages/`, or `apps/` source trees (verified via `grep -rE '/Users/[a-z]'`)
- `shellcheck .githooks/pre-commit` exits 0
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass (211 tests)

## Test plan

- [ ] `git config core.hooksPath .githooks` then attempt a commit with a `/Users/somebody/` literal in a `.sh` file — hook must reject it
- [ ] Normal commits without hardcoded paths must pass through unaffected

Closes #63