### PR TITLE
fix(desktop): align default API base port to 21567 (#81)

### DIFF
--- a/apps/desktop/ui/src/lib/api/adapters/http.ts
+++ b/apps/desktop/ui/src/lib/api/adapters/http.ts
@@ -26,7 +26,7 @@ type ApiEnvelope<T extends object> = T & {
   message?: string
 }
 
-const DEFAULT_API_BASE = 'http://127.0.0.1:5567'
+const DEFAULT_API_BASE = 'http://127.0.0.1:21567'
 const TOKEN_STORAGE_KEY = 'refine_api_token'
 
 const capabilities: ApiCapabilities = {


### PR DESCRIPTION
## Summary
- Desktop UI HTTP adapter (`apps/desktop/ui/src/lib/api/adapters/http.ts`) defaulted to `http://127.0.0.1:5567`, but the canonical local API contract is `21567` (matches `refine-server` `DEFAULT_SERVER_PORT` and the extension's discovery port set `21567..21570`). With the old default, the desktop UI silently pointed at the wrong (or absent) local service and every request failed.
- Aligns the desktop client with U-13 / U-14: every entry point converges on the same port.

Closes part of #81 (desktop alignment slice).

## Out of scope (follow-up issue / PR)
This PR was dispatched with a narrow file-ownership scope (`apps/server/src/config.rs`, `apps/desktop/**/config*`, `apps/extension/**/config*`) per W-14. The remaining drift listed in #81 is **not** fixed here and still needs a follow-up that owns the docs/server surface:

- `apps/server/README.md` — still says default is `http://localhost:8787` and uses `HOST` / `PORT` env vars (real env vars are `REFINE_SERVER_HOST` / `REFINE_SERVER_PORT`).
- `docs/USAGE.md` — `Default server address: http://localhost:8787` and `curl` examples on 8787.
- `docs/11_API_SPEC.md` — local desktop / standalone API base shown as `http://localhost:8787`; example client uses `8787`.
- `scripts/import_claude_code.sh` and `scripts/eval_recommendations.mjs` — default `REFINE_API_BASE` to `http://localhost:8787`.
- `CHANGELOG.md` line referring to the old `5567 / 5568` plan.
- The `parse_bind_addr` unit tests in `apps/server/src/main.rs` use `5567` as a sample literal; harmless but could be aligned.

## Test plan
- [x] `bunx tsc --noEmit` in `apps/desktop/ui` (exit 0)
- [ ] Manual: `cargo run -p refine-server` → desktop UI now hits `127.0.0.1:21567` by default and returns live data instead of `ERR_CONNECTION_REFUSED`