### PR TITLE
[codex] add local install and release flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@
 ## Quick Start
 
 ```bash
-# Install both tools
-cargo install --path apps/cli      # refine
-cargo install --path apps/mirror   # mirror
+# Install the local stack: CLI tools, server, launchd jobs, and optional UI dev service
+scripts/install-local.sh
 
 # Configure LLM (.env file)
 cat > .env << 'EOF'
@@ -43,6 +42,9 @@ refine ingest-sessions
 # See your cognitive snapshot
 mirror score
 ```
+
+For local install, doctor, and upgrade details, see [Local Setup](docs/LOCAL_SETUP.md)
+and [Local Release Flow](docs/LOCAL_RELEASE.md).
 
 ## Mirror — Cognitive Growth Tracker
 
@@ -94,6 +96,13 @@ mirror profile                      # Cognitive portrait narrative (requires LLM
 **SessionStart hook** injects cognitive dashboard + LLM advice into every Claude Code conversation.
 
 ### Automation (launchd)
+
+The local installer writes and reloads these jobs:
+
+```bash
+scripts/install-local.sh
+scripts/doctor-local.sh
+```
 
 | Schedule | Task | What It Does |
 |----------|------|-------------|

--- a/docs/LOCAL_RELEASE.md
+++ b/docs/LOCAL_RELEASE.md
@@ -1,0 +1,55 @@
+# Local Release Flow
+
+Use the local release flow when promoting a checkout to the machine-local Refine install.
+
+```bash
+scripts/release-local.sh
+```
+
+The command is intentionally conservative:
+
+1. Requires a clean working tree unless `--allow-dirty` is passed.
+2. Runs the port/default contract check.
+3. Runs Rust format, check, tests, and clippy.
+4. Builds the desktop UI when Bun is available.
+5. Runs `scripts/install-local.sh`.
+6. Runs `scripts/doctor-local.sh` as a smoke check.
+
+## Upgrade From A Branch
+
+```bash
+git switch main
+git pull --ff-only
+scripts/release-local.sh
+```
+
+For a feature branch under active development:
+
+```bash
+scripts/release-local.sh --allow-dirty
+```
+
+Use `--allow-dirty` only when validating a local change before commit.
+
+## Faster Inner Loop
+
+Skip slower checks only while iterating:
+
+```bash
+scripts/release-local.sh --allow-dirty --skip-tests --skip-clippy --skip-ui --skip-install
+```
+
+Before publishing a PR or declaring a local release complete, run the full command again.
+
+## CI Relationship
+
+GitHub CI remains the repository gate for pull requests. The local release flow is the machine install gate: it proves this checkout can be built, installed, reloaded, and smoke-tested on the current macOS user account.
+
+## Issue Tracking
+
+This flow addresses:
+
+- #112 local one-command installer
+- #115 local doctor
+- #114 reproducible local release and upgrade flow
+- #113 consolidated local setup documentation

--- a/docs/LOCAL_RELEASE.md
+++ b/docs/LOCAL_RELEASE.md
@@ -41,6 +41,14 @@ scripts/release-local.sh --allow-dirty --skip-tests --skip-clippy --skip-ui --sk
 
 Before publishing a PR or declaring a local release complete, run the full command again.
 
+For a headless local install without the desktop UI dev LaunchAgent:
+
+```bash
+scripts/release-local.sh --no-ui-dev
+```
+
+When `--skip-ui` or `--no-ui-dev` is used, the release flow also passes `--no-ui-dev` to the doctor smoke check.
+
 ## CI Relationship
 
 GitHub CI remains the repository gate for pull requests. The local release flow is the machine install gate: it proves this checkout can be built, installed, reloaded, and smoke-tested on the current macOS user account.

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -38,7 +38,7 @@ Token mode:
 REFINE_API_TOKEN=your-token scripts/install-local.sh --token-auth
 ```
 
-Token mode writes `REFINE_API_TOKEN` into the server LaunchAgent. Clients must send `Authorization: Bearer <token>`.
+Token mode writes the token to `~/.refine/refine-server.token` with mode `0600` and points the server LaunchAgent at `~/.refine/run-refine-server.sh`. The token is not written into the plist. Clients must send `Authorization: Bearer <token>`.
 
 ## Useful Variants
 
@@ -52,6 +52,12 @@ Install services without the UI dev server:
 
 ```bash
 scripts/install-local.sh --no-ui-dev
+```
+
+This also unloads and removes an existing `com.lifcc.refine-ui-dev` LaunchAgent. Verify the same shape with:
+
+```bash
+scripts/doctor-local.sh --no-ui-dev
 ```
 
 Write LaunchAgents without starting them:
@@ -77,7 +83,7 @@ Run:
 scripts/doctor-local.sh
 ```
 
-The doctor checks installed binaries, LaunchAgents, `/health`, a protected `/v1/*` API route, database freshness, log files, and UI dependencies.
+The doctor checks installed binaries, LaunchAgents, `/health`, a protected `/v1/*` API route, database freshness, log files, and UI dependencies. Use `scripts/doctor-local.sh --no-ui-dev` for installs that intentionally disable the desktop UI dev service.
 
 Common symptoms:
 

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -1,0 +1,86 @@
+# Local Setup
+
+Refine has two local surfaces:
+
+- CLI tools: `refine` and `mirror`
+- Local services: `refine-server`, daily ingest, weekly insights, and optional desktop UI dev server
+
+Use the installer from the repository root:
+
+```bash
+scripts/install-local.sh
+```
+
+The installer is idempotent. It can be used for first install and for upgrades from a newer checkout.
+
+## What The Installer Does
+
+- Installs `refine`, `mirror`, and `refine-server` with `cargo install --path`.
+- Installs desktop UI dependencies with `bun install` when Bun is available.
+- Writes macOS user LaunchAgents under `~/Library/LaunchAgents/`.
+- Starts or reloads the local server and UI dev service.
+- Schedules daily ingest at 08:00 and weekly insights on Monday at 09:00.
+- Enables local dashboard/API access with `REFINE_DEV_ANON=1` by default.
+
+## Auth Modes
+
+Default local mode:
+
+```bash
+scripts/install-local.sh
+```
+
+This writes `REFINE_DEV_ANON=1` into `com.lifcc.refine-server.plist`. It is intended for loopback local development.
+
+Token mode:
+
+```bash
+REFINE_API_TOKEN=your-token scripts/install-local.sh --token-auth
+```
+
+Token mode writes `REFINE_API_TOKEN` into the server LaunchAgent. Clients must send `Authorization: Bearer <token>`.
+
+## Useful Variants
+
+Install binaries only:
+
+```bash
+scripts/install-local.sh --no-launchd
+```
+
+Install services without the UI dev server:
+
+```bash
+scripts/install-local.sh --no-ui-dev
+```
+
+Write LaunchAgents without starting them:
+
+```bash
+scripts/install-local.sh --no-start
+```
+
+## Services
+
+| Label | Role | Trigger | Log |
+| --- | --- | --- | --- |
+| `com.lifcc.refine-server` | Local API/dashboard | RunAtLoad + KeepAlive | `~/Library/Logs/refine-server.log` |
+| `com.lifcc.refine-daily-ingest` | `refine ingest-sessions` + `mirror score` | Daily 08:00 | `~/Library/Logs/refine-daily-ingest.log` |
+| `com.lifcc.refine-weekly-insights` | `refine insights --prescription` | Monday 09:00 | `~/Library/Logs/refine-insights.log` |
+| `com.lifcc.refine-ui-dev` | Desktop UI Vite dev server | RunAtLoad + KeepAlive | `.run/launchd-refine-ui.*.log` |
+
+## Health Check
+
+Run:
+
+```bash
+scripts/doctor-local.sh
+```
+
+The doctor checks installed binaries, LaunchAgents, `/health`, a protected `/v1/*` API route, database freshness, log files, and UI dependencies.
+
+Common symptoms:
+
+- `/health` works but `/v1/items` returns Unauthorized: reinstall with default local mode or set a matching `REFINE_API_TOKEN`.
+- `last-refresh-ok` is stale: run `scripts/daily-refresh.sh` once, then inspect `~/Library/Logs/refine-daily-ingest.log`.
+- UI dev LaunchAgent exits with `vite: not found`: run `scripts/install-local.sh` so `apps/desktop/ui/node_modules` is installed.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -32,10 +32,27 @@ Use this when your main goal is analyzing Claude Code / Codex coding sessions.
 - Bun (for extension)
 - Chromium-based browser (for loading unpacked extension)
 
-### Install CLI
+### Install Local Stack
+
+Recommended:
+
+```bash
+scripts/install-local.sh
+scripts/doctor-local.sh
+```
+
+This installs `refine`, `mirror`, and `refine-server`, writes macOS LaunchAgents,
+starts the local server, schedules daily/weekly jobs, and installs desktop UI
+dependencies when Bun is available.
+
+For details, see [LOCAL_SETUP.md](./LOCAL_SETUP.md).
+
+### Install CLI Only
 
 ```bash
 cargo install --path apps/cli
+cargo install --path apps/mirror
+cargo install --path apps/server
 ```
 
 ### Configure LLM (optional but recommended)
@@ -57,6 +74,15 @@ cargo run --package refine-server
 ```
 
 Default server address: `http://127.0.0.1:21567`. If that port is occupied by another process, `refine-server` tries `21568`, `21569`, then `21570`.
+
+For unauthenticated local dashboard/API access, set:
+
+```bash
+REFINE_DEV_ANON=1 cargo run --package refine-server
+```
+
+For token auth, set `REFINE_API_TOKEN` and send `Authorization: Bearer <token>`
+from the client.
 
 Optional server bind overrides:
 
@@ -126,6 +152,10 @@ curl "http://127.0.0.1:21567/v1/items?cursor=0&limit=20"
 curl "http://127.0.0.1:21567/v1/recommendations?q=rust&limit=5"
 ```
 
+If `/health` succeeds but `/v1/items` returns Unauthorized, the server is
+running without `REFINE_DEV_ANON=1` and without a matching `REFINE_API_TOKEN`.
+Run `scripts/install-local.sh` for the default local setup.
+
 ## 6. Data and Paths
 
 - Unified DB path priority:
@@ -136,6 +166,8 @@ curl "http://127.0.0.1:21567/v1/recommendations?q=rust&limit=5"
 ## 7. Where To Go Next
 
 - Project overview: [00_OVERVIEW.md](./00_OVERVIEW.md)
+- Local setup: [LOCAL_SETUP.md](./LOCAL_SETUP.md)
+- Local release flow: [LOCAL_RELEASE.md](./LOCAL_RELEASE.md)
 - Server details: [../apps/server/README.md](../apps/server/README.md)
 - API details: [11_API_SPEC.md](./11_API_SPEC.md)
 - Architecture details: [09_ARCHITECTURE.md](./09_ARCHITECTURE.md)

--- a/scripts/check_port_contract.sh
+++ b/scripts/check_port_contract.sh
@@ -3,7 +3,13 @@ set -euo pipefail
 
 stale_pattern='localhost:8787|127\.0\.0\.1:8787|localhost:5567|127\.0\.0\.1:5567|5568'
 
-if grep -RInE "$stale_pattern" apps docs CHANGELOG.md scripts/import_claude_code.sh scripts/eval_recommendations.mjs; then
+if grep -RInE \
+  --exclude-dir=.git \
+  --exclude-dir=.run \
+  --exclude-dir=dist \
+  --exclude-dir=node_modules \
+  --exclude-dir=target \
+  "$stale_pattern" apps docs CHANGELOG.md scripts/import_claude_code.sh scripts/eval_recommendations.mjs; then
   echo "Found stale local API port references. Use 21567 with fallback ports 21568..21570." >&2
   exit 1
 fi

--- a/scripts/doctor-local.sh
+++ b/scripts/doctor-local.sh
@@ -1,10 +1,41 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: scripts/doctor-local.sh [OPTIONS]
+
+Check the machine-local Refine install.
+
+Options:
+  --no-ui-dev   Skip desktop UI dev LaunchAgent, log, and dependency checks.
+  -h, --help    Show this help.
+EOF
+}
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 server_url="${REFINE_SERVER_URL:-http://127.0.0.1:21567}"
 failures=0
 warnings=0
+ui_dev_enabled=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-ui-dev)
+      ui_dev_enabled=0
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
 
 pass() {
   printf 'PASS %s\n' "$*"
@@ -164,12 +195,17 @@ check_freshness() {
 
 check_logs() {
   local log_path
-  for log_path in \
+  local log_paths=(
     "${HOME}/Library/Logs/refine-server.log" \
     "${HOME}/Library/Logs/refine-server.err.log" \
     "${HOME}/Library/Logs/refine-daily-ingest.log" \
-    "${HOME}/Library/Logs/refine-insights.log" \
-    "${repo_root}/.run/launchd-refine-ui.err.log"; do
+    "${HOME}/Library/Logs/refine-insights.log"
+  )
+  if [[ "$ui_dev_enabled" == "1" ]]; then
+    log_paths+=("${repo_root}/.run/launchd-refine-ui.err.log")
+  fi
+
+  for log_path in "${log_paths[@]}"; do
     if [[ -f "$log_path" ]]; then
       pass "log exists: $log_path ($(mtime_text "$log_path"))"
     else
@@ -206,13 +242,21 @@ check_cmd refine-server
 check_launch_agent com.lifcc.refine-server
 check_launch_agent com.lifcc.refine-daily-ingest
 check_launch_agent com.lifcc.refine-weekly-insights
-check_launch_agent com.lifcc.refine-ui-dev
+if [[ "$ui_dev_enabled" == "1" ]]; then
+  check_launch_agent com.lifcc.refine-ui-dev
+else
+  pass "desktop UI dev service skipped"
+fi
 
 check_http
 check_db
 check_freshness
 check_logs
-check_ui_deps
+if [[ "$ui_dev_enabled" == "1" ]]; then
+  check_ui_deps
+else
+  pass "desktop UI dependency check skipped"
+fi
 
 printf '\nSummary: %s failure(s), %s warning(s)\n' "$failures" "$warnings"
 if [[ "$failures" -gt 0 ]]; then

--- a/scripts/doctor-local.sh
+++ b/scripts/doctor-local.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+server_url="${REFINE_SERVER_URL:-http://127.0.0.1:21567}"
+failures=0
+warnings=0
+
+pass() {
+  printf 'PASS %s\n' "$*"
+}
+
+warn() {
+  warnings=$((warnings + 1))
+  printf 'WARN %s\n' "$*"
+}
+
+fail() {
+  failures=$((failures + 1))
+  printf 'FAIL %s\n' "$*"
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+mtime_epoch() {
+  local path="$1"
+  if stat -f %m "$path" >/dev/null 2>&1; then
+    stat -f %m "$path"
+  else
+    stat -c %Y "$path"
+  fi
+}
+
+mtime_text() {
+  local path="$1"
+  if stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S %Z' "$path" >/dev/null 2>&1; then
+    stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S %Z' "$path"
+  else
+    stat -c '%y' "$path"
+  fi
+}
+
+check_cmd() {
+  local cmd="$1"
+  if have_cmd "$cmd"; then
+    pass "command available: $cmd ($(command -v "$cmd"))"
+  else
+    fail "missing command: $cmd"
+  fi
+}
+
+check_launch_agent() {
+  local label="$1"
+  local plist="${HOME}/Library/LaunchAgents/${label}.plist"
+
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    warn "launchd unavailable on this OS; skipped $label"
+    return
+  fi
+
+  if [[ ! -f "$plist" ]]; then
+    fail "missing LaunchAgent: $plist"
+    return
+  fi
+
+  if ! plutil -lint "$plist" >/dev/null 2>&1; then
+    fail "invalid plist: $plist"
+    return
+  fi
+
+  local state
+  state="$(launchctl print "gui/$(id -u)/${label}" 2>&1 || true)"
+  if grep -q 'state = running' <<<"$state"; then
+    pass "LaunchAgent running: $label"
+  elif grep -q 'state = not running' <<<"$state"; then
+    pass "LaunchAgent loaded: $label (not running now)"
+  elif grep -q 'spawn scheduled' <<<"$state"; then
+    warn "LaunchAgent spawn scheduled: $label"
+  else
+    fail "LaunchAgent not loaded: $label"
+  fi
+
+  if grep -q 'last exit code = [1-9]' <<<"$state"; then
+    warn "$label has a non-zero last exit code"
+  fi
+}
+
+check_http() {
+  if ! have_cmd curl; then
+    fail "missing curl; cannot check server"
+    return
+  fi
+
+  local health
+  health="$(curl -fsS --max-time 3 "${server_url}/health" 2>/dev/null || true)"
+  if grep -q '"success":true' <<<"$health"; then
+    pass "server health OK: ${server_url}/health"
+  else
+    fail "server health failed: ${server_url}/health"
+    return
+  fi
+
+  local items
+  items="$(curl -sS --max-time 3 "${server_url}/v1/items?cursor=0&limit=1" 2>/dev/null || true)"
+  if grep -q '"success":true' <<<"$items"; then
+    pass "API items endpoint OK"
+  elif grep -q 'REFINE_API_TOKEN is not set' <<<"$items"; then
+    fail "API auth blocks local dashboard; run scripts/install-local.sh or set REFINE_DEV_ANON=1"
+  elif grep -q 'Authorization: Bearer' <<<"$items"; then
+    fail "API requires a bearer token; set REFINE_API_TOKEN consistently in server and client"
+  else
+    fail "API items endpoint failed"
+  fi
+}
+
+check_db() {
+  local db_path="${REFINE_DB_PATH:-}"
+  if [[ -z "$db_path" ]]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      db_path="${HOME}/Library/Application Support/refine/refine.db"
+    else
+      db_path="${XDG_DATA_HOME:-$HOME/.local/share}/refine/refine.db"
+    fi
+  fi
+
+  if [[ ! -f "$db_path" ]]; then
+    warn "database not found: $db_path"
+    return
+  fi
+
+  pass "database exists: $db_path"
+  if have_cmd sqlite3; then
+    local summary
+    summary="$(sqlite3 -readonly "$db_path" "select 'items=' || count(*) || ' last_item=' || coalesce(max(created_at),'none') from items;" 2>/dev/null || true)"
+    if [[ -n "$summary" ]]; then
+      pass "database query OK: $summary"
+    else
+      fail "database query failed: $db_path"
+    fi
+  else
+    warn "sqlite3 missing; skipped database query"
+  fi
+}
+
+check_freshness() {
+  local stamp="${HOME}/.refine/last-refresh-ok"
+  if [[ ! -f "$stamp" ]]; then
+    warn "missing refresh success marker: $stamp"
+    return
+  fi
+
+  local now last age_hours
+  now="$(date +%s)"
+  last="$(mtime_epoch "$stamp")"
+  age_hours=$(( (now - last) / 3600 ))
+  if [[ "$age_hours" -le 36 ]]; then
+    pass "daily refresh marker fresh (${age_hours}h old): $(cat "$stamp" 2>/dev/null || true)"
+  else
+    warn "daily refresh marker stale (${age_hours}h old): $(cat "$stamp" 2>/dev/null || true)"
+  fi
+}
+
+check_logs() {
+  local log_path
+  for log_path in \
+    "${HOME}/Library/Logs/refine-server.log" \
+    "${HOME}/Library/Logs/refine-server.err.log" \
+    "${HOME}/Library/Logs/refine-daily-ingest.log" \
+    "${HOME}/Library/Logs/refine-insights.log" \
+    "${repo_root}/.run/launchd-refine-ui.err.log"; do
+    if [[ -f "$log_path" ]]; then
+      pass "log exists: $log_path ($(mtime_text "$log_path"))"
+    else
+      warn "log missing: $log_path"
+    fi
+  done
+}
+
+check_ui_deps() {
+  local ui_dir="${repo_root}/apps/desktop/ui"
+  if [[ ! -d "$ui_dir" ]]; then
+    warn "desktop UI directory missing"
+    return
+  fi
+  if ! have_cmd bun; then
+    warn "Bun missing; UI dev service cannot start"
+    return
+  fi
+  if [[ -x "${ui_dir}/node_modules/.bin/vite" ]]; then
+    pass "desktop UI dependencies installed"
+  else
+    warn "desktop UI dependencies missing; run scripts/install-local.sh"
+  fi
+}
+
+printf 'Refine local doctor\n'
+printf 'Repo: %s\n' "$repo_root"
+printf 'Server: %s\n\n' "$server_url"
+
+check_cmd refine
+check_cmd mirror
+check_cmd refine-server
+
+check_launch_agent com.lifcc.refine-server
+check_launch_agent com.lifcc.refine-daily-ingest
+check_launch_agent com.lifcc.refine-weekly-insights
+check_launch_agent com.lifcc.refine-ui-dev
+
+check_http
+check_db
+check_freshness
+check_logs
+check_ui_deps
+
+printf '\nSummary: %s failure(s), %s warning(s)\n' "$failures" "$warnings"
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/install-local.sh [OPTIONS]
+
+Install or upgrade the local Refine stack from this checkout.
+
+Options:
+  --no-ui-dev       Do not install/start the desktop UI Vite dev service.
+  --no-launchd      Install binaries only; skip macOS LaunchAgents.
+  --no-start        Write LaunchAgents but do not start/restart services.
+  --token-auth      Require REFINE_API_TOKEN instead of local dev anonymous API access.
+  -h, --help        Show this help.
+
+Defaults:
+  - Installs refine, mirror, and refine-server into Cargo's bin directory.
+  - On macOS, writes user LaunchAgents for server, daily ingest, weekly insights,
+    and the desktop UI dev service when Bun is available.
+  - Uses REFINE_DEV_ANON=1 for loopback-only local dashboard/API access unless
+    --token-auth is passed.
+EOF
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+launchd_enabled=1
+start_services=1
+ui_dev_enabled=1
+auth_mode="dev-anon"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-ui-dev)
+      ui_dev_enabled=0
+      ;;
+    --no-launchd)
+      launchd_enabled=0
+      ;;
+    --no-start)
+      start_services=0
+      ;;
+    --token-auth)
+      auth_mode="token"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+log() {
+  printf '[install-local] %s\n' "$*"
+}
+
+die() {
+  printf '[install-local] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+xml_escape() {
+  sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g'
+}
+
+write_file() {
+  local path="$1"
+  local tmp
+  tmp="$(mktemp "${path}.tmp.XXXXXX")"
+  cat > "$tmp"
+  if [[ -f "$path" ]] && cmp -s "$tmp" "$path"; then
+    rm -f "$tmp"
+    log "unchanged $path"
+  else
+    mv "$tmp" "$path"
+    log "wrote $path"
+  fi
+}
+
+write_server_plist() {
+  local path="$1"
+  local cargo_bin="$2"
+  local repo="$3"
+  local path_env="$4"
+  local repo_xml cargo_bin_xml path_xml token_xml=""
+  repo_xml="$(printf '%s' "$repo" | xml_escape)"
+  cargo_bin_xml="$(printf '%s' "$cargo_bin" | xml_escape)"
+  path_xml="$(printf '%s' "$path_env" | xml_escape)"
+
+  if [[ "$auth_mode" == "token" ]]; then
+    [[ -n "${REFINE_API_TOKEN:-}" ]] || die "--token-auth requires REFINE_API_TOKEN in the current environment"
+    token_xml="<key>REFINE_API_TOKEN</key>
+    <string>$(printf '%s' "$REFINE_API_TOKEN" | xml_escape)</string>"
+  else
+    token_xml="<key>REFINE_DEV_ANON</key>
+    <string>1</string>"
+  fi
+
+  write_file "$path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.lifcc.refine-server</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${cargo_bin_xml}/refine-server</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${repo_xml}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${path_xml}</string>
+    ${token_xml}
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${HOME}/Library/Logs/refine-server.log</string>
+  <key>StandardErrorPath</key>
+  <string>${HOME}/Library/Logs/refine-server.err.log</string>
+</dict>
+</plist>
+EOF
+}
+
+write_calendar_plist() {
+  local path="$1"
+  local label="$2"
+  local script_path="$3"
+  local log_path="$4"
+  local hour="$5"
+  local minute="$6"
+  local weekday="${7:-}"
+  local repo_xml script_xml log_xml weekday_block=""
+  repo_xml="$(printf '%s' "$repo_root" | xml_escape)"
+  script_xml="$(printf '%s' "$script_path" | xml_escape)"
+  log_xml="$(printf '%s' "$log_path" | xml_escape)"
+  if [[ -n "$weekday" ]]; then
+    weekday_block="    <key>Weekday</key>
+    <integer>${weekday}</integer>"
+  fi
+
+  write_file "$path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>${script_xml}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${repo_xml}</string>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>${hour}</integer>
+    <key>Minute</key>
+    <integer>${minute}</integer>
+${weekday_block}
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${log_xml}</string>
+  <key>StandardErrorPath</key>
+  <string>${log_xml}</string>
+</dict>
+</plist>
+EOF
+}
+
+write_ui_plist() {
+  local path="$1"
+  local bun_bin="$2"
+  local path_env="$3"
+  local ui_dir="${repo_root}/apps/desktop/ui"
+  local bun_xml path_xml ui_xml
+  bun_xml="$(printf '%s' "$bun_bin" | xml_escape)"
+  path_xml="$(printf '%s' "$path_env" | xml_escape)"
+  ui_xml="$(printf '%s' "$ui_dir" | xml_escape)"
+
+  mkdir -p "${repo_root}/.run"
+  write_file "$path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.lifcc.refine-ui-dev</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${bun_xml}</string>
+    <string>run</string>
+    <string>dev</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${ui_xml}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>${HOME}</string>
+    <key>PATH</key>
+    <string>${path_xml}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${repo_root}/.run/launchd-refine-ui.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>${repo_root}/.run/launchd-refine-ui.err.log</string>
+</dict>
+</plist>
+EOF
+}
+
+load_plist() {
+  local path="$1"
+  local label="$2"
+  local kickstart="${3:-0}"
+  local domain="gui/$(id -u)"
+
+  launchctl bootout "$domain" "$path" >/dev/null 2>&1 || true
+  launchctl bootstrap "$domain" "$path"
+  if [[ "$kickstart" == "1" ]]; then
+    launchctl kickstart -k "${domain}/${label}" >/dev/null 2>&1 || true
+  fi
+}
+
+need_cmd cargo
+
+log "repo root: $repo_root"
+log "installing Rust binaries"
+cargo install --path "${repo_root}/apps/cli"
+cargo install --path "${repo_root}/apps/mirror"
+cargo install --path "${repo_root}/apps/server"
+
+cargo_bin="${CARGO_HOME:-$HOME/.cargo}/bin"
+path_env="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${cargo_bin}"
+
+if [[ "$ui_dev_enabled" == "1" && -d "${repo_root}/apps/desktop/ui" ]]; then
+  if command -v bun >/dev/null 2>&1; then
+    log "installing desktop UI dependencies"
+    (cd "${repo_root}/apps/desktop/ui" && bun install)
+  else
+    log "Bun not found; skipping desktop UI dev service"
+    ui_dev_enabled=0
+  fi
+fi
+
+if [[ "$launchd_enabled" != "1" ]]; then
+  log "launchd disabled; binaries installed only"
+  exit 0
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  log "launchd is only supported on macOS; binaries installed only"
+  exit 0
+fi
+
+need_cmd launchctl
+need_cmd plutil
+
+launch_agents="${HOME}/Library/LaunchAgents"
+mkdir -p "$launch_agents" "${HOME}/Library/Logs" "${HOME}/.refine"
+
+server_plist="${launch_agents}/com.lifcc.refine-server.plist"
+daily_plist="${launch_agents}/com.lifcc.refine-daily-ingest.plist"
+weekly_plist="${launch_agents}/com.lifcc.refine-weekly-insights.plist"
+ui_plist="${launch_agents}/com.lifcc.refine-ui-dev.plist"
+
+write_server_plist "$server_plist" "$cargo_bin" "$repo_root" "$path_env"
+write_calendar_plist "$daily_plist" "com.lifcc.refine-daily-ingest" "${repo_root}/scripts/daily-refresh.sh" "${HOME}/Library/Logs/refine-daily-ingest.log" 8 0
+write_calendar_plist "$weekly_plist" "com.lifcc.refine-weekly-insights" "${repo_root}/scripts/weekly-insights.sh" "${HOME}/Library/Logs/refine-insights.log" 9 0 1
+if [[ "$ui_dev_enabled" == "1" ]]; then
+  write_ui_plist "$ui_plist" "$(command -v bun)" "$path_env"
+fi
+
+for plist in "$server_plist" "$daily_plist" "$weekly_plist"; do
+  plutil -lint "$plist" >/dev/null
+done
+if [[ "$ui_dev_enabled" == "1" ]]; then
+  plutil -lint "$ui_plist" >/dev/null
+fi
+
+if [[ "$start_services" == "1" ]]; then
+  log "loading LaunchAgents"
+  load_plist "$server_plist" "com.lifcc.refine-server" 1
+  load_plist "$daily_plist" "com.lifcc.refine-daily-ingest" 0
+  load_plist "$weekly_plist" "com.lifcc.refine-weekly-insights" 0
+  if [[ "$ui_dev_enabled" == "1" ]]; then
+    load_plist "$ui_plist" "com.lifcc.refine-ui-dev" 1
+  fi
+fi
+
+log "done"
+log "Run scripts/doctor-local.sh to verify the local stack."

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -8,7 +8,7 @@ Usage: scripts/install-local.sh [OPTIONS]
 Install or upgrade the local Refine stack from this checkout.
 
 Options:
-  --no-ui-dev       Do not install/start the desktop UI Vite dev service.
+  --no-ui-dev       Do not install/start the desktop UI Vite dev service; disable any existing UI LaunchAgent.
   --no-launchd      Install binaries only; skip macOS LaunchAgents.
   --no-start        Write LaunchAgents but do not start/restart services.
   --token-auth      Require REFINE_API_TOKEN instead of local dev anonymous API access.
@@ -73,6 +73,10 @@ xml_escape() {
   sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g'
 }
 
+shell_quote() {
+  printf '%q' "$1"
+}
+
 write_file() {
   local path="$1"
   local tmp
@@ -87,24 +91,70 @@ write_file() {
   fi
 }
 
+write_server_token_file() {
+  local path="$1"
+
+  [[ -n "${REFINE_API_TOKEN:-}" ]] || die "--token-auth requires REFINE_API_TOKEN in the current environment"
+  write_file "$path" <<EOF
+${REFINE_API_TOKEN}
+EOF
+  chmod 600 "$path"
+}
+
+write_server_token_wrapper() {
+  local path="$1"
+  local token_path="$2"
+  local server_bin="$3"
+  local token_path_sh server_bin_sh
+  token_path_sh="$(shell_quote "$token_path")"
+  server_bin_sh="$(shell_quote "$server_bin")"
+
+  write_file "$path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+token_file=${token_path_sh}
+server_bin=${server_bin_sh}
+
+if [[ ! -f "\$token_file" ]]; then
+  echo "[refine-server] missing token file: \$token_file" >&2
+  exit 1
+fi
+
+IFS= read -r token < "\$token_file" || true
+if [[ -z "\$token" ]]; then
+  echo "[refine-server] token file is empty: \$token_file" >&2
+  exit 1
+fi
+
+export REFINE_API_TOKEN="\$token"
+exec "\$server_bin"
+EOF
+  chmod 700 "$path"
+}
+
 write_server_plist() {
   local path="$1"
   local cargo_bin="$2"
   local repo="$3"
   local path_env="$4"
-  local repo_xml cargo_bin_xml path_xml token_xml=""
+  local repo_xml server_program_xml path_xml token_xml=""
+  local server_program="${cargo_bin}/refine-server"
   repo_xml="$(printf '%s' "$repo" | xml_escape)"
-  cargo_bin_xml="$(printf '%s' "$cargo_bin" | xml_escape)"
   path_xml="$(printf '%s' "$path_env" | xml_escape)"
 
   if [[ "$auth_mode" == "token" ]]; then
-    [[ -n "${REFINE_API_TOKEN:-}" ]] || die "--token-auth requires REFINE_API_TOKEN in the current environment"
-    token_xml="<key>REFINE_API_TOKEN</key>
-    <string>$(printf '%s' "$REFINE_API_TOKEN" | xml_escape)</string>"
+    local token_file="${HOME}/.refine/refine-server.token"
+    local wrapper_file="${HOME}/.refine/run-refine-server.sh"
+    write_server_token_file "$token_file"
+    write_server_token_wrapper "$wrapper_file" "$token_file" "$server_program"
+    server_program="$wrapper_file"
   else
+    rm -f "${HOME}/.refine/refine-server.token" "${HOME}/.refine/run-refine-server.sh"
     token_xml="<key>REFINE_DEV_ANON</key>
     <string>1</string>"
   fi
+  server_program_xml="$(printf '%s' "$server_program" | xml_escape)"
 
   write_file "$path" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -115,7 +165,7 @@ write_server_plist() {
   <string>com.lifcc.refine-server</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${cargo_bin_xml}/refine-server</string>
+    <string>${server_program_xml}</string>
   </array>
   <key>WorkingDirectory</key>
   <string>${repo_xml}</string>
@@ -245,6 +295,21 @@ load_plist() {
   fi
 }
 
+disable_plist() {
+  local path="$1"
+  local label="$2"
+  local domain="gui/$(id -u)"
+
+  launchctl bootout "$domain" "$path" >/dev/null 2>&1 || true
+  launchctl bootout "${domain}/${label}" >/dev/null 2>&1 || true
+  if [[ -f "$path" ]]; then
+    rm -f "$path"
+    log "removed $path"
+  else
+    log "not installed $path"
+  fi
+}
+
 need_cmd cargo
 
 log "repo root: $repo_root"
@@ -299,6 +364,8 @@ for plist in "$server_plist" "$daily_plist" "$weekly_plist"; do
 done
 if [[ "$ui_dev_enabled" == "1" ]]; then
   plutil -lint "$ui_plist" >/dev/null
+else
+  disable_plist "$ui_plist" "com.lifcc.refine-ui-dev"
 fi
 
 if [[ "$start_services" == "1" ]]; then

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -112,6 +112,10 @@ if [[ "$skip_install" != "1" ]]; then
   run scripts/install-local.sh "${install_args[@]}"
 fi
 
-run scripts/doctor-local.sh
+doctor_args=()
+if [[ "$no_ui_dev" == "1" || "$skip_ui" == "1" ]]; then
+  doctor_args+=(--no-ui-dev)
+fi
+run scripts/doctor-local.sh "${doctor_args[@]}"
 
 printf '\n[release-local] local release flow completed\n'

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/release-local.sh [OPTIONS]
+
+Run the local release/upgrade flow:
+  1. verify repository state
+  2. run Rust and UI checks
+  3. install/upgrade local services
+  4. run doctor smoke checks
+
+Options:
+  --allow-dirty      Allow running with uncommitted changes.
+  --skip-tests       Skip cargo test.
+  --skip-clippy      Skip cargo clippy.
+  --skip-ui          Skip desktop UI install/build checks.
+  --skip-install     Do not run scripts/install-local.sh.
+  --no-ui-dev        Pass --no-ui-dev through to install-local.sh.
+  -h, --help         Show this help.
+EOF
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+allow_dirty=0
+skip_tests=0
+skip_clippy=0
+skip_ui=0
+skip_install=0
+no_ui_dev=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-dirty)
+      allow_dirty=1
+      ;;
+    --skip-tests)
+      skip_tests=1
+      ;;
+    --skip-clippy)
+      skip_clippy=1
+      ;;
+    --skip-ui)
+      skip_ui=1
+      ;;
+    --skip-install)
+      skip_install=1
+      ;;
+    --no-ui-dev)
+      no_ui_dev=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+run() {
+  printf '\n[release-local] %s\n' "$*"
+  "$@"
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "[release-local] ERROR: missing required command: $1" >&2
+    exit 1
+  }
+}
+
+need_cmd cargo
+need_cmd git
+
+cd "$repo_root"
+
+if [[ "$allow_dirty" != "1" && -n "$(git status --porcelain)" ]]; then
+  echo "[release-local] ERROR: working tree is dirty. Commit/stash changes or pass --allow-dirty." >&2
+  git status --short >&2
+  exit 1
+fi
+
+run bash scripts/check_port_contract.sh
+run cargo fmt --all -- --check
+run cargo check --workspace
+if [[ "$skip_tests" != "1" ]]; then
+  run cargo test --workspace
+fi
+if [[ "$skip_clippy" != "1" ]]; then
+  run cargo clippy --workspace -- -D warnings
+fi
+
+if [[ "$skip_ui" != "1" ]]; then
+  if command -v bun >/dev/null 2>&1 && [[ -d apps/desktop/ui ]]; then
+    run bash -lc 'cd apps/desktop/ui && bun install && bun run build'
+  else
+    echo "[release-local] WARN: Bun or desktop UI missing; skipped UI build" >&2
+  fi
+fi
+
+if [[ "$skip_install" != "1" ]]; then
+  install_args=()
+  if [[ "$no_ui_dev" == "1" || "$skip_ui" == "1" ]]; then
+    install_args+=(--no-ui-dev)
+  fi
+  run scripts/install-local.sh "${install_args[@]}"
+fi
+
+run scripts/doctor-local.sh
+
+printf '\n[release-local] local release flow completed\n'


### PR DESCRIPTION
## What

Adds a reproducible local install and release flow:

- `scripts/install-local.sh` installs `refine`, `mirror`, and `refine-server`, writes macOS LaunchAgents, enables local dev auth with `REFINE_DEV_ANON=1` by default, installs UI deps when Bun is present, and reloads services.
- `scripts/doctor-local.sh` reports installed binaries, LaunchAgent state, server/API health, DB freshness, logs, and UI dependency state.
- `scripts/release-local.sh` runs the local release gate: port contract, format, Rust check/test/clippy, UI build, optional install, then doctor smoke checks.
- Documents first install, upgrade, auth modes, services, logs, and release usage in `docs/LOCAL_SETUP.md` and `docs/LOCAL_RELEASE.md`.

Closes #112.
Closes #113.
Closes #114.
Closes #115.

## Why

The repo had manual setup notes and standalone daily/weekly scripts, but no one-command local installer or release path. That made common drift states look like app bugs: server running without dashboard auth, stale ingest, or UI dev failing because `vite` was never installed.

## Test Plan

- [x] `bash -n scripts/install-local.sh scripts/doctor-local.sh scripts/release-local.sh scripts/daily-refresh.sh scripts/weekly-insights.sh scripts/check_port_contract.sh`
- [x] `scripts/install-local.sh --help`
- [x] `scripts/doctor-local.sh`
- [x] `scripts/release-local.sh --help`
- [x] `bash scripts/check_port_contract.sh`
- [x] `scripts/release-local.sh --allow-dirty --skip-install`
  - includes `cargo fmt --all -- --check`
  - includes `cargo check --workspace`
  - includes `cargo test --workspace`
  - includes `cargo clippy --workspace -- -D warnings`
  - includes `cd apps/desktop/ui && bun install && bun run build`
  - includes `scripts/doctor-local.sh`
- [x] `git diff --check`

Note: I did not run the installer against the live LaunchAgents from this feature worktree; the release flow was validated with `--skip-install` to avoid repointing the current machine service before the PR lands.
