### PR TITLE
Unify shared LLM retry policy across CLI and mirror

### DIFF
--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Context, Result};
 use refine_core::error::InfraError;
-use refine_core::infra::{set_quota_exhausted, LlmClient};
+use refine_core::infra::{llm_with_retry_policy, LlmClient, LlmRetryPolicy};
 use refine_core::knowledge::{Document, DocumentRepository, ItemRepository};
 use refine_core::session::{
     build_facet_prompt, chunk_session, discover_sessions, facets_to_items, needs_chunking,
@@ -16,8 +16,6 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::sync::Semaphore;
 
-const MAX_RETRIES: usize = 5;
-const RETRY_BASE_DELAY_SECS: u64 = 10;
 const DEFAULT_CONCURRENCY: usize = 1;
 
 fn concurrency() -> usize {
@@ -332,56 +330,39 @@ async fn llm_call_with_retry(
     content: &str,
     quota_hit: &Arc<AtomicBool>,
 ) -> Result<String> {
-    let prompt = build_facet_prompt(content);
-    let mut last_err = String::new();
-
-    for attempt in 0..MAX_RETRIES {
-        if quota_hit.load(Ordering::Relaxed) {
-            return Err(anyhow::anyhow!("LLM 配额已耗尽，跳过"));
-        }
-
-        match client.complete(&prompt, Some(FACET_SYSTEM_PROMPT)).await {
-            Ok(response) => return Ok(response),
-            Err(InfraError::RateLimited { retry_after_secs }) => {
-                quota_hit.store(true, Ordering::Relaxed);
-                set_quota_exhausted(retry_after_secs);
-                return Err(anyhow::anyhow!(
-                    "LLM 配额已耗尽 (retry_after: {:?}s)",
-                    retry_after_secs
-                ));
-            }
-            Err(e) => {
-                last_err = e.to_string();
-                let is_retryable = last_err.contains("cooldown")
-                    || last_err.contains("service_busy")
-                    || last_err.contains("rate")
-                    || last_err.contains("429")
-                    || last_err.contains("Upstream")
-                    || last_err.contains("timeout")
-                    || last_err.contains("empty response");
-
-                if !is_retryable || attempt == MAX_RETRIES - 1 {
-                    break;
-                }
-
-                let delay = RETRY_BASE_DELAY_SECS * (1 << attempt);
-                eprintln!(
-                    "    ⏳ 重试 ({}/{}) 等待 {}s: {}",
-                    attempt + 1,
-                    MAX_RETRIES,
-                    delay,
-                    &last_err[..last_err.len().min(80)],
-                );
-                tokio::time::sleep(Duration::from_secs(delay)).await;
-            }
-        }
+    if quota_hit.load(Ordering::Relaxed) {
+        return Err(anyhow::anyhow!("LLM 配额已耗尽，跳过"));
     }
 
-    Err(anyhow::anyhow!(
-        "LLM 调用失败 (重试 {} 次): {}",
-        MAX_RETRIES,
-        last_err
-    ))
+    let prompt = build_facet_prompt(content);
+    match llm_with_retry_policy(
+        client,
+        &prompt,
+        FACET_SYSTEM_PROMPT,
+        LlmRetryPolicy::default(),
+        |attempt, max_retries, delay_secs, err| {
+            let message = err.to_string();
+            eprintln!(
+                "    ⏳ 重试 ({}/{}) 等待 {}s: {}",
+                attempt,
+                max_retries,
+                delay_secs,
+                &message[..message.len().min(80)],
+            );
+        },
+    )
+    .await
+    {
+        Ok(response) => Ok(response),
+        Err(InfraError::RateLimited { retry_after_secs }) => {
+            quota_hit.store(true, Ordering::Relaxed);
+            Err(anyhow::anyhow!(
+                "LLM 配额已耗尽 (retry_after: {:?}s)",
+                retry_after_secs
+            ))
+        }
+        Err(err) => Err(anyhow::Error::new(err)),
+    }
 }
 
 async fn extract_and_parse_facets_with_retry(
@@ -564,5 +545,18 @@ mod tests {
         assert!(linked_items
             .iter()
             .all(|item| item.document_id() == Some(saved_doc.id())));
+    }
+
+    #[tokio::test]
+    async fn quota_hit_short_circuits_before_llm_call() {
+        use refine_core::infra::ClaudeClient;
+        let client: Arc<dyn LlmClient> = Arc::new(ClaudeClient::new("test-key"));
+        let quota_hit = Arc::new(AtomicBool::new(true));
+
+        let err = llm_call_with_retry(&client, "content", &quota_hit)
+            .await
+            .expect_err("quota flag should skip the call");
+
+        assert!(err.to_string().contains("LLM 配额已耗尽"));
     }
 }

--- a/apps/cli/src/insights.rs
+++ b/apps/cli/src/insights.rs
@@ -1,19 +1,16 @@
 //! insights v2 — 两级分析：本地聚类 + 10 路 LLM 并发
 
 use anyhow::{Context, Result};
-use refine_core::infra::LlmClient;
+use refine_core::infra::{llm_with_retry_policy, LlmClient, LlmRetryPolicy};
 use refine_core::knowledge::{Document, DocumentRepository, ItemRepository, ItemType};
 use refine_core::session::{
     build_final_prompt, cluster_observations, merge_route_results, plan_routes, RouteResult,
     INSIGHTS_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT,
 };
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::Semaphore;
 
 const LLM_CONCURRENCY: usize = 10;
-const MAX_RETRIES: usize = 5;
-const RETRY_BASE_DELAY_SECS: u64 = 10;
 
 #[allow(dead_code)]
 pub struct InsightsOptions {
@@ -73,7 +70,20 @@ pub async fn handle_insights(
         let client = client.clone();
         let handle = tokio::spawn(async move {
             let _permit = sem.acquire().await.expect("semaphore closed");
-            let content = match llm_with_retry(&client, &route.prompt, ROUTE_SYSTEM_PROMPT).await {
+            let content = match llm_with_retry_policy(
+                &client,
+                &route.prompt,
+                ROUTE_SYSTEM_PROMPT,
+                LlmRetryPolicy::default(),
+                |attempt, max_retries, delay_secs, _err| {
+                    eprintln!(
+                        "    ⏳ 重试 ({}/{}) 等待 {}s...",
+                        attempt, max_retries, delay_secs
+                    );
+                },
+            )
+            .await
+            {
                 Ok(c) => c,
                 Err(e) => format!("分析失败: {}", e),
             };
@@ -103,9 +113,20 @@ pub async fn handle_insights(
     let combined = merge_route_results(&route_results);
     let final_prompt = build_final_prompt(&combined, stats, options.with_prescription);
 
-    let report = llm_with_retry(&client, &final_prompt, INSIGHTS_SYSTEM_PROMPT)
-        .await
-        .map_err(|e| anyhow::anyhow!("最终报告生成失败: {}", e))?;
+    let report = llm_with_retry_policy(
+        &client,
+        &final_prompt,
+        INSIGHTS_SYSTEM_PROMPT,
+        LlmRetryPolicy::default(),
+        |attempt, max_retries, delay_secs, _err| {
+            eprintln!(
+                "    ⏳ 重试 ({}/{}) 等待 {}s...",
+                attempt, max_retries, delay_secs
+            );
+        },
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("最终报告生成失败: {}", e))?;
 
     println!("{}", report);
 
@@ -122,40 +143,4 @@ pub async fn handle_insights(
     println!("\n报告已保存 (ID: {})", doc.id());
 
     Ok(())
-}
-
-async fn llm_with_retry(client: &Arc<dyn LlmClient>, prompt: &str, system: &str) -> Result<String> {
-    let mut last_err = String::new();
-    for attempt in 0..MAX_RETRIES {
-        match client.complete(prompt, Some(system)).await {
-            Ok(response) => return Ok(response),
-            Err(e) => {
-                last_err = e.to_string();
-                let is_retryable = last_err.contains("cooldown")
-                    || last_err.contains("service_busy")
-                    || last_err.contains("rate")
-                    || last_err.contains("429")
-                    || last_err.contains("Upstream")
-                    || last_err.contains("timeout")
-                    || last_err.contains("empty response");
-
-                if !is_retryable || attempt == MAX_RETRIES - 1 {
-                    break;
-                }
-                let delay = RETRY_BASE_DELAY_SECS * (1 << attempt);
-                eprintln!(
-                    "    ⏳ 重试 ({}/{}) 等待 {}s...",
-                    attempt + 1,
-                    MAX_RETRIES,
-                    delay,
-                );
-                tokio::time::sleep(Duration::from_secs(delay)).await;
-            }
-        }
-    }
-    Err(anyhow::anyhow!(
-        "LLM 调用失败 ({}次重试): {}",
-        MAX_RETRIES,
-        last_err
-    ))
 }

--- a/apps/mirror/src/advice.rs
+++ b/apps/mirror/src/advice.rs
@@ -1,9 +1,8 @@
 use crate::lang::t;
-use crate::llm_retry::llm_with_retry;
 use crate::score::{indicator_display, layer_display, ScoreResult, Signal};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use refine_core::infra::LlmClient;
+use refine_core::infra::{llm_with_retry, LlmClient};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::sync::Arc;

--- a/apps/mirror/src/main.rs
+++ b/apps/mirror/src/main.rs
@@ -4,7 +4,6 @@ mod config;
 mod dashboard;
 mod document_save;
 mod lang;
-mod llm_retry;
 mod motd;
 mod profile;
 mod score;

--- a/apps/mirror/src/profile.rs
+++ b/apps/mirror/src/profile.rs
@@ -1,10 +1,9 @@
 use crate::config::ensure_mirror_dir;
 use crate::document_save::{save_report_to_document, SaveDocumentOptions};
 use crate::lang::t;
-use crate::llm_retry::llm_with_retry;
 use crate::score::{self, layer_display, Signal};
 use anyhow::Result;
-use refine_core::infra::LlmClient;
+use refine_core::infra::{llm_with_retry, LlmClient};
 use refine_core::knowledge::{DocumentRepository, Item, ItemRepository, ItemType};
 use refine_core::session::{cluster_observations, ClusterResult};
 use std::collections::HashMap;

--- a/packages/core/src/infra/llm_retry.rs
+++ b/packages/core/src/infra/llm_retry.rs
@@ -1,6 +1,8 @@
-use anyhow::Result;
-use refine_core::error::InfraError;
-use refine_core::infra::{is_quota_exhausted, set_quota_exhausted, LlmClient};
+use super::llm::LlmClient;
+use super::quota_state::{
+    is_exhausted as is_quota_exhausted, set_exhausted as set_quota_exhausted,
+};
+use crate::error::{InfraError, InfraResult};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -26,79 +28,88 @@ pub async fn llm_with_retry(
     client: &Arc<dyn LlmClient>,
     prompt: &str,
     system: &str,
-) -> Result<String> {
-    llm_with_retry_policy(client, prompt, system, LlmRetryPolicy::default()).await
+) -> InfraResult<String> {
+    llm_with_retry_policy(
+        client,
+        prompt,
+        system,
+        LlmRetryPolicy::default(),
+        |_a, _m, _d, _e| {},
+    )
+    .await
 }
 
-pub async fn llm_with_retry_policy(
+pub async fn llm_with_retry_policy<F>(
     client: &Arc<dyn LlmClient>,
     prompt: &str,
     system: &str,
     policy: LlmRetryPolicy,
-) -> Result<String> {
+    mut on_retry: F,
+) -> InfraResult<String>
+where
+    F: FnMut(usize, usize, u64, &InfraError),
+{
     let max_retries = policy.max_retries.max(1);
-    let mut last_err = String::new();
 
     for attempt in 0..max_retries {
         if is_quota_exhausted() {
-            return Err(anyhow::anyhow!("LLM quota exhausted — skipping call"));
+            return Err(InfraError::RateLimited {
+                retry_after_secs: None,
+            });
         }
 
         match client.complete(prompt, Some(system)).await {
             Ok(response) => return Ok(response),
-            Err(InfraError::RateLimited { retry_after_secs }) => {
+            Err(err @ InfraError::RateLimited { retry_after_secs }) => {
                 set_quota_exhausted(retry_after_secs);
-                return Err(anyhow::anyhow!(
-                    "LLM quota exhausted (retry_after: {:?}s)",
-                    retry_after_secs
-                ));
+                return Err(err);
             }
-            Err(e) => {
-                last_err = e.to_string();
-                if !is_retryable_error(&last_err) || attempt == max_retries - 1 {
-                    break;
+            Err(err) => {
+                if !is_retryable_error(&err) || attempt == max_retries - 1 {
+                    return Err(err);
                 }
 
-                let backoff_factor = 1u64.checked_shl(attempt as u32).unwrap_or(u64::MAX);
-                let delay = policy.base_delay_secs.saturating_mul(backoff_factor);
-                eprintln!(
-                    "    Retry ({}/{}) waiting {}s...",
-                    attempt + 1,
-                    max_retries,
-                    delay
-                );
-                if delay > 0 {
-                    tokio::time::sleep(Duration::from_secs(delay)).await;
+                let delay_secs = backoff_delay_secs(policy.base_delay_secs, attempt);
+                on_retry(attempt + 1, max_retries, delay_secs, &err);
+                if delay_secs > 0 {
+                    tokio::time::sleep(Duration::from_secs(delay_secs)).await;
                 }
             }
         }
     }
 
-    Err(anyhow::anyhow!(
-        "LLM call failed ({} retries): {}",
-        max_retries,
-        last_err
-    ))
+    unreachable!("retry loop always returns on success or failure")
 }
 
-fn is_retryable_error(err: &str) -> bool {
-    err.contains("cooldown")
-        || err.contains("service_busy")
-        || err.contains("rate")
-        || err.contains("429")
-        || err.contains("Upstream")
-        || err.contains("timeout")
-        || err.contains("empty response")
+fn is_retryable_error(err: &InfraError) -> bool {
+    let msg = err.to_string();
+    msg.contains("cooldown")
+        || msg.contains("service_busy")
+        || msg.contains("rate")
+        || msg.contains("429")
+        || msg.contains("Upstream")
+        || msg.contains("timeout")
+        || msg.contains("empty response")
+}
+
+fn backoff_delay_secs(base_delay_secs: u64, attempt: usize) -> u64 {
+    let backoff_factor = 1u64.checked_shl(attempt as u32).unwrap_or(u64::MAX);
+    base_delay_secs.saturating_mul(backoff_factor)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::infra::quota_state::{is_exhausted as is_quota_exhausted, set_quota_file_override};
     use async_trait::async_trait;
-    use refine_core::error::{InfraError, InfraResult};
     use std::collections::VecDeque;
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Mutex;
+    use std::sync::{LazyLock, Mutex};
+    use tempfile::TempDir;
+    use tokio::sync::Mutex as AsyncMutex;
+
+    static QUOTA_TEST_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
 
     struct SequenceClient {
         calls: AtomicUsize,
@@ -130,8 +141,30 @@ mod tests {
         }
     }
 
+    struct QuotaTestGuard {
+        _dir: TempDir,
+    }
+
+    impl QuotaTestGuard {
+        fn new() -> Self {
+            let dir = TempDir::new().expect("tempdir");
+            let path = dir.path().join(".refine").join("quota_exhausted_until");
+            set_quota_file_override(Some(path));
+            Self { _dir: dir }
+        }
+    }
+
+    impl Drop for QuotaTestGuard {
+        fn drop(&mut self) {
+            set_quota_file_override(None::<PathBuf>);
+        }
+    }
+
     #[tokio::test]
     async fn retries_on_retryable_error_then_succeeds() {
+        let _env_guard = QUOTA_TEST_LOCK.lock().await;
+        let _quota_guard = QuotaTestGuard::new();
+
         let client = Arc::new(SequenceClient::new(vec![
             Err(InfraError::LlmRequest("429 rate limit".into())),
             Ok("ok".into()),
@@ -145,6 +178,7 @@ mod tests {
                 max_retries: 3,
                 base_delay_secs: 0,
             },
+            |_attempt, _max_retries, _delay_secs, _err| {},
         )
         .await
         .expect("should succeed after retry");
@@ -155,6 +189,9 @@ mod tests {
 
     #[tokio::test]
     async fn does_not_retry_non_retryable_error() {
+        let _env_guard = QUOTA_TEST_LOCK.lock().await;
+        let _quota_guard = QuotaTestGuard::new();
+
         let client = Arc::new(SequenceClient::new(vec![
             Err(InfraError::LlmRequest("invalid api key".into())),
             Ok("unused".into()),
@@ -168,36 +205,45 @@ mod tests {
                 max_retries: 5,
                 base_delay_secs: 0,
             },
+            |_attempt, _max_retries, _delay_secs, _err| {},
         )
         .await
         .expect_err("non-retryable errors should fail fast");
 
+        assert!(matches!(err, InfraError::LlmRequest(_)));
         assert!(err.to_string().contains("invalid api key"));
         assert_eq!(client.calls(), 1);
     }
 
     #[tokio::test]
-    async fn stops_after_max_retries() {
-        let client = Arc::new(SequenceClient::new(vec![
-            Err(InfraError::LlmRequest("timeout".into())),
-            Err(InfraError::LlmRequest("timeout".into())),
-            Err(InfraError::LlmRequest("timeout".into())),
-            Ok("unused".into()),
-        ]));
+    async fn explicit_rate_limit_stops_and_records_quota_state() {
+        let _env_guard = QUOTA_TEST_LOCK.lock().await;
+        let _quota_guard = QuotaTestGuard::new();
+
+        let client = Arc::new(SequenceClient::new(vec![Err(InfraError::RateLimited {
+            retry_after_secs: Some(42),
+        })]));
 
         let err = llm_with_retry_policy(
             &(client.clone() as Arc<dyn LlmClient>),
             "prompt",
             "system",
             LlmRetryPolicy {
-                max_retries: 3,
+                max_retries: 5,
                 base_delay_secs: 0,
             },
+            |_attempt, _max_retries, _delay_secs, _err| {},
         )
         .await
-        .expect_err("should fail when retries exhausted");
+        .expect_err("rate-limited calls should stop immediately");
 
-        assert!(err.to_string().contains("3 retries"));
-        assert_eq!(client.calls(), 3);
+        assert!(matches!(
+            err,
+            InfraError::RateLimited {
+                retry_after_secs: Some(42)
+            }
+        ));
+        assert_eq!(client.calls(), 1);
+        assert!(is_quota_exhausted());
     }
 }

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -12,6 +12,7 @@ use rusqlite::Connection;
 mod contract;
 mod db_migration;
 mod llm;
+mod llm_retry;
 mod paths;
 pub mod quota_state;
 mod sqlite;
@@ -139,6 +140,10 @@ pub use db_migration::{migrate_stale_dbs, MigrationReport};
 pub use llm::{
     build_llm_client_from_env, build_required_llm_client_from_env, ClaudeClient, LlmClient,
     OpenAIClient,
+};
+pub use llm_retry::{
+    llm_with_retry, llm_with_retry_policy, LlmRetryPolicy, DEFAULT_MAX_RETRIES,
+    DEFAULT_RETRY_BASE_DELAY_SECS,
 };
 pub use paths::{default_db_path, ensure_db_dir, resolve_db_path, stale_db_candidates};
 pub use quota_state::{is_exhausted as is_quota_exhausted, set_exhausted as set_quota_exhausted};

--- a/packages/core/src/infra/quota_state.rs
+++ b/packages/core/src/infra/quota_state.rs
@@ -16,8 +16,31 @@ pub const DEFAULT_QUOTA_BACKOFF_SECS: u64 = 3600;
 const MAX_QUOTA_BACKOFF_SECS: u64 = 3600;
 
 fn quota_file_path() -> PathBuf {
+    #[cfg(test)]
+    if let Some(path) = quota_file_override()
+        .lock()
+        .expect("quota override lock poisoned")
+        .clone()
+    {
+        return path;
+    }
+
     let base = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
     base.join(".refine").join("quota_exhausted_until")
+}
+
+#[cfg(test)]
+fn quota_file_override() -> &'static std::sync::Mutex<Option<PathBuf>> {
+    static OVERRIDE: std::sync::OnceLock<std::sync::Mutex<Option<PathBuf>>> =
+        std::sync::OnceLock::new();
+    OVERRIDE.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+#[cfg(test)]
+pub(crate) fn set_quota_file_override(path: Option<PathBuf>) {
+    *quota_file_override()
+        .lock()
+        .expect("quota override lock poisoned") = path;
 }
 
 /// Returns `true` when the persisted quota-exhaustion timestamp is still in


### PR DESCRIPTION
## Summary
- move the canonical LLM retry policy into `refine_core::infra`
- switch CLI ingest/insights and mirror advice/profile to the shared retry helper
- keep focused tests for retry behavior and the CLI quota-hit short circuit

## Testing
- cargo check
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #83