### PR TITLE
fix(session): tolerate malformed JSONL lines and populate started_at

### DIFF
--- a/packages/core/src/session/parser.rs
+++ b/packages/core/src/session/parser.rs
@@ -1,9 +1,23 @@
 //! JSONL 会话解析器
 //!
 //! 支持 Claude Code 和 Codex 两种格式
+//!
+//! 解析策略：line-level error recovery。
+//! JSONL 是 append-only 流；当进程被 SIGKILL 或盘满时常见尾行被截断，
+//! 中途偶发损坏行不应该让整个会话被丢弃。每条 line 独立解析：
+//! - 解析成功 → 累积到 messages / meta
+//! - 解析失败 → 记 warn 日志（带 line index 与截断 snippet），继续下一行
+//!
+//! 同时从原始 JSONL 提取首个时间戳填充 `SessionMeta.started_at`，
+//! 弥补先前的 declaration-execution gap（字段定义但从未写入）。
 
 use super::types::{MessageRole, Session, SessionMessage, SessionMeta, SessionSource};
+use chrono::{DateTime, Utc};
 use std::path::Path;
+use tracing::warn;
+
+/// 单行 snippet 在日志里的最大长度，避免泄漏整条原始内容到日志后端。
+const SNIPPET_MAX: usize = 120;
 
 /// 解析 JSONL 文件为 Session
 pub fn parse_session_file(path: &Path, source: SessionSource) -> Result<Session, String> {
@@ -12,6 +26,9 @@ pub fn parse_session_file(path: &Path, source: SessionSource) -> Result<Session,
 }
 
 /// 解析 JSONL 字符串内容为 Session（可测试）
+///
+/// 返回 `Err` 仅在调用方传入完全无法处理的输入时；单行 JSON 错误不会
+/// 中断整个文件解析，遵循 JSONL append-only 流的容错惯例。
 pub fn parse_session_content(
     content: &str,
     path: &Path,
@@ -19,14 +36,29 @@ pub fn parse_session_content(
 ) -> Result<Session, String> {
     let mut messages = Vec::new();
     let mut meta = SessionMeta::default();
+    let mut malformed = 0usize;
 
-    for line in content.lines() {
+    for (idx, line) in content.lines().enumerate() {
         let line = line.trim();
         if line.is_empty() {
             continue;
         }
-        let value: serde_json::Value =
-            serde_json::from_str(line).map_err(|e| format!("JSON 解析失败: {}", e))?;
+        let value: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(e) => {
+                malformed += 1;
+                warn!(
+                    path = %path.display(),
+                    line = idx + 1,
+                    error = %e,
+                    snippet = %truncate_snippet(line),
+                    "skipping malformed JSONL line"
+                );
+                continue;
+            }
+        };
+
+        update_meta_started_at(&value, &mut meta);
 
         match source {
             SessionSource::ClaudeCode => {
@@ -38,12 +70,58 @@ pub fn parse_session_content(
         }
     }
 
+    if malformed > 0 {
+        warn!(
+            path = %path.display(),
+            malformed,
+            kept = messages.len(),
+            "JSONL parse completed with skipped lines"
+        );
+    }
+
     Ok(Session {
         source,
         file_path: path.to_path_buf(),
         messages,
         meta,
     })
+}
+
+/// 截断单行内容用于日志输出。
+fn truncate_snippet(line: &str) -> String {
+    if line.len() <= SNIPPET_MAX {
+        line.to_string()
+    } else {
+        // char_indices 避免在 UTF-8 字符中间切断。
+        let cut = line
+            .char_indices()
+            .take_while(|(i, _)| *i < SNIPPET_MAX)
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
+        format!("{}…", &line[..cut])
+    }
+}
+
+/// 解析 ISO-8601 字符串为 `DateTime<Utc>`。
+fn parse_iso8601_utc(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+/// 同时覆盖两种格式：Claude Code 与 Codex 行均在顶层带 `timestamp` 字段。
+/// 取首个能解析成 RFC3339 的时间戳作为 `started_at`，与 JSONL 写入顺序对齐。
+fn update_meta_started_at(value: &serde_json::Value, meta: &mut SessionMeta) {
+    if meta.started_at.is_some() {
+        return;
+    }
+    let Some(ts_str) = value.get("timestamp").and_then(|v| v.as_str()) else {
+        return;
+    };
+    if let Some(ts) = parse_iso8601_utc(ts_str) {
+        meta.started_at = Some(ts);
+    }
 }
 
 /// Claude Code 格式:
@@ -239,5 +317,144 @@ mod tests {
         .unwrap();
 
         assert_eq!(session.messages.len(), 0);
+    }
+
+    /// 真实场景：JSONL 进程被 SIGKILL 后尾行截断，前面的合法行不应该被丢弃。
+    #[test]
+    fn parse_recovers_from_truncated_tail() {
+        let jsonl = "{\"type\":\"user\",\"message\":{\"content\":\"hello\"}}\n\
+                     {\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n\
+                     {\"type\":\"user\",\"message\":{\"content\":\"oh n";
+        let session = parse_session_content(
+            jsonl,
+            &PathBuf::from("/tmp/truncated.jsonl"),
+            SessionSource::ClaudeCode,
+        )
+        .unwrap();
+
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].content, "hello");
+        assert_eq!(session.messages[1].content, "hi");
+    }
+
+    /// 中段单行损坏：仅丢弃损坏行，前后行正常累积。
+    #[test]
+    fn parse_recovers_from_midstream_corruption() {
+        let jsonl = r#"{"type":"user","message":{"content":"first"}}
+{not even json
+{"type":"assistant","message":{"content":[{"type":"text","text":"after corruption"}]}}
+"#;
+        let session = parse_session_content(
+            jsonl,
+            &PathBuf::from("/tmp/midcorrupt.jsonl"),
+            SessionSource::ClaudeCode,
+        )
+        .unwrap();
+
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].content, "first");
+        assert_eq!(session.messages[1].content, "after corruption");
+    }
+
+    #[test]
+    fn parse_extracts_started_at_claude_code() {
+        let jsonl = r#"{"type":"system","timestamp":"2026-04-21T05:09:08.212Z","message":{"model":"claude-sonnet-4-20250514"}}
+{"type":"user","timestamp":"2026-04-21T05:09:09.000Z","message":{"content":"hello"}}
+{"type":"assistant","timestamp":"2026-04-21T05:09:10.500Z","message":{"content":[{"type":"text","text":"hi"}]}}
+"#;
+        let session = parse_session_content(
+            jsonl,
+            &PathBuf::from("/tmp/ts.jsonl"),
+            SessionSource::ClaudeCode,
+        )
+        .unwrap();
+
+        let started = session.meta.started_at.expect("started_at should be set");
+        assert_eq!(started.to_rfc3339(), "2026-04-21T05:09:08.212+00:00");
+    }
+
+    #[test]
+    fn parse_extracts_started_at_codex() {
+        let jsonl = r#"{"timestamp":"2026-04-10T05:46:47.113Z","type":"session_meta","payload":{},"model":"o3-mini"}
+{"timestamp":"2026-04-10T05:46:48.000Z","type":"user_message","content":"go"}
+{"timestamp":"2026-04-10T05:46:49.222Z","type":"response_item","payload":{"content":[{"type":"text","text":"ok"}]}}
+"#;
+        let session = parse_session_content(
+            jsonl,
+            &PathBuf::from("/tmp/codex-ts.jsonl"),
+            SessionSource::Codex,
+        )
+        .unwrap();
+
+        let started = session.meta.started_at.expect("started_at should be set");
+        assert_eq!(started.to_rfc3339(), "2026-04-10T05:46:47.113+00:00");
+        assert_eq!(session.messages.len(), 2);
+    }
+
+    #[test]
+    fn parse_started_at_remains_none_without_timestamps() {
+        let jsonl = r#"{"type":"user","message":{"content":"no ts here"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"nor here"}]}}
+"#;
+        let session = parse_session_content(
+            jsonl,
+            &PathBuf::from("/tmp/no-ts.jsonl"),
+            SessionSource::ClaudeCode,
+        )
+        .unwrap();
+
+        assert!(session.meta.started_at.is_none());
+        assert_eq!(session.messages.len(), 2);
+    }
+
+    /// `started_at` 锁定首个合法时间戳；后续行的更晚时间戳不应覆盖它。
+    #[test]
+    fn parse_started_at_keeps_first_valid_timestamp() {
+        let jsonl = r#"{"type":"user","timestamp":"2026-01-01T00:00:00Z","message":{"content":"first"}}
+{"type":"user","timestamp":"2026-12-31T23:59:59Z","message":{"content":"later"}}
+"#;
+        let session = parse_session_content(
+            jsonl,
+            &PathBuf::from("/tmp/order-ts.jsonl"),
+            SessionSource::ClaudeCode,
+        )
+        .unwrap();
+
+        let started = session.meta.started_at.expect("started_at should be set");
+        assert_eq!(started.to_rfc3339(), "2026-01-01T00:00:00+00:00");
+    }
+
+    /// 时间戳字符串无法解析时不写入 started_at，但其它字段照常处理，避免静默降级污染元数据。
+    #[test]
+    fn parse_ignores_unparseable_timestamp_strings() {
+        let jsonl = r#"{"type":"user","timestamp":"not-a-real-date","message":{"content":"hello"}}
+{"type":"assistant","timestamp":"2026-04-21T05:00:00Z","message":{"content":[{"type":"text","text":"hi"}]}}
+"#;
+        let session = parse_session_content(
+            jsonl,
+            &PathBuf::from("/tmp/bad-ts.jsonl"),
+            SessionSource::ClaudeCode,
+        )
+        .unwrap();
+
+        let started = session.meta.started_at.expect("should fall through to next valid ts");
+        assert_eq!(started.to_rfc3339(), "2026-04-21T05:00:00+00:00");
+        assert_eq!(session.messages.len(), 2);
+    }
+
+    #[test]
+    fn truncate_snippet_handles_utf8_boundaries() {
+        // 多字节字符在 SNIPPET_MAX 边界附近时不应导致越界 panic。
+        let s: String = "中".repeat(80); // 240 bytes, well past SNIPPET_MAX
+        let out = truncate_snippet(&s);
+        assert!(out.ends_with('…'));
+        // 必须仍是合法 UTF-8（如果切坏 String 构造会 panic）
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn truncate_snippet_passthrough_for_short_lines() {
+        let out = truncate_snippet("short");
+        assert_eq!(out, "short");
     }
 }


### PR DESCRIPTION
## Summary

Two related robustness fixes inside the session JSONL parser used by `refine ingest-sessions`.

**1. Line-level error recovery for malformed JSONL.** Today a single bad line aborts `parse_session_content` and the entire session is discarded. JSONL files from Claude Code and Codex are append-only streams; a truncated tail after SIGKILL or disk-pressure flush is a real failure mode and shouldn't take a 30 MB session with it. Each line is now parsed independently — malformed lines emit a `warn` with line index and a UTF-8-safe snippet, parsing continues, and an end-of-file summary `warn` surfaces the degraded-output condition (rule U-29) instead of letting it pass silently.

**2. Close the `started_at` declaration-execution gap (RS-14).** `SessionMeta.started_at: Option<DateTime<Utc>>` is declared in `types.rs` but was never populated. Both source formats already carry a top-level RFC3339 `timestamp` field on every line — the parser now locks `started_at` to the first successfully parsed timestamp, which matches JSONL append order. Unparseable strings fall through to the next valid timestamp rather than being silently coerced.

## Why these two changes ride together

They touch the same function (`parse_session_content`) and share the same per-line scan. Splitting them into two PRs would force two reviews of the same control flow. The behavior of each is independently tested.

## Test plan

- [x] `cargo test -p refine-core --lib session::parser` — 12/12 pass (3 pre-existing + 9 new)
- [x] `cargo test -p refine-core --lib` — 87/87 pass, no regressions
- [x] `cargo check --workspace` — clean
- [x] `cargo clippy -p refine-core --lib --no-deps` — clean

### New tests

| Test | What it pins |
|------|--------------|
| `parse_recovers_from_truncated_tail` | SIGKILL-style trailing partial line is skipped, prior lines kept |
| `parse_recovers_from_midstream_corruption` | Single bad line in middle does not poison surrounding messages |
| `parse_extracts_started_at_claude_code` | First Claude Code top-level `timestamp` populates `started_at` |
| `parse_extracts_started_at_codex` | First Codex top-level `timestamp` populates `started_at` |
| `parse_started_at_remains_none_without_timestamps` | Backward-compatible with timestamp-free fixtures |
| `parse_started_at_keeps_first_valid_timestamp` | Earliest timestamp wins; later lines do not overwrite |
| `parse_ignores_unparseable_timestamp_strings` | RFC3339 parse failure falls through, no silent coercion |
| `truncate_snippet_handles_utf8_boundaries` | Multibyte chars near `SNIPPET_MAX` do not panic |
| `truncate_snippet_passthrough_for_short_lines` | Short lines are unmodified |

## Backward compatibility

- Public API unchanged: `parse_session_content` still returns `Result<Session, String>`. The error path is now reserved for input the function genuinely cannot process at all (currently nothing — line errors are no longer fatal). Callers that previously received `Ok(session)` continue to receive it. Callers that previously received `Err(...)` for a truncated tail now receive `Ok(session)` with the salvaged messages plus a `warn` log.
- `SessionMeta.started_at` was already `Option<DateTime<Utc>>` and was always `None`; existing consumers see either the same `None` (no timestamps in input) or now a real value when one is present.

## What this does not change

- No new dependencies (`chrono` already in `Cargo.toml`).
- No DB schema, no public CLI flag, no env var.
- Discovery, filtering, chunking, LLM calls, persistence — all untouched.