### PR TITLE
Scope incremental ingest cursor by source and DB

### DIFF
--- a/apps/cli/src/handlers.rs
+++ b/apps/cli/src/handlers.rs
@@ -11,12 +11,14 @@ use refine_core::refinement::{apply_defaults, extract_items_with_llm, Extraction
 use refine_core::search::{SearchEngine, SearchQuery};
 use refine_core::session::SessionSource;
 use std::io::{self, Read};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 pub async fn run(
     command: Commands,
     store: Arc<SqliteStore>,
     engine: Arc<SearchEngine>,
+    db_path: PathBuf,
 ) -> Result<()> {
     match command {
         Commands::Extract { stdin } => handle_extract(stdin, store).await,
@@ -49,6 +51,7 @@ pub async fn run(
                     limit,
                     latest,
                     dry_run,
+                    db_path,
                 },
                 item_store,
                 doc_store,

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -10,6 +10,7 @@ use refine_core::session::{
     build_facet_prompt, chunk_session, discover_sessions, facets_to_items, needs_chunking,
     parse_facet_response, parse_session_file, FilterConfig, SessionSource, FACET_SYSTEM_PROMPT,
 };
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -33,6 +34,7 @@ pub struct IngestOptions {
     /// 按 mtime 降序取最近 N 个会话，与 limit 互斥
     pub latest: Option<usize>,
     pub dry_run: bool,
+    pub db_path: PathBuf,
 }
 
 /// 待处理的会话（已通过去重和过滤）
@@ -47,26 +49,58 @@ struct PendingSession {
     chunks: Vec<String>,
 }
 
-/// Read the Unix-second timestamp from `~/.refine/last-ingest-mtime`.
-fn read_last_ingest_mtime() -> Option<SystemTime> {
-    let path = dirs::home_dir()?.join(".refine").join("last-ingest-mtime");
+/// Read the Unix-second timestamp for the current ingest scope.
+fn read_last_ingest_mtime(source: Option<&SessionSource>, db_path: &Path) -> Option<SystemTime> {
+    let path = ingest_cursor_path(source, db_path)?;
     let secs: u64 = std::fs::read_to_string(path).ok()?.trim().parse().ok()?;
     Some(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
 }
 
-/// Persist the Unix-second timestamp to `~/.refine/last-ingest-mtime`.
-fn write_last_ingest_mtime(t: SystemTime) {
-    let Some(home) = dirs::home_dir() else { return };
-    let dir = home.join(".refine");
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        tracing::warn!("failed to create ~/.refine: {}", e);
+/// Persist the Unix-second timestamp for the current ingest scope.
+fn write_last_ingest_mtime(source: Option<&SessionSource>, db_path: &Path, t: SystemTime) {
+    let Some(path) = ingest_cursor_path(source, db_path) else {
+        return;
+    };
+    let Some(dir) = path.parent() else { return };
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        tracing::warn!(
+            "failed to create ingest cursor dir {}: {}",
+            dir.display(),
+            e
+        );
         return;
     }
     if let Ok(dur) = t.duration_since(SystemTime::UNIX_EPOCH) {
-        if let Err(e) = std::fs::write(dir.join("last-ingest-mtime"), dur.as_secs().to_string()) {
-            tracing::warn!("failed to write last-ingest-mtime: {}", e);
+        if let Err(e) = std::fs::write(&path, dur.as_secs().to_string()) {
+            tracing::warn!("failed to write ingest cursor {}: {}", path.display(), e);
         }
     }
+}
+
+fn ingest_cursor_path(source: Option<&SessionSource>, db_path: &Path) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    Some(ingest_cursor_path_in(&home, source, db_path))
+}
+
+fn ingest_cursor_path_in(home: &Path, source: Option<&SessionSource>, db_path: &Path) -> PathBuf {
+    let source_key = source.map_or("all-sources", SessionSource::as_str);
+    let db_hash = stable_path_hash(db_path);
+    home.join(".refine")
+        .join("ingest-cursors")
+        .join(format!("{source_key}-{db_hash}.mtime"))
+}
+
+fn stable_path_hash(path: &Path) -> String {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in path.to_string_lossy().as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+
+    format!("{hash:016x}")
 }
 
 pub async fn handle_ingest_sessions(
@@ -80,7 +114,7 @@ pub async fn handle_ingest_sessions(
     let incremental = options.limit.is_none() && options.latest.is_none() && !options.dry_run;
     let scan_start = SystemTime::now();
     let mtime_after = if incremental {
-        read_last_ingest_mtime().map(|last| {
+        read_last_ingest_mtime(options.source.as_ref(), &options.db_path).map(|last| {
             last.checked_sub(Duration::from_secs(3600))
                 .unwrap_or(SystemTime::UNIX_EPOCH)
         })
@@ -88,7 +122,7 @@ pub async fn handle_ingest_sessions(
         None
     };
 
-    let mut discovered = discover_sessions(options.source, mtime_after);
+    let mut discovered = discover_sessions(options.source.clone(), mtime_after);
     if mtime_after.is_some() {
         println!("增量扫描：发现 {} 个会话文件", discovered.len());
     } else {
@@ -250,7 +284,7 @@ pub async fn handle_ingest_sessions(
 
     // Advance the incremental scan cursor so the next run only sees newer files.
     if incremental {
-        write_last_ingest_mtime(scan_start);
+        write_last_ingest_mtime(options.source.as_ref(), &options.db_path, scan_start);
     }
 
     Ok(())
@@ -365,4 +399,37 @@ async fn extract_and_parse_facets_with_retry(
 ) -> Result<refine_core::session::FacetResponse> {
     let response = llm_call_with_retry(client, content, quota_hit).await?;
     parse_facet_response(&response).map_err(|e| anyhow::anyhow!(e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_path_is_partitioned_by_source() {
+        let home = Path::new("/tmp/home");
+        let db_path = Path::new("/tmp/refine.db");
+
+        let all_sources = ingest_cursor_path_in(home, None, db_path);
+        let codex_only = ingest_cursor_path_in(home, Some(&SessionSource::Codex), db_path);
+
+        assert_ne!(all_sources, codex_only);
+    }
+
+    #[test]
+    fn cursor_path_is_partitioned_by_db_path() {
+        let home = Path::new("/tmp/home");
+        let primary = ingest_cursor_path_in(
+            home,
+            Some(&SessionSource::ClaudeCode),
+            Path::new("/tmp/refine.db"),
+        );
+        let alternate = ingest_cursor_path_in(
+            home,
+            Some(&SessionSource::ClaudeCode),
+            Path::new("/tmp/alternate/refine.db"),
+        );
+
+        assert_ne!(primary, alternate);
+    }
 }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -55,8 +55,9 @@ async fn main() -> Result<()> {
     }
 
     let store = Arc::new(SqliteStore::open(&db_path).context("打开数据库失败")?);
+    let authoritative_db_path = std::fs::canonicalize(&db_path).unwrap_or_else(|_| db_path.clone());
     let repo: Arc<dyn ItemRepository> = store.clone();
     let engine = Arc::new(SearchEngine::new(repo));
 
-    handlers::run(cli.command, store, engine).await
+    handlers::run(cli.command, store, engine, authoritative_db_path).await
 }


### PR DESCRIPTION
## Summary
- scope the incremental ingest cursor by session source filter and canonical database path
- thread the authoritative CLI DB path into `ingest-sessions`
- add focused tests covering source and DB-path cursor partitioning

## Signal Report
- Root cause: incremental ingest stored a single global cursor at `~/.refine/last-ingest-mtime`.
- Failure mode: a full ingest run scoped with `--source` could advance that shared watermark past older sessions belonging to another source, so later runs filtered those sessions out before they were ever ingested.
- Additional risk: the same shared cursor was reused across different target SQLite DB paths, so separate databases could incorrectly suppress each other's session discovery state.
- Fix: persist the incremental cursor under a scope key derived from the source filter (`all-sources` or a concrete session source) plus the canonical target DB path.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
