### PR TITLE
fix(sec): require REFINE_DEV_ANON opt-in and restrict CORS origins (Closes #60)

### DIFF
--- a/apps/server/src/auth.rs
+++ b/apps/server/src/auth.rs
@@ -3,7 +3,19 @@ use axum::http::HeaderMap;
 const UNAUTHORIZED_MESSAGE: &str =
     "Unauthorized: provide Authorization: Bearer <token> and ensure REFINE_API_TOKEN matches.";
 
-pub fn authorize_user(headers: &HeaderMap, expected_token: Option<&str>) -> Result<String, String> {
+const ANON_DISABLED_MESSAGE: &str = "Unauthorized: REFINE_API_TOKEN is not set. \
+     Set REFINE_DEV_ANON=1 to allow unauthenticated local access in development.";
+
+/// Authenticate the request. Returns a user identifier on success.
+///
+/// - If `expected_token` is set: the request must carry a matching Bearer token.
+/// - If `expected_token` is absent and `dev_anon` is true: returns "dev-user" (dev opt-in).
+/// - If `expected_token` is absent and `dev_anon` is false: returns an error (secure default).
+pub fn authorize_user(
+    headers: &HeaderMap,
+    expected_token: Option<&str>,
+    dev_anon: bool,
+) -> Result<String, String> {
     if let Some(token) = expected_token.filter(|v| !v.trim().is_empty()) {
         let authorization = headers
             .get("authorization")
@@ -24,7 +36,11 @@ pub fn authorize_user(headers: &HeaderMap, expected_token: Option<&str>) -> Resu
         return Ok("token-user".to_string());
     }
 
-    Ok("dev-user".to_string())
+    if dev_anon {
+        return Ok("dev-user".to_string());
+    }
+
+    Err(ANON_DISABLED_MESSAGE.to_string())
 }
 
 #[cfg(test)]
@@ -35,7 +51,7 @@ mod tests {
     #[test]
     fn authorize_rejects_missing_token_when_required() {
         let headers = HeaderMap::new();
-        let result = authorize_user(&headers, Some("secret-token"));
+        let result = authorize_user(&headers, Some("secret-token"), false);
         assert!(result.is_err());
         assert!(result
             .err()
@@ -51,7 +67,26 @@ mod tests {
             HeaderValue::from_static("Bearer secret-token"),
         );
 
-        let result = authorize_user(&headers, Some("secret-token"));
+        let result = authorize_user(&headers, Some("secret-token"), false);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn authorize_rejects_anonymous_when_dev_anon_disabled() {
+        let headers = HeaderMap::new();
+        // No token configured, dev_anon opt-in is off — must return 401
+        let result = authorize_user(&headers, None, false);
+        assert!(result.is_err(), "anonymous request must be rejected");
+        assert!(
+            result.err().unwrap_or_default().contains("REFINE_DEV_ANON"),
+            "error message must mention REFINE_DEV_ANON"
+        );
+    }
+
+    #[test]
+    fn authorize_accepts_anonymous_when_dev_anon_enabled() {
+        let headers = HeaderMap::new();
+        let result = authorize_user(&headers, None, true);
+        assert_eq!(result.unwrap(), "dev-user");
     }
 }

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -9,13 +9,13 @@ mod request_guard;
 mod state;
 mod vector_search;
 
-use axum::http::{header, Method};
+use axum::http::{header, HeaderValue, Method};
 use axum::routing::{delete, get, post};
 use axum::Router;
 use state::AppState;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{AllowOrigin, CorsLayer};
 
 const DEFAULT_BIND_HOST: &str = "127.0.0.1";
 const DEFAULT_SERVER_PORT: u16 = 21567;
@@ -48,7 +48,7 @@ async fn main() {
     }
 
     let cors = CorsLayer::new()
-        .allow_origin(Any)
+        .allow_origin(trusted_origins())
         .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
         .allow_headers([
             header::CONTENT_TYPE,
@@ -186,6 +186,19 @@ async fn is_refine_server(addr: &SocketAddr) -> bool {
             .is_ok_and(|body| body.contains("Refine cloud API")),
         Err(_) => false,
     }
+}
+
+/// Build the CORS allowed-origin list from `REFINE_TRUSTED_ORIGINS` (comma-separated).
+/// Returns an empty list when the variable is unset, blocking all cross-origin requests.
+fn trusted_origins() -> AllowOrigin {
+    let origins: Vec<HeaderValue> = std::env::var("REFINE_TRUSTED_ORIGINS")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| s.parse::<HeaderValue>().ok())
+        .collect();
+    AllowOrigin::list(origins)
 }
 
 fn parse_bind_addr(host: &str, port: u16) -> SocketAddr {

--- a/apps/server/src/request_guard.rs
+++ b/apps/server/src/request_guard.rs
@@ -24,7 +24,7 @@ where
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         validate_client_contract(&parts.headers)?;
         let state = Arc::<AppState>::from_ref(state);
-        let user_id = authorize_user(&parts.headers, state.api_token.as_deref())
+        let user_id = authorize_user(&parts.headers, state.api_token.as_deref(), state.dev_anon)
             .map_err(|err| error_message(StatusCode::UNAUTHORIZED, &err))?;
         Ok(Self(user_id))
     }

--- a/apps/server/src/state.rs
+++ b/apps/server/src/state.rs
@@ -20,6 +20,8 @@ pub struct AppState {
     pub premium_users: HashSet<String>,
     pub llm_client: Option<Arc<dyn LlmClient>>,
     pub api_token: Option<String>,
+    /// Explicit opt-in for unauthenticated local access. Requires `REFINE_DEV_ANON=1`.
+    pub dev_anon: bool,
     pub conversation_repo: Arc<dyn ConversationRepository>,
     pub job_repo: Arc<dyn JobRepository>,
     pub event_repo: Arc<dyn EventRepository>,
@@ -52,6 +54,7 @@ impl AppState {
         let store: Arc<dyn ItemRepository> = sqlite_store.clone();
         let doc_store: Arc<dyn DocumentRepository> = sqlite_store;
         let api_token = env_var(&["REFINE_API_TOKEN"]);
+        let dev_anon = env_flag(&["REFINE_DEV_ANON"]);
         if is_production_env() && api_token.is_none() {
             return Err(
                 "REFINE_API_TOKEN is required when REFINE_ENV is set to production".to_string(),
@@ -99,6 +102,7 @@ impl AppState {
             premium_users,
             llm_client: build_llm_client_from_env(),
             api_token,
+            dev_anon,
             conversation_repo,
             job_repo,
             event_repo,


### PR DESCRIPTION
## Summary

- **auth.rs**: `authorize_user()` now requires `dev_anon: bool` — missing `REFINE_API_TOKEN` returns `Err` unless the caller explicitly opts in via `REFINE_DEV_ANON=1` (eliminates silent dev-user fallback).
- **state.rs**: `AppState` gains a `dev_anon: bool` field, populated from `REFINE_DEV_ANON` env var at startup.
- **request_guard.rs**: forwards `state.dev_anon` to `authorize_user`.
- **main.rs**: replaces `CorsLayer::allow_origin(Any)` with `trusted_origins()` which parses `REFINE_TRUSTED_ORIGINS` (comma-separated); defaults to an empty list — all cross-origin requests are blocked when unconfigured.

## Operator migration

| Scenario | Before | After |
|---|---|---|
| Local dev, no token | worked silently | set `REFINE_DEV_ANON=1` |
| Extension/desktop CORS | any origin allowed | set `REFINE_TRUSTED_ORIGINS=<origin1>,<origin2>` |
| Token-authenticated | unchanged | unchanged |

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 40/40 server tests pass, including:
  - `auth::authorize_rejects_anonymous_when_dev_anon_disabled` (new)
  - `auth::authorize_accepts_anonymous_when_dev_anon_enabled` (new)