### PR TITLE
feat: unify sqlite bootstrap for stale DB migration

### DIFF
--- a/apps/server/src/persistence.rs
+++ b/apps/server/src/persistence.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use refine_core::infra::prepare_sqlite_db;
 use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::application::ports::{ConversationRepository, EventRepository, JobRepository};
@@ -322,62 +323,7 @@ impl ServerPersistence {
 
     fn ensure_schema(&self) -> Result<(), String> {
         let conn = self.open()?;
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS conversations (
-                id TEXT PRIMARY KEY,
-                user_id TEXT NOT NULL,
-                source TEXT NOT NULL,
-                url TEXT NOT NULL,
-                title TEXT,
-                raw_content TEXT NOT NULL,
-                metadata_json TEXT NOT NULL DEFAULT '{}',
-                captured_at TEXT NOT NULL,
-                created_at TEXT NOT NULL,
-                status TEXT NOT NULL,
-                idempotency_key TEXT NOT NULL UNIQUE,
-                item_ids TEXT NOT NULL,
-                last_error TEXT
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_conversations_status_created
-            ON conversations(status, created_at DESC);
-
-            CREATE INDEX IF NOT EXISTS idx_conversations_captured_at
-            ON conversations(captured_at DESC);
-
-            CREATE TABLE IF NOT EXISTS extraction_jobs (
-                id TEXT PRIMARY KEY,
-                conversation_id TEXT NOT NULL,
-                mode TEXT NOT NULL,
-                status TEXT NOT NULL,
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL,
-                error TEXT
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_extraction_jobs_conversation
-            ON extraction_jobs(conversation_id, created_at DESC);
-
-            CREATE TABLE IF NOT EXISTS events (
-                id TEXT PRIMARY KEY,
-                user_id TEXT NOT NULL,
-                event_name TEXT NOT NULL,
-                source TEXT NOT NULL,
-                properties_json TEXT NOT NULL DEFAULT '{}',
-                created_at TEXT NOT NULL
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_events_created_at
-            ON events(created_at DESC);
-
-            CREATE INDEX IF NOT EXISTS idx_events_event_name_created_at
-            ON events(event_name, created_at DESC);
-            "#,
-        )
-        .map_err(|e| e.to_string())?;
-
-        Ok(())
+        prepare_sqlite_db(&conn).map_err(|e| e.to_string())
     }
 }
 

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -3,8 +3,6 @@ use std::path::{Path, PathBuf};
 
 use super::paths::stale_db_candidates;
 
-const SCHEMA_SQL: &str = include_str!("schema.sql");
-
 /// Result of a `migrate_stale_dbs` run.
 pub enum MigrationReport {
     /// No legacy files were found; nothing was done.
@@ -32,7 +30,8 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     let conn = Connection::open(target)
         .map_err(|e| format!("failed to open target DB {}: {}", target.display(), e))?;
 
-    init_target_schema(&conn)?;
+    crate::infra::prepare_sqlite_db(&conn)
+        .map_err(|e| format!("failed to initialise target schema: {}", e))?;
 
     let mut sources = Vec::new();
     let mut total_rows = 0usize;
@@ -79,11 +78,6 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
         sources,
         rows_copied: total_rows,
     })
-}
-
-fn init_target_schema(conn: &Connection) -> Result<(), String> {
-    conn.execute_batch(SCHEMA_SQL)
-        .map_err(|e| format!("failed to initialise target schema: {}", e))
 }
 
 fn copy_all_tables(conn: &Connection, legacy_alias: &str) -> Result<usize, String> {
@@ -166,7 +160,7 @@ mod tests {
     fn make_target_db(dir: &Path) -> PathBuf {
         let p = dir.join("refine.db");
         let conn = Connection::open(&p).unwrap();
-        init_target_schema(&conn).unwrap();
+        crate::infra::prepare_sqlite_db(&conn).unwrap();
         p
     }
 
@@ -235,39 +229,152 @@ mod tests {
     }
 
     #[test]
-    fn migrates_matching_tables_from_server_db() {
+    fn migrates_server_owned_tables_into_fresh_target() {
         let tmp = TempDir::new().unwrap();
         let target_path = tmp.path().join("refine.db");
-
-        // Target: base schema + a conversations table
-        let tc = Connection::open(&target_path).unwrap();
-        init_target_schema(&tc).unwrap();
-        tc.execute_batch(
-            "CREATE TABLE IF NOT EXISTS conversations (id TEXT PRIMARY KEY, data TEXT)",
-        )
-        .unwrap();
-        drop(tc);
-
-        // Legacy: conversations only
         let legacy = tmp.path().join("server.db");
         let lc = Connection::open(&legacy).unwrap();
         lc.execute_batch(
-            "CREATE TABLE IF NOT EXISTS conversations (id TEXT PRIMARY KEY, data TEXT)",
+            "CREATE TABLE conversations (
+                id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                source TEXT NOT NULL,
+                url TEXT NOT NULL,
+                title TEXT,
+                raw_content TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                captured_at TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                status TEXT NOT NULL,
+                idempotency_key TEXT NOT NULL UNIQUE,
+                item_ids TEXT NOT NULL,
+                last_error TEXT
+            );
+            CREATE TABLE extraction_jobs (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                mode TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                error TEXT
+            );
+            CREATE TABLE events (
+                id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                event_name TEXT NOT NULL,
+                source TEXT NOT NULL,
+                properties_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL
+            );",
         )
         .unwrap();
-        lc.execute("INSERT INTO conversations VALUES ('conv-1', 'hello')", [])
-            .unwrap();
+        lc.execute(
+            "INSERT INTO conversations
+             (id, user_id, source, url, title, raw_content, metadata_json, captured_at,
+              created_at, status, idempotency_key, item_ids, last_error)
+             VALUES
+             ('conv-1', 'user-1', 'extension', 'https://example.com/1', 'Title 1', 'Raw 1',
+              '{}', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'captured', 'idem-1',
+              '[]', NULL)",
+            [],
+        )
+        .unwrap();
+        lc.execute(
+            "INSERT INTO extraction_jobs
+             (id, conversation_id, mode, status, created_at, updated_at, error)
+             VALUES
+             ('job-1', 'conv-1', 'auto', 'pending', '2026-01-01T00:00:00Z',
+              '2026-01-01T00:05:00Z', NULL)",
+            [],
+        )
+        .unwrap();
+        lc.execute(
+            "INSERT INTO events
+             (id, user_id, event_name, source, properties_json, created_at)
+             VALUES
+             ('event-1', 'user-1', 'conversation_created', 'extension', '{}',
+              '2026-01-01T00:10:00Z')",
+            [],
+        )
+        .unwrap();
         drop(lc);
 
-        migrate_stale_dbs(&target_path).unwrap();
+        let report = migrate_stale_dbs(&target_path).unwrap();
+        assert!(matches!(
+            report,
+            MigrationReport::Migrated { rows_copied: 3, .. }
+        ));
+        assert!(
+            !legacy.exists(),
+            "legacy DB should be renamed after success"
+        );
+        assert!(tmp.path().join("server.db.migrated").exists());
 
         let tc = Connection::open(&target_path).unwrap();
-        let count: i64 = tc
+        let conversation_count: i64 = tc
             .query_row(
                 "SELECT COUNT(*) FROM conversations WHERE id='conv-1'",
                 [],
                 |r| r.get(0),
             )
+            .unwrap();
+        let job_count: i64 = tc
+            .query_row(
+                "SELECT COUNT(*) FROM extraction_jobs WHERE id='job-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let event_count: i64 = tc
+            .query_row("SELECT COUNT(*) FROM events WHERE id='event-1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(conversation_count, 1);
+        assert_eq!(job_count, 1);
+        assert_eq!(event_count, 1);
+    }
+
+    #[test]
+    fn migrates_subset_of_server_tables_without_manual_target_bootstrap() {
+        let tmp = TempDir::new().unwrap();
+        let target_path = tmp.path().join("refine.db");
+        let legacy = tmp.path().join("server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        lc.execute_batch(
+            "CREATE TABLE events (
+                id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                event_name TEXT NOT NULL,
+                source TEXT NOT NULL,
+                properties_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        lc.execute(
+            "INSERT INTO events
+             (id, user_id, event_name, source, properties_json, created_at)
+             VALUES
+             ('event-2', 'user-2', 'conversation_synced', 'extension', '{}',
+              '2026-02-02T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+        drop(lc);
+
+        let report = migrate_stale_dbs(&target_path).unwrap();
+        assert!(matches!(
+            report,
+            MigrationReport::Migrated { rows_copied: 1, .. }
+        ));
+
+        let tc = Connection::open(&target_path).unwrap();
+        let count: i64 = tc
+            .query_row("SELECT COUNT(*) FROM events WHERE id='event-2'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert_eq!(count, 1);
     }

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -6,12 +6,127 @@
 //! - `llm.rs` - LLM 客户端 (Claude, OpenAI)
 //! - `schema.sql` - 数据库 Schema
 
+use crate::error::{InfraError, InfraResult};
+use rusqlite::Connection;
+
 mod contract;
 mod db_migration;
 mod llm;
 mod paths;
 pub mod quota_state;
 mod sqlite;
+
+const FTS_BOOTSTRAP_USER_VERSION: i64 = 1;
+const ALLOWED_COLUMN_EXISTS_TABLES: &[&str] = &["items", "documents"];
+
+pub fn prepare_sqlite_db(conn: &Connection) -> InfraResult<()> {
+    conn.execute_batch(include_str!("schema.sql"))
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+
+    migrate_items_add_document_columns(conn)?;
+    migrate_documents_url_unique(conn)?;
+    let _ = maybe_rebuild_fts_index(conn)?;
+
+    Ok(())
+}
+
+pub(crate) fn maybe_rebuild_fts_index(conn: &Connection) -> InfraResult<bool> {
+    let user_version = conn
+        .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    if user_version < FTS_BOOTSTRAP_USER_VERSION {
+        let item_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM items", [], |row| row.get(0))
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+        let rebuilt = if item_count > 0 {
+            conn.execute("INSERT INTO items_fts(items_fts) VALUES('rebuild')", [])
+                .map_err(|e| InfraError::Database(e.to_string()))?;
+            true
+        } else {
+            false
+        };
+        conn.pragma_update(None, "user_version", FTS_BOOTSTRAP_USER_VERSION)
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+        return Ok(rebuilt);
+    }
+
+    if conn
+        .execute(
+            "INSERT INTO items_fts(items_fts) VALUES('integrity-check')",
+            [],
+        )
+        .is_ok()
+    {
+        return Ok(false);
+    }
+
+    conn.execute("INSERT INTO items_fts(items_fts) VALUES('rebuild')", [])
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    conn.execute(
+        "INSERT INTO items_fts(items_fts) VALUES('integrity-check')",
+        [],
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(true)
+}
+
+pub(crate) fn column_exists(conn: &Connection, table: &str, column: &str) -> InfraResult<bool> {
+    if !ALLOWED_COLUMN_EXISTS_TABLES.contains(&table) {
+        return Err(InfraError::Database(format!("unknown table: {table}")));
+    }
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let names: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| InfraError::Database(e.to_string()))?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(names.iter().any(|n| n == column))
+}
+
+fn migrate_items_add_document_columns(conn: &Connection) -> InfraResult<()> {
+    let has_document_id = column_exists(conn, "items", "document_id")?;
+    if !has_document_id {
+        conn.execute_batch("ALTER TABLE items ADD COLUMN document_id TEXT")
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+    }
+    let has_excerpt = column_exists(conn, "items", "excerpt")?;
+    if !has_excerpt {
+        conn.execute_batch("ALTER TABLE items ADD COLUMN excerpt TEXT")
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+    }
+    conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_items_document ON items(document_id)")
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(())
+}
+
+fn migrate_documents_url_unique(conn: &Connection) -> InfraResult<()> {
+    conn.execute_batch(
+        "UPDATE items
+         SET document_id = (
+             SELECT d_keep.id
+             FROM documents d_dup
+             JOIN documents d_keep ON d_dup.url = d_keep.url
+             WHERE d_dup.id = items.document_id
+               AND d_keep.rowid = (SELECT MIN(rowid) FROM documents WHERE url = d_dup.url)
+         )
+         WHERE document_id IN (
+             SELECT id FROM documents
+             WHERE rowid NOT IN (SELECT MIN(rowid) FROM documents GROUP BY url)
+         )",
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))?;
+    conn.execute_batch(
+        "DELETE FROM documents WHERE rowid NOT IN (SELECT MIN(rowid) FROM documents GROUP BY url)",
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))?;
+    conn.execute_batch("DROP INDEX IF EXISTS idx_documents_url")
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    conn.execute_batch("CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_url ON documents(url)")
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(())
+}
 
 // 公共 API
 pub use contract::{

--- a/packages/core/src/infra/schema.sql
+++ b/packages/core/src/infra/schema.sql
@@ -85,3 +85,53 @@ CREATE TRIGGER IF NOT EXISTS documents_au AFTER UPDATE ON documents BEGIN
     INSERT INTO documents_fts(rowid, title, raw_content, source)
     VALUES (NEW.rowid, NEW.title, NEW.raw_content, NEW.source);
 END;
+
+CREATE TABLE IF NOT EXISTS conversations (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    url TEXT NOT NULL,
+    title TEXT,
+    raw_content TEXT NOT NULL,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    captured_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    status TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    item_ids TEXT NOT NULL,
+    last_error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_status_created
+ON conversations(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_captured_at
+ON conversations(captured_at DESC);
+
+CREATE TABLE IF NOT EXISTS extraction_jobs (
+    id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_extraction_jobs_conversation
+ON extraction_jobs(conversation_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS events (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    event_name TEXT NOT NULL,
+    source TEXT NOT NULL,
+    properties_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_created_at
+ON events(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_events_event_name_created_at
+ON events(event_name, created_at DESC);

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -4,122 +4,21 @@ use crate::knowledge::{Item, ItemType};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension};
 
-const FTS_BOOTSTRAP_USER_VERSION: i64 = 1;
+#[cfg(test)]
+const FTS_BOOTSTRAP_USER_VERSION: i64 = super::super::FTS_BOOTSTRAP_USER_VERSION;
 
 pub(super) fn init_schema(conn: &Connection) -> InfraResult<()> {
-    conn.execute_batch(include_str!("../schema.sql"))
-        .map_err(|e| InfraError::Database(e.to_string()))?;
-
-    migrate_items_add_document_columns(conn)?;
-    migrate_documents_url_unique(conn)?;
-    let _ = maybe_rebuild_fts_index(conn)?;
-
-    Ok(())
+    super::super::prepare_sqlite_db(conn)
 }
 
-fn migrate_items_add_document_columns(conn: &Connection) -> InfraResult<()> {
-    let has_document_id = column_exists(conn, "items", "document_id")?;
-    if !has_document_id {
-        conn.execute_batch("ALTER TABLE items ADD COLUMN document_id TEXT")
-            .map_err(|e| InfraError::Database(e.to_string()))?;
-    }
-    let has_excerpt = column_exists(conn, "items", "excerpt")?;
-    if !has_excerpt {
-        conn.execute_batch("ALTER TABLE items ADD COLUMN excerpt TEXT")
-            .map_err(|e| InfraError::Database(e.to_string()))?;
-    }
-    conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_items_document ON items(document_id)")
-        .map_err(|e| InfraError::Database(e.to_string()))?;
-    Ok(())
-}
-
-fn migrate_documents_url_unique(conn: &Connection) -> InfraResult<()> {
-    // Remap items that point to a duplicate document to the kept document (earliest rowid
-    // per URL) before deleting duplicates, so no items become orphans after the migration.
-    conn.execute_batch(
-        "UPDATE items
-         SET document_id = (
-             SELECT d_keep.id
-             FROM documents d_dup
-             JOIN documents d_keep ON d_dup.url = d_keep.url
-             WHERE d_dup.id = items.document_id
-               AND d_keep.rowid = (SELECT MIN(rowid) FROM documents WHERE url = d_dup.url)
-         )
-         WHERE document_id IN (
-             SELECT id FROM documents
-             WHERE rowid NOT IN (SELECT MIN(rowid) FROM documents GROUP BY url)
-         )",
-    )
-    .map_err(|e| InfraError::Database(e.to_string()))?;
-    // Remove duplicate URLs keeping the earliest-inserted row before adding constraint.
-    conn.execute_batch(
-        "DELETE FROM documents WHERE rowid NOT IN (SELECT MIN(rowid) FROM documents GROUP BY url)",
-    )
-    .map_err(|e| InfraError::Database(e.to_string()))?;
-    // Drop old non-unique index (may not exist on fresh databases).
-    conn.execute_batch("DROP INDEX IF EXISTS idx_documents_url")
-        .map_err(|e| InfraError::Database(e.to_string()))?;
-    // Create unique index so concurrent inserts of the same URL fail fast.
-    conn.execute_batch("CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_url ON documents(url)")
-        .map_err(|e| InfraError::Database(e.to_string()))?;
-    Ok(())
-}
-
-const ALLOWED_TABLES: &[&str] = &["items", "documents"];
-
+#[cfg(test)]
 fn column_exists(conn: &Connection, table: &str, column: &str) -> InfraResult<bool> {
-    if !ALLOWED_TABLES.contains(&table) {
-        return Err(InfraError::Database(format!("unknown table: {table}")));
-    }
-    let mut stmt = conn
-        .prepare(&format!("PRAGMA table_info({table})"))
-        .map_err(|e| InfraError::Database(e.to_string()))?;
-    let names: Vec<String> = stmt
-        .query_map([], |row| row.get::<_, String>(1))
-        .map_err(|e| InfraError::Database(e.to_string()))?
-        .filter_map(|r| r.ok())
-        .collect();
-    Ok(names.iter().any(|n| n == column))
+    super::super::column_exists(conn, table, column)
 }
 
+#[cfg(test)]
 fn maybe_rebuild_fts_index(conn: &Connection) -> InfraResult<bool> {
-    let user_version = conn
-        .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
-        .map_err(|e| InfraError::Database(e.to_string()))?;
-    if user_version < FTS_BOOTSTRAP_USER_VERSION {
-        let item_count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM items", [], |row| row.get(0))
-            .map_err(|e| InfraError::Database(e.to_string()))?;
-        let rebuilt = if item_count > 0 {
-            conn.execute("INSERT INTO items_fts(items_fts) VALUES('rebuild')", [])
-                .map_err(|e| InfraError::Database(e.to_string()))?;
-            true
-        } else {
-            false
-        };
-        conn.pragma_update(None, "user_version", FTS_BOOTSTRAP_USER_VERSION)
-            .map_err(|e| InfraError::Database(e.to_string()))?;
-        return Ok(rebuilt);
-    }
-
-    if conn
-        .execute(
-            "INSERT INTO items_fts(items_fts) VALUES('integrity-check')",
-            [],
-        )
-        .is_ok()
-    {
-        return Ok(false);
-    }
-
-    conn.execute("INSERT INTO items_fts(items_fts) VALUES('rebuild')", [])
-        .map_err(|e| InfraError::Database(e.to_string()))?;
-    conn.execute(
-        "INSERT INTO items_fts(items_fts) VALUES('integrity-check')",
-        [],
-    )
-    .map_err(|e| InfraError::Database(e.to_string()))?;
-    Ok(true)
+    super::super::maybe_rebuild_fts_index(conn)
 }
 pub(super) fn find_by_id(conn: &Connection, id: &str) -> InfraResult<Option<Item>> {
     let mut stmt = conn


### PR DESCRIPTION
## Summary
- unify SQLite bootstrap so migration, SqliteStore startup, and server persistence prepare the same schema
- add server-owned tables and indexes to the canonical core schema used before stale DB row copying
- add migration regressions for fresh-target server.db imports and partial legacy server schemas

Closes #84