### PR TITLE
fix(server): apply canonical SQLite PRAGMAs on every connection (#98)

### DIFF
--- a/apps/server/src/persistence.rs
+++ b/apps/server/src/persistence.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use refine_core::infra::prepare_sqlite_db;
+use refine_core::infra::{configure_sqlite_connection, prepare_sqlite_db};
 use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::application::ports::{ConversationRepository, EventRepository, JobRepository};
@@ -316,8 +316,7 @@ impl ServerPersistence {
 
     fn open(&self) -> Result<Connection, String> {
         let conn = Connection::open(&self.db_path).map_err(|e| e.to_string())?;
-        conn.busy_timeout(std::time::Duration::from_secs(5))
-            .map_err(|e| e.to_string())?;
+        configure_sqlite_connection(&conn).map_err(|e| e.to_string())?;
         Ok(conn)
     }
 
@@ -691,6 +690,32 @@ mod tests {
             .expect("job should exist");
         assert_eq!(loaded.id, job.id);
         assert_eq!(loaded.status, JobStatus::Pending);
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn open_applies_canonical_pragmas() {
+        let path = temp_db_path();
+        let persistence = ServerPersistence::new(path.clone()).expect("persistence init failed");
+
+        let conn = persistence.open().expect("open connection");
+        let foreign_keys: i64 = conn
+            .pragma_query_value(None, "foreign_keys", |row| row.get(0))
+            .expect("read foreign_keys pragma");
+        let journal_mode: String = conn
+            .pragma_query_value(None, "journal_mode", |row| row.get(0))
+            .expect("read journal_mode pragma");
+
+        assert_eq!(
+            foreign_keys, 1,
+            "foreign_keys must be enabled on every server connection"
+        );
+        assert_eq!(
+            journal_mode.to_lowercase(),
+            "wal",
+            "server connections must run under WAL journal mode"
+        );
 
         cleanup(&path);
     }

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -30,6 +30,9 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     let conn = Connection::open(target)
         .map_err(|e| format!("failed to open target DB {}: {}", target.display(), e))?;
 
+    crate::infra::configure_sqlite_connection(&conn)
+        .map_err(|e| format!("failed to configure target connection: {}", e))?;
+
     crate::infra::prepare_sqlite_db(&conn)
         .map_err(|e| format!("failed to initialise target schema: {}", e))?;
 

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -31,6 +31,18 @@ pub fn prepare_sqlite_db(conn: &Connection) -> InfraResult<()> {
     Ok(())
 }
 
+/// Apply the canonical PRAGMA configuration (foreign_keys, WAL, busy_timeout,
+/// temp_store, synchronous) to a freshly opened SQLite connection.
+///
+/// Every entry point that opens a connection to the shared application database
+/// must call this — `foreign_keys` and `busy_timeout` are connection-scoped, so
+/// missing the call leaves the connection running with SQLite defaults
+/// regardless of how the WAL journal was initialised on the file.
+pub fn configure_sqlite_connection(conn: &Connection) -> InfraResult<()> {
+    let in_memory = matches!(conn.path(), Some(":memory:") | None);
+    sqlite::configure_connection(conn, in_memory)
+}
+
 pub(crate) fn maybe_rebuild_fts_index(conn: &Connection) -> InfraResult<bool> {
     let user_version = conn
         .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))

--- a/packages/core/src/infra/sqlite/mod.rs
+++ b/packages/core/src/infra/sqlite/mod.rs
@@ -19,6 +19,8 @@ mod worker;
 
 use worker::{start_worker, OpenMode, SqliteCommand, WorkerHandle};
 
+pub(crate) use rows::configure_connection;
+
 const WORKER_CLOSED: &str = "sqlite worker closed";
 
 /// SQLite 存储

--- a/packages/core/src/infra/sqlite/rows.rs
+++ b/packages/core/src/infra/sqlite/rows.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 use std::time::Duration;
 
-pub(super) fn configure_connection(conn: &Connection, in_memory: bool) -> InfraResult<()> {
+pub(crate) fn configure_connection(conn: &Connection, in_memory: bool) -> InfraResult<()> {
     conn.busy_timeout(Duration::from_secs(5))
         .map_err(|e| InfraError::Database(e.to_string()))?;
 


### PR DESCRIPTION
## Summary
- `ServerPersistence::open()` now invokes a shared `configure_sqlite_connection` helper so every server connection gets the same `foreign_keys=ON`, `journal_mode=WAL`, `busy_timeout=5s`, `temp_store=MEMORY`, `synchronous=NORMAL` PRAGMA stack as the SQLite worker.
- Promotes the worker's PRAGMA logic from `pub(super)` in `infra::sqlite::rows` to a public infra API (`refine_core::infra::configure_sqlite_connection`) that auto-detects in-memory vs file mode.
- Wires the same helper into the stale-db migration target so the migration connection no longer runs with SQLite defaults.

## Why this matters (CR-4 in #98)
`ServerPersistence` opened raw `Connection::open()` handles and only set `busy_timeout`. The worker path applied WAL + foreign keys + temp_store via `configure_connection`. With two PRAGMA strategies on the same physical file, concurrent writes triggered `SQLITE_BUSY`, and — more importantly — every server query ran with `foreign_keys=OFF` because that PRAGMA is connection-scoped. Schema FK constraints (added later in #98 follow-ups) would have been silently ignored.

## Test plan
- [x] `cargo check -p refine-core -p refine-server`
- [x] `cargo test -p refine-server persistence::` (6 tests, including new `open_applies_canonical_pragmas` regression check)
- [x] `cargo test -p refine-core --lib infra::` (35 tests, no regressions)

## Notes
- This PR addresses CR-4 only. CR-5 (FOREIGN KEY constraints in schema), HI-1 (transaction boundaries), and HI-2 (state-machine transition validation) remain open in #98 and need separate PRs because they require schema migrations / API shape changes.
- Does not modify Cargo.toml versions (per project policy on concurrent PRs).