### PR TITLE
fix(security): session file size cap + constant-time token compare (#101)

### DIFF
--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -20,6 +20,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 dirs = "5"
 dotenvy = "0.15"
 rusqlite.workspace = true
+subtle = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/server/src/auth.rs
+++ b/apps/server/src/auth.rs
@@ -1,4 +1,5 @@
 use axum::http::HeaderMap;
+use subtle::ConstantTimeEq;
 
 const UNAUTHORIZED_MESSAGE: &str =
     "Unauthorized: provide Authorization: Bearer <token> and ensure REFINE_API_TOKEN matches.";
@@ -29,7 +30,9 @@ pub fn authorize_user(
             .unwrap_or_default()
             .trim();
 
-        if provided != token {
+        // Constant-time comparison to avoid byte-by-byte timing leak (HI-7).
+        // `ct_eq` short-circuits to false on length mismatch in constant time.
+        if provided.as_bytes().ct_eq(token.as_bytes()).unwrap_u8() != 1 {
             return Err(UNAUTHORIZED_MESSAGE.to_string());
         }
 
@@ -81,6 +84,29 @@ mod tests {
             result.err().unwrap_or_default().contains("REFINE_DEV_ANON"),
             "error message must mention REFINE_DEV_ANON"
         );
+    }
+
+    #[test]
+    fn authorize_rejects_token_with_wrong_length() {
+        // Constant-time comparison must still reject length-mismatched tokens (HI-7).
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_static("Bearer secret"));
+
+        let result = authorize_user(&headers, Some("secret-token"), false);
+        assert!(result.is_err(), "shorter token must be rejected");
+    }
+
+    #[test]
+    fn authorize_rejects_token_with_one_byte_differ() {
+        // Single-byte mismatch must still produce an unauthorized error (HI-7).
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer secret-tokeX"),
+        );
+
+        let result = authorize_user(&headers, Some("secret-token"), false);
+        assert!(result.is_err(), "differing-byte token must be rejected");
     }
 
     #[test]

--- a/packages/core/src/session/parser.rs
+++ b/packages/core/src/session/parser.rs
@@ -5,8 +5,28 @@
 use super::types::{MessageRole, Session, SessionMessage, SessionMeta, SessionSource};
 use std::path::Path;
 
+/// 单个 session 文件大小上限（200 MiB）。
+///
+/// 超出后跳过解析，避免 jsonl 异常膨胀触发 OOM 杀掉整个 batch ingest。
+/// 对应 HI-6：`std::fs::read_to_string` 默认无上限，本地恶意/损坏/外部共享的
+/// jsonl 几 GB 即可耗尽进程内存。
+pub const MAX_SESSION_FILE_BYTES: u64 = 200 * 1024 * 1024;
+
 /// 解析 JSONL 文件为 Session
 pub fn parse_session_file(path: &Path, source: SessionSource) -> Result<Session, String> {
+    let metadata = std::fs::metadata(path).map_err(|e| format!("读取文件失败: {}", e))?;
+    let size = metadata.len();
+    if size > MAX_SESSION_FILE_BYTES {
+        let msg = format!(
+            "session 文件过大: {} ({} 字节 > 上限 {} 字节)，已跳过",
+            path.display(),
+            size,
+            MAX_SESSION_FILE_BYTES
+        );
+        tracing::error!(target: "session::parser", path = %path.display(), bytes = size, limit = MAX_SESSION_FILE_BYTES, "session file exceeds size cap, skipping");
+        return Err(msg);
+    }
+
     let content = std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?;
     parse_session_content(&content, path, source)
 }
@@ -224,6 +244,29 @@ mod tests {
         assert_eq!(session.messages[1].role, MessageRole::Assistant);
         assert_eq!(session.messages[1].content, "I found the issue.");
         assert_eq!(session.meta.model.as_deref(), Some("o3-mini"));
+    }
+
+    #[test]
+    fn parse_session_file_rejects_oversize_files() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("oversize.jsonl");
+
+        // Write a sparse file just over the configured limit so the test runs cheaply.
+        let mut file = std::fs::File::create(&path).expect("create oversize file");
+        file.set_len(MAX_SESSION_FILE_BYTES + 1)
+            .expect("expand to oversize");
+        file.write_all(b"{}").ok();
+        drop(file);
+
+        let result = parse_session_file(&path, SessionSource::ClaudeCode);
+        assert!(result.is_err(), "oversize file must be rejected");
+        let msg = result.err().unwrap();
+        assert!(
+            msg.contains("过大"),
+            "error must mention size cap, got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #101.

- **HI-6 — session OOM**: `parse_session_file` now stats the path before `read_to_string` and refuses anything over `MAX_SESSION_FILE_BYTES` (200 MiB) with an `error`-level log. A single oversize/corrupt JSONL can no longer kill the entire batch ingest worker.
- **HI-7 — non-constant-time token compare**: replaces `provided != token` in `apps/server/src/auth.rs` with `subtle::ConstantTimeEq::ct_eq`, eliminating the byte-by-byte timing oracle that becomes reachable once the server binds to a non-loopback address (post #78). `subtle = \"2\"` is added as a direct dependency on `refine-server` (lightweight, no transitive deps).

## Validation

- `cargo check -p refine-server -p refine-core` — passed
- `cargo test -p refine-core --lib session::parser::` — 4/4 passed (including new `parse_session_file_rejects_oversize_files`)
- `cargo test -p refine-server` — 52/52 passed (including new `authorize_rejects_token_with_wrong_length` and `authorize_rejects_token_with_one_byte_differ`)

## Test plan

- [x] Oversize file is rejected with size cap error (regression test)
- [x] Wrong-length bearer token rejected via `ct_eq`
- [x] One-byte-mismatch bearer token rejected via `ct_eq`
- [x] Existing auth/CORS regression suite (#93) still green