### PR TITLE
ci: gate rustfmt and frontend typecheck/build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,39 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libglib2.0-dev
       - run: cargo clippy --workspace -- -D warnings
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  extension:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/extension
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+      - run: bun run build
+
+  desktop-ui:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/desktop/ui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run build


### PR DESCRIPTION
## Summary
- Adds `fmt` job that runs `cargo fmt --all -- --check`
- Adds `extension` job that installs deps with bun, then runs `typecheck` + `build` for `apps/extension`
- Adds `desktop-ui` job that installs deps with bun, then runs `build` (`tsc && vite build`) for `apps/desktop/ui`

Each frontend job runs in its own GitHub Actions runner so failures stay isolated and do not hide Rust results.

Closes #82.

## Test plan
- [x] Local `cargo fmt --all -- --check` exits 0
- [x] Local `bun install --frozen-lockfile && bun run typecheck && bun run build` in `apps/extension` succeeds
- [x] Local `bun install --frozen-lockfile && bun run build` in `apps/desktop/ui` succeeds
- [ ] CI runs and all five new/existing jobs pass on this PR