### PR TITLE
fix(persistence): atomic idempotency insert via ON CONFLICT...RETURNING

### DIFF
--- a/apps/server/src/application/conversation.rs
+++ b/apps/server/src/application/conversation.rs
@@ -65,17 +65,6 @@ pub async fn create_conversation(
     let normalized = normalize_conversation_input(content, url, source, title, idempotency_key)
         .map_err(CreateConversationError::BadRequest)?;
 
-    if let Some(record) =
-        find_conversation_by_idempotency(&state, &normalized.idempotency_key).await?
-    {
-        return Ok(CreateConversationResult {
-            conversation_id: record.id,
-            status: record.status,
-            deduplicated: true,
-            job_id: None,
-        });
-    }
-
     if state.free_quota_items > 0 && !state.is_premium_user(&user_id) {
         let used = state
             .store
@@ -116,10 +105,21 @@ pub async fn create_conversation(
         last_error: None,
     };
 
-    state
+    // Atomically insert or, on idempotency-key conflict, fetch the existing row.
+    // Comparing returned id against the generated id reveals deduplication.
+    let persisted = state
         .conversation_repo
-        .upsert_conversation(&conversation)
+        .insert_or_fetch_conversation_by_idempotency(&conversation)
         .map_err(CreateConversationError::Internal)?;
+
+    if persisted.id != conversation_id {
+        return Ok(CreateConversationResult {
+            conversation_id: persisted.id,
+            status: persisted.status,
+            deduplicated: true,
+            job_id: None,
+        });
+    }
 
     let mut job_id = None;
     if !ingest_only {
@@ -225,16 +225,6 @@ pub async fn create_extraction_job(
         job_id,
         status: JobStatus::Pending,
     })
-}
-
-async fn find_conversation_by_idempotency(
-    state: &Arc<AppState>,
-    key: &str,
-) -> Result<Option<crate::models::ConversationRecord>, CreateConversationError> {
-    state
-        .conversation_repo
-        .find_conversation_by_idempotency(key)
-        .map_err(CreateConversationError::Internal)
 }
 
 #[cfg(test)]

--- a/apps/server/src/application/ports.rs
+++ b/apps/server/src/application/ports.rs
@@ -2,10 +2,6 @@ use crate::models::{ConversationRecord, EventRecord, ExtractionJobRecord};
 
 pub trait ConversationRepository: Send + Sync {
     fn find_conversation_by_id(&self, id: &str) -> Result<Option<ConversationRecord>, String>;
-    fn find_conversation_by_idempotency(
-        &self,
-        idempotency_key: &str,
-    ) -> Result<Option<ConversationRecord>, String>;
     fn list_conversations(
         &self,
         status: Option<&str>,
@@ -14,6 +10,13 @@ pub trait ConversationRepository: Send + Sync {
     ) -> Result<Vec<ConversationRecord>, String>;
     fn count_conversations(&self, status: Option<&str>) -> Result<usize, String>;
     fn upsert_conversation(&self, record: &ConversationRecord) -> Result<(), String>;
+    /// Atomically inserts `record` or, on idempotency-key conflict, returns the
+    /// pre-existing row unchanged. Callers detect deduplication by comparing
+    /// the returned `id` with the one they supplied in `record`.
+    fn insert_or_fetch_conversation_by_idempotency(
+        &self,
+        record: &ConversationRecord,
+    ) -> Result<ConversationRecord, String>;
 }
 
 pub trait JobRepository: Send + Sync {

--- a/apps/server/src/persistence.rs
+++ b/apps/server/src/persistence.rs
@@ -35,25 +35,6 @@ impl ServerPersistence {
         .map_err(|e| e.to_string())
     }
 
-    pub fn find_conversation_by_idempotency(
-        &self,
-        idempotency_key: &str,
-    ) -> Result<Option<ConversationRecord>, String> {
-        let conn = self.open()?;
-        conn.query_row(
-            r#"
-            SELECT id, user_id, source, url, title, raw_content, metadata_json,
-                   captured_at, created_at, status, idempotency_key, item_ids, last_error
-            FROM conversations
-            WHERE idempotency_key = ?1
-            "#,
-            [idempotency_key],
-            row_to_conversation,
-        )
-        .optional()
-        .map_err(|e| e.to_string())
-    }
-
     pub fn list_conversations(
         &self,
         status: Option<&str>,
@@ -294,8 +275,49 @@ impl ServerPersistence {
         collect_event_counts(rows)
     }
 
+    pub fn insert_or_fetch_conversation_by_idempotency(
+        &self,
+        record: &ConversationRecord,
+    ) -> Result<ConversationRecord, String> {
+        let conn = self.open()?;
+        let item_ids = serde_json::to_string(&record.item_ids).map_err(|e| e.to_string())?;
+        let metadata = serde_json::to_string(&record.metadata).map_err(|e| e.to_string())?;
+        conn.query_row(
+            r#"
+            INSERT INTO conversations
+              (id, user_id, source, url, title, raw_content, metadata_json,
+               captured_at, created_at, status, idempotency_key, item_ids, last_error)
+            VALUES
+              (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            ON CONFLICT(idempotency_key) DO UPDATE SET id=id
+            RETURNING id, user_id, source, url, title, raw_content, metadata_json,
+                      captured_at, created_at, status, idempotency_key, item_ids, last_error
+            "#,
+            params![
+                record.id,
+                record.user_id,
+                record.source,
+                record.url,
+                record.title,
+                record.raw_content,
+                metadata,
+                record.captured_at,
+                record.created_at,
+                conversation_status_to_db(&record.status),
+                record.idempotency_key,
+                item_ids,
+                record.last_error,
+            ],
+            row_to_conversation,
+        )
+        .map_err(|e| e.to_string())
+    }
+
     fn open(&self) -> Result<Connection, String> {
-        Connection::open(&self.db_path).map_err(|e| e.to_string())
+        let conn = Connection::open(&self.db_path).map_err(|e| e.to_string())?;
+        conn.busy_timeout(std::time::Duration::from_secs(5))
+            .map_err(|e| e.to_string())?;
+        Ok(conn)
     }
 
     fn ensure_schema(&self) -> Result<(), String> {
@@ -364,13 +386,6 @@ impl ConversationRepository for ServerPersistence {
         ServerPersistence::find_conversation_by_id(self, id)
     }
 
-    fn find_conversation_by_idempotency(
-        &self,
-        idempotency_key: &str,
-    ) -> Result<Option<ConversationRecord>, String> {
-        ServerPersistence::find_conversation_by_idempotency(self, idempotency_key)
-    }
-
     fn list_conversations(
         &self,
         status: Option<&str>,
@@ -386,6 +401,13 @@ impl ConversationRepository for ServerPersistence {
 
     fn upsert_conversation(&self, record: &ConversationRecord) -> Result<(), String> {
         ServerPersistence::upsert_conversation(self, record)
+    }
+
+    fn insert_or_fetch_conversation_by_idempotency(
+        &self,
+        record: &ConversationRecord,
+    ) -> Result<ConversationRecord, String> {
+        ServerPersistence::insert_or_fetch_conversation_by_idempotency(self, record)
     }
 }
 
@@ -553,6 +575,7 @@ mod tests {
     };
     use serde_json::json;
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
     use uuid::Uuid;
 
     fn temp_db_path() -> PathBuf {
@@ -686,13 +709,11 @@ mod tests {
             .expect("count queued conversations");
         assert_eq!(queued_total, 1);
 
-        let found = persistence
-            .find_conversation_by_idempotency("k1")
-            .expect("find by idempotency");
-        assert_eq!(
-            found.expect("conversation should exist").idempotency_key,
-            "k1".to_string()
-        );
+        let fetched = persistence
+            .insert_or_fetch_conversation_by_idempotency(&queued)
+            .expect("insert_or_fetch for existing key");
+        assert_eq!(fetched.id, queued.id);
+        assert_eq!(fetched.idempotency_key, "k1");
 
         let page = persistence
             .list_conversations(Some("queued"), 0, 10)
@@ -724,6 +745,51 @@ mod tests {
             .expect("job should exist");
         assert_eq!(loaded.id, job.id);
         assert_eq!(loaded.status, JobStatus::Pending);
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn concurrent_inserts_same_idempotency_key_return_same_id() {
+        let path = temp_db_path();
+        // Pre-create the schema so both threads start from a clean, ready state.
+        ServerPersistence::new(path.clone()).expect("schema init");
+
+        let record1 = build_conversation(ConversationStatus::Queued, "concurrent-key");
+        let record2 = build_conversation(ConversationStatus::Queued, "concurrent-key");
+
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let b1 = Arc::clone(&barrier);
+        let b2 = Arc::clone(&barrier);
+
+        let path1 = path.clone();
+        let path2 = path.clone();
+
+        let h1 = std::thread::spawn(move || {
+            let p = ServerPersistence::new(path1).expect("init p1");
+            b1.wait();
+            p.insert_or_fetch_conversation_by_idempotency(&record1)
+        });
+        let h2 = std::thread::spawn(move || {
+            let p = ServerPersistence::new(path2).expect("init p2");
+            b2.wait();
+            p.insert_or_fetch_conversation_by_idempotency(&record2)
+        });
+
+        let r1 = h1
+            .join()
+            .expect("thread 1 panicked")
+            .expect("thread 1 error");
+        let r2 = h2
+            .join()
+            .expect("thread 2 panicked")
+            .expect("thread 2 error");
+
+        assert_eq!(
+            r1.id, r2.id,
+            "concurrent inserts with same idempotency key must return the same conversation id"
+        );
+        assert_eq!(r1.idempotency_key, "concurrent-key");
 
         cleanup(&path);
     }


### PR DESCRIPTION
## Summary

- Replaces the non-atomic `find → insert` sequence in `create_conversation()` with a single `INSERT … ON CONFLICT(idempotency_key) DO UPDATE SET id=id RETURNING *` statement, eliminating the race window where two concurrent requests with the same key both see "not found" and race to insert
- Adds `busy_timeout(5 s)` to every SQLite connection to prevent `SQLITE_BUSY` under concurrent write contention
- Removes the now-unused `find_conversation_by_idempotency` trait method (confirmed dead code by the compiler after the above change)

## Root cause

`create_conversation` called `find_conversation_by_idempotency` then `upsert_conversation` as two separate operations. Under concurrent load both callers could observe "not found" before either had committed, causing the second insert to fail on the `UNIQUE(idempotency_key)` constraint and surface as an internal error rather than a deduplicated success.

## Test plan

- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo test --workspace` — 41 tests pass, including new `concurrent_inserts_same_idempotency_key_return_same_id` which races two threads against the same idempotency key and asserts both receive the same `conversation_id`

Closes #61