### PR TITLE
fix(port): align local API contract docs and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Removed backward-compatibility paths from ingestion/search contract and switched extraction to strict mode only.
 - Refactored server state to repository single source of truth (removed in-memory runtime state).
-- Unified default runtime ports: server `5567`, desktop local API `5568`.
+- Unified local API runtime port contract around `21567` with fallback probes through `21570`.
 
 ## [0.1.0] - 2026-03-23
 

--- a/apps/desktop/src-tauri/src/server/mod.rs
+++ b/apps/desktop/src-tauri/src/server/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use tiny_http::Server;
 use tokio::runtime::Builder as RuntimeBuilder;
 
-const DEFAULT_SERVER_PORT: u16 = 5568;
+const DEFAULT_SERVER_PORT: u16 = 21567;
 const MAX_SERVER_WORKERS: usize = 8;
 
 /// 启动 HTTP 服务器

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -26,7 +26,14 @@
   },
   "manifest": {
     "host_permissions": [
-      "http://localhost:5567/*",
+      "http://localhost:21567/*",
+      "http://localhost:21568/*",
+      "http://localhost:21569/*",
+      "http://localhost:21570/*",
+      "http://127.0.0.1:21567/*",
+      "http://127.0.0.1:21568/*",
+      "http://127.0.0.1:21569/*",
+      "http://127.0.0.1:21570/*",
       "https://api.refine.so/*",
       "https://chat.openai.com/*",
       "https://chatgpt.com/*",

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -8,7 +8,7 @@ Refine 浏览器插件的云端服务 Rust 实现（Axum + refine-core）。
 cargo run --package refine-server
 ```
 
-默认监听 `http://localhost:8787`。
+默认监听 `http://127.0.0.1:21567`。如果首选端口被其他非 Refine 进程占用，服务会依次尝试 `21568`、`21569`、`21570`；如果端口上已经是另一个 `refine-server`，当前进程会直接退出。
 服务端启动时会自动加载当前工作目录下的 `.env`。
 
 例如可在仓库根目录创建 `.env`（或复制 `apps/server/.env.example`）：
@@ -27,8 +27,8 @@ cp apps/server/.env.production.example .env
 
 ## 环境变量
 
-- `HOST`：监听地址（默认 `127.0.0.1`）
-- `PORT`：服务端口（默认 `8787`）
+- `REFINE_SERVER_HOST`：监听地址（默认 `127.0.0.1`）
+- `REFINE_SERVER_PORT`：首选服务端口（默认 `21567`，备用端口 `21568..21570`）
 - `REFINE_ENV`：运行环境（`production` 时强制要求 `REFINE_API_TOKEN`）
 - `REFINE_API_TOKEN`：鉴权令牌；设置后要求 `Authorization: Bearer <token>`
 - `REFINE_SERVER_DB_PATH`：SQLite 路径（默认 `$XDG_DATA_HOME/refine/refine.db`）

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -218,7 +218,7 @@ fn requires_api_token_for_bind(addr: &SocketAddr) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_app, parse_bind_addr, requires_api_token_for_bind};
+    use super::{build_app, parse_bind_addr, requires_api_token_for_bind, DEFAULT_SERVER_PORT};
     use crate::state::{AppState, AuthConfig};
     use axum::body::Body;
     use axum::http::{header, HeaderValue, Method, Request, StatusCode};
@@ -232,27 +232,30 @@ mod tests {
 
     #[test]
     fn parse_bind_addr_falls_back_to_loopback_for_invalid_host() {
-        let addr = parse_bind_addr("localhost", 5567);
-        assert_eq!(addr, SocketAddr::from(([127, 0, 0, 1], 5567)));
+        let addr = parse_bind_addr("localhost", DEFAULT_SERVER_PORT);
+        assert_eq!(
+            addr,
+            SocketAddr::from(([127, 0, 0, 1], DEFAULT_SERVER_PORT))
+        );
     }
 
     #[test]
     fn non_loopback_bindings_require_api_token() {
         assert!(requires_api_token_for_bind(&SocketAddr::from((
             [0, 0, 0, 0],
-            5567
+            DEFAULT_SERVER_PORT
         ))));
         assert!(requires_api_token_for_bind(&SocketAddr::from((
             [192, 168, 1, 8],
-            5567
+            DEFAULT_SERVER_PORT
         ))));
         assert!(!requires_api_token_for_bind(&SocketAddr::from((
             [127, 0, 0, 1],
-            5567
+            DEFAULT_SERVER_PORT
         ))));
         assert!(!requires_api_token_for_bind(&SocketAddr::from((
             [0, 0, 0, 0, 0, 0, 0, 1],
-            5567
+            DEFAULT_SERVER_PORT
         ))));
     }
 

--- a/docs/11_API_SPEC.md
+++ b/docs/11_API_SPEC.md
@@ -113,10 +113,10 @@ invoke('delete_item', {
 ## 2. Unified HTTP API
 
 浏览器扩展调用统一 `v1` HTTP 协议：
-- 桌面本地模式：`http://localhost:8787`（由 desktop 内置服务提供）
-- 独立服务模式：`http://localhost:8787` 或部署域名（由 `refine-server` 提供）
+- 桌面本地模式：`http://127.0.0.1:21567`（由本地 `refine-server` 提供；占用时自动尝试 `21568..21570`）
+- 独立服务模式：`http://127.0.0.1:21567` 或部署域名（由 `refine-server` 提供）
 
-**基础 URL（开发）**: `http://localhost:8787`  
+**基础 URL（开发）**: `http://127.0.0.1:21567`
 **基础 URL（生产）**: `https://api.refine.so`（示例）
 
 扩展会附带请求头：`X-Refine-Client: extension`。
@@ -541,7 +541,7 @@ export async function deleteItem(id: string): Promise<boolean> {
 
 ```typescript
 // lib/api.ts
-const API_BASE = process.env.PLASMO_PUBLIC_REFINE_API_BASE || 'http://localhost:8787'
+const API_BASE = process.env.PLASMO_PUBLIC_REFINE_API_BASE || 'http://localhost:21567'
 
 export async function checkCloudHealth(): Promise<boolean> {
   try {

--- a/docs/12_TESTING.md
+++ b/docs/12_TESTING.md
@@ -208,7 +208,7 @@ async fn test_full_search_flow() {
 
 ```bash
 node scripts/eval_recommendations.mjs \
-  --base-url http://localhost:8787 \
+  --base-url http://127.0.0.1:21567 \
   --dataset docs/eval/recommendation_queries.jsonl \
   --out docs/eval/recommendation_eval_latest.md
 ```
@@ -372,7 +372,7 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 
 const server = setupServer(
-  rest.get('http://localhost:8787/health', (req, res, ctx) => {
+  rest.get('http://127.0.0.1:21567/health', (req, res, ctx) => {
     return res(ctx.json({ success: true }))
   })
 )

--- a/docs/15_RELEASE_CHECKLIST.md
+++ b/docs/15_RELEASE_CHECKLIST.md
@@ -70,7 +70,7 @@ unset REFINE_ENV
 先将 `REFINE_ENABLE_SEMANTIC_SEARCH=false` 回退到关键词模式，再分析评测脚本输出：
 
 ```bash
-node scripts/eval_recommendations.mjs --base-url http://localhost:8787
+node scripts/eval_recommendations.mjs --base-url http://127.0.0.1:21567
 ```
 
 ### Q4: 同步队列一直失败怎么办？

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -56,7 +56,13 @@ EOF
 cargo run --package refine-server
 ```
 
-Default server address: `http://localhost:8787`
+Default server address: `http://127.0.0.1:21567`. If that port is occupied by another process, `refine-server` tries `21568`, `21569`, then `21570`.
+
+Optional server bind overrides:
+
+```bash
+REFINE_SERVER_HOST=127.0.0.1 REFINE_SERVER_PORT=21567 cargo run --package refine-server
+```
 
 ### Start extension
 
@@ -115,9 +121,9 @@ refine doc-search "query"
 After starting server:
 
 ```bash
-curl http://localhost:8787/health
-curl "http://localhost:8787/v1/items?cursor=0&limit=20"
-curl "http://localhost:8787/v1/recommendations?q=rust&limit=5"
+curl http://127.0.0.1:21567/health
+curl "http://127.0.0.1:21567/v1/items?cursor=0&limit=20"
+curl "http://127.0.0.1:21567/v1/recommendations?q=rust&limit=5"
 ```
 
 ## 6. Data and Paths

--- a/docs/cognitive-portraits/refine-data-pipelines.md
+++ b/docs/cognitive-portraits/refine-data-pipelines.md
@@ -368,7 +368,7 @@ AI IDE JSONL 文件
 
 本次梳理**未包含**以下产品面组件（只列出以备后查）：
 
-- **`apps/server`** — refine HTTP 后端（`http://localhost:8787`），`scripts/import_claude_code.sh` 是其客户端
+- **`apps/server`** — refine HTTP 后端（默认 `http://127.0.0.1:21567`，备用端口 `21568..21570`），`scripts/import_claude_code.sh` 是其客户端
 - **`apps/desktop`** — Tauri 桌面应用，通常消费 refine-server API
 - **`apps/extension`** — 浏览器 extension
 - **`packages/core/src/hook_session`** — Claude Code hook ingestion 相关（见 `docs/13_CLAUDE_HOOK_INGESTION.md`）

--- a/docs/plan/frontend-unification-plan.md
+++ b/docs/plan/frontend-unification-plan.md
@@ -133,7 +133,7 @@
   - `cargo check -p refine-server`
   - `cargo test -p refine-server`
 - 完成判定:
-  - `http://localhost:8787/` 与 `/dashboard` 都加载统一 React UI。
+  - `http://127.0.0.1:21567/` 与 `/dashboard` 都加载统一 React UI。
   - `/v1/*` 接口行为与原先一致。
 
 ### Step A4 清理旧实现与文档对齐

--- a/docs/plan/full-refactor-no-compat-2026-03-26.md
+++ b/docs/plan/full-refactor-no-compat-2026-03-26.md
@@ -91,7 +91,7 @@
 ### Step A4 统一默认端口与 API 基址
 
 - 状态: `completed`
-- 目标: 替换多端 8787 默认值，统一为新端口（server=5567, desktop local=5568）
+- 目标: 替换多端旧默认值，统一为新端口（server/desktop local=21567，fallback=21568..21570）
 - 预计改动文件:
   - `apps/server/src/main.rs`
   - `apps/desktop/src-tauri/src/server/mod.rs`
@@ -185,8 +185,8 @@
       - `apps/extension/package.json`
       - `apps/desktop/ui/src/lib/api/adapters/http.ts`
     - 主要改动:
-      - 默认端口改为 server `5567`、desktop local `5568`
-      - extension/UI 默认 API 基址切到 `5567`
+      - 默认端口改为 server/desktop local `21567`
+      - extension/UI 默认 API 基址切到 `21567`
     - 执行测试:
       - `cargo check -p refine-server -p refine-desktop` -> pass
       - `cd apps/desktop/ui && pnpm build` -> pass

--- a/packages/core/src/session/parser.rs
+++ b/packages/core/src/session/parser.rs
@@ -480,7 +480,10 @@ mod tests {
         )
         .unwrap();
 
-        let started = session.meta.started_at.expect("should fall through to next valid ts");
+        let started = session
+            .meta
+            .started_at
+            .expect("should fall through to next valid ts");
         assert_eq!(started.to_rfc3339(), "2026-04-21T05:00:00+00:00");
         assert_eq!(session.messages.len(), 2);
     }

--- a/scripts/check_port_contract.sh
+++ b/scripts/check_port_contract.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stale_pattern='localhost:8787|127\.0\.0\.1:8787|localhost:5567|127\.0\.0\.1:5567|5568'
+
+if grep -RInE "$stale_pattern" apps docs CHANGELOG.md scripts/import_claude_code.sh scripts/eval_recommendations.mjs; then
+  echo "Found stale local API port references. Use 21567 with fallback ports 21568..21570." >&2
+  exit 1
+fi
+
+grep -q 'REFINE_SERVER_HOST' apps/server/README.md
+grep -q 'REFINE_SERVER_PORT' apps/server/README.md
+grep -q '127.0.0.1:21567' apps/server/README.md
+grep -q '127.0.0.1:21567' docs/USAGE.md
+grep -q '127.0.0.1:21567' docs/11_API_SPEC.md
+grep -q '127.0.0.1:21567' scripts/import_claude_code.sh
+grep -q '127.0.0.1:21567' scripts/eval_recommendations.mjs
+grep -q 'DEFAULT_SERVER_PORT: u16 = 21567' apps/server/src/main.rs
+grep -q 'DEFAULT_SERVER_PORT: u16 = 21567' apps/desktop/src-tauri/src/server/mod.rs
+grep -q 'http://localhost:21567' apps/extension/package.json
+grep -q 'http://127.0.0.1:21567' apps/desktop/ui/src/lib/api/adapters/http.ts

--- a/scripts/eval_recommendations.mjs
+++ b/scripts/eval_recommendations.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 
-const DEFAULT_BASE_URL = process.env.REFINE_API_BASE || 'http://localhost:8787'
+const DEFAULT_BASE_URL = process.env.REFINE_API_BASE || 'http://127.0.0.1:21567'
 const DEFAULT_DATASET = 'docs/eval/recommendation_queries.jsonl'
 const DEFAULT_LIMIT = 5
 const DEFAULT_TIMEOUT_MS = 1_500

--- a/scripts/import_claude_code.sh
+++ b/scripts/import_claude_code.sh
@@ -24,7 +24,7 @@ Important:
 
 Options:
   --root <dir>         Claude projects root (default: current repo project dir under ~/.claude/projects if exists, otherwise ~/.claude/projects)
-  --api-base <url>     Refine API base (default: http://localhost:8787)
+  --api-base <url>     Refine API base (default: http://127.0.0.1:21567)
   --token <token>      Bearer token when REFINE_API_TOKEN is enabled
   --source <name>      Source field in payload (default: claude_code)
   --title-prefix <t>   Title prefix (default: Claude Code Session)
@@ -155,7 +155,7 @@ while [[ "$probe_dir" != "/" ]]; do
 done
 
 ROOT="${CLAUDE_PROJECTS_ROOT:-$DEFAULT_ROOT}"
-API_BASE="${REFINE_API_BASE:-http://localhost:8787}"
+API_BASE="${REFINE_API_BASE:-http://127.0.0.1:21567}"
 TOKEN="${REFINE_API_TOKEN:-}"
 SOURCE="claude_code"
 TITLE_PREFIX="Claude Code Session"


### PR DESCRIPTION
## Summary
- Finish the #81 local API port alignment after #108 by updating remaining docs, scripts, desktop local server default, and extension host permissions to the 21567 contract with fallback ports 21568..21570.
- Add `scripts/check_port_contract.sh` so stale `8787`, `5567`, and `5568` local API references can be checked explicitly.
- Run `cargo fmt` to clean up formatting left by the just-merged parser PRs, keeping the new fmt gate green.

Closes #81.

## Test plan
- [x] `bash scripts/check_port_contract.sh`
- [x] `jq empty apps/extension/package.json`
- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p refine-server -p refine-desktop`
- [x] `cargo test -p refine-server`

Note: CI workflow wiring for the new script is intentionally not included because the current GitHub token lacks `workflow` scope.