### PR TITLE
[codex] Use session event time for Mirror Weekly

### DIFF
--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 refine-core.workspace = true
 tokio.workspace = true
 anyhow.workspace = true
+chrono.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 clap = { version = "4", features = ["derive"] }

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -3,6 +3,7 @@
 //! 支持 3 路并发 + 断点续传 + API 限流重试
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use refine_core::error::InfraError;
 use refine_core::infra::{llm_with_retry_policy, LlmClient, LlmRetryPolicy};
 use refine_core::knowledge::{Document, DocumentRepository, ItemRepository};
@@ -41,6 +42,7 @@ struct PendingSession {
     url: String,
     source: SessionSource,
     project: Option<String>,
+    captured_at: DateTime<Utc>,
     content: String,
     needs_chunk: bool,
     chunks: Vec<String>,
@@ -53,6 +55,13 @@ fn project_for_ingest(
     discovered_project
         .or(session_project)
         .map(ToOwned::to_owned)
+}
+
+fn session_captured_at(
+    session_started_at: Option<DateTime<Utc>>,
+    file_modified_at: SystemTime,
+) -> DateTime<Utc> {
+    session_started_at.unwrap_or_else(|| DateTime::<Utc>::from(file_modified_at))
 }
 
 fn incremental_cursor_path(home: &Path, source: Option<&SessionSource>, db_path: &Path) -> PathBuf {
@@ -181,6 +190,7 @@ pub async fn handle_ingest_sessions(
         }
 
         let project = project_for_ingest(ds.project.as_deref(), session.meta.project.as_deref());
+        let captured_at = session_captured_at(session.meta.started_at, ds.modified_at);
 
         let (content, chunks) = if needs_chunking(&session) {
             let cs = chunk_session(&session);
@@ -196,6 +206,7 @@ pub async fn handle_ingest_sessions(
             url,
             source: ds.source.clone(),
             project,
+            captured_at,
             content,
             needs_chunk: !chunks.is_empty(),
             chunks,
@@ -325,6 +336,7 @@ async fn process_single_session(
     let mut doc = Document::new(ps.source.as_str(), &content);
     doc.set_title(&facet_response.session_summary);
     doc.set_url(&ps.url);
+    doc.set_captured_at(ps.captured_at);
     doc_store.save(&doc).await.context("保存 Document 失败")?;
 
     let items = facets_to_items(&facet_response, doc.id(), ps.project.as_deref());
@@ -397,6 +409,7 @@ async fn extract_and_parse_facets_with_retry(
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use chrono::TimeZone;
     use refine_core::error::InfraResult;
     use refine_core::infra::SqliteStore;
     use refine_core::knowledge::{DocumentRepository, ItemRepository};
@@ -425,6 +438,16 @@ mod tests {
             Some("codex-cwd")
         );
         assert_eq!(project_for_ingest(None, None), None);
+    }
+
+    #[test]
+    fn session_captured_at_prefers_session_started_at_then_file_mtime() {
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap();
+        let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(42);
+        assert_eq!(session_captured_at(Some(started_at), mtime), started_at);
+
+        let fallback = session_captured_at(None, mtime);
+        assert_eq!(fallback, DateTime::<Utc>::from(mtime));
     }
 
     #[test]
@@ -552,6 +575,7 @@ mod tests {
             url: "file:///tmp/session.jsonl".to_string(),
             source: SessionSource::Codex,
             project: Some("refine".to_string()),
+            captured_at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
             content: "user: fix the ingest bug".to_string(),
             needs_chunk: false,
             chunks: Vec::new(),
@@ -568,6 +592,7 @@ mod tests {
             .expect("documents should load");
         assert_eq!(docs.len(), 1);
         let saved_doc = &docs[0];
+        assert_eq!(saved_doc.captured_at(), pending.captured_at);
 
         let linked_items = store
             .find_by_document_id(saved_doc.id())

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -4,7 +4,7 @@ use crate::lang::t;
 use crate::score::{self, LayerScore, ScoreResult, Signal};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Datelike, Duration, Utc};
-use refine_core::knowledge::{DocumentRepository, Item, ItemRepository, ItemType};
+use refine_core::knowledge::{DocumentRepository, ItemRepository};
 use refine_core::session::cluster_observations;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
@@ -66,13 +66,14 @@ pub async fn handle_weekly(
     let week_ago = now - Duration::days(7);
     let two_weeks_ago = now - Duration::days(14);
 
-    let observations = item_repo
-        .find_by_type(ItemType::Observation)
+    let this_week = item_repo
+        .find_observations_by_event_range(week_ago, now)
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))?;
-
-    let this_week = filter_by_time_range(&observations, week_ago, now);
-    let last_week = filter_by_time_range(&observations, two_weeks_ago, week_ago);
+    let last_week = item_repo
+        .find_observations_by_event_range(two_weeks_ago, week_ago)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     if this_week.is_empty() {
         println!(
@@ -145,7 +146,12 @@ pub async fn handle_weekly(
     Ok(())
 }
 
-fn filter_by_time_range(items: &[Item], from: DateTime<Utc>, to: DateTime<Utc>) -> Vec<Item> {
+#[cfg(test)]
+fn filter_by_time_range(
+    items: &[refine_core::knowledge::Item],
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+) -> Vec<refine_core::knowledge::Item> {
     items
         .iter()
         .filter(|item| {
@@ -424,7 +430,7 @@ fn write_weekly_history_lines_atomically(path: &Path, lines: &[String]) -> Resul
 mod tests {
     use super::*;
     use crate::score::{Indicator, Signal};
-    use refine_core::knowledge::{ItemId, RestoreParams, Tag};
+    use refine_core::knowledge::{Item, ItemId, ItemType, RestoreParams, Tag};
 
     fn make_weekly_record(seed: usize) -> WeeklyRecord {
         WeeklyRecord {

--- a/packages/core/src/infra/sqlite/mod.rs
+++ b/packages/core/src/infra/sqlite/mod.rs
@@ -159,6 +159,16 @@ impl ItemRepository for SqliteStore {
             .map_err(Into::into)
     }
 
+    async fn find_observations_by_event_range(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> RepoResult<Vec<Item>> {
+        self.request(|resp| SqliteCommand::FindObservationsByEventRange { start, end, resp })
+            .await
+            .map_err(Into::into)
+    }
+
     async fn find_by_document_id(&self, doc_id: &DocumentId) -> RepoResult<Vec<Item>> {
         let id = doc_id.as_str().to_string();
         self.request(|resp| SqliteCommand::FindByDocumentId {

--- a/packages/core/src/infra/sqlite/ops.rs
+++ b/packages/core/src/infra/sqlite/ops.rs
@@ -270,6 +270,38 @@ pub(super) fn find_by_date_range(
         .collect()
 }
 
+pub(super) fn find_observations_by_event_range(
+    conn: &Connection,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> InfraResult<Vec<Item>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT i.id, i.item_type, i.title, i.summary, i.content, i.tags, i.source, i.created_at, i.updated_at, i.document_id, i.excerpt
+             FROM items i
+             LEFT JOIN documents d ON i.document_id = d.id
+             WHERE i.item_type = ?1
+               AND COALESCE(d.captured_at, i.created_at) >= ?2
+               AND COALESCE(d.captured_at, i.created_at) < ?3
+             ORDER BY COALESCE(d.captured_at, i.created_at) DESC, i.created_at DESC",
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+
+    let rows = stmt
+        .query_map(
+            params![
+                ItemType::Observation.as_str(),
+                start.to_rfc3339(),
+                end.to_rfc3339()
+            ],
+            |row| row_to_item(row).map_err(to_row_err),
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+
+    rows.map(|r| r.map_err(|e| InfraError::Database(e.to_string())))
+        .collect()
+}
+
 pub(super) fn find_by_document_id(conn: &Connection, document_id: &str) -> InfraResult<Vec<Item>> {
     let mut stmt = conn
         .prepare(
@@ -371,6 +403,78 @@ mod tests {
         let result = find_by_date_range(&conn, start, end).unwrap();
 
         assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn find_observations_by_event_range_uses_document_captured_at_before_item_created_at() {
+        use super::{find_observations_by_event_range, save};
+        use crate::knowledge::{DocumentId, Item, ItemId, ItemType, RestoreParams};
+        use chrono::{Duration, TimeZone, Utc};
+
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        init_schema(&conn).expect("init schema");
+
+        let base = Utc.with_ymd_and_hms(2026, 5, 25, 0, 0, 0).unwrap();
+        let historical_event = base - Duration::days(10);
+        let current_ingest = base - Duration::days(1);
+        let doc_id = DocumentId::from("doc-historical");
+
+        conn.execute(
+            "INSERT INTO documents (id, title, raw_content, source, url, captured_at, created_at, updated_at)
+             VALUES (?1, 'Historical session', 'raw', 'codex-session', 'file:///session.jsonl', ?2, ?3, ?3)",
+            (
+                doc_id.as_str(),
+                historical_event.to_rfc3339(),
+                current_ingest.to_rfc3339(),
+            ),
+        )
+        .expect("insert document");
+
+        let linked_observation = Item::restore(RestoreParams {
+            id: ItemId::from("linked-observation"),
+            item_type: ItemType::Observation,
+            title: "linked".to_string(),
+            summary: String::new(),
+            content: String::new(),
+            tags: vec![],
+            source: None,
+            document_id: Some(doc_id),
+            excerpt: None,
+            created_at: current_ingest,
+            updated_at: current_ingest,
+        })
+        .unwrap();
+        save(&conn, &linked_observation).unwrap();
+
+        let fallback_observation = Item::restore(RestoreParams {
+            id: ItemId::from("fallback-observation"),
+            item_type: ItemType::Observation,
+            title: "fallback".to_string(),
+            summary: String::new(),
+            content: String::new(),
+            tags: vec![],
+            source: None,
+            document_id: None,
+            excerpt: None,
+            created_at: current_ingest,
+            updated_at: current_ingest,
+        })
+        .unwrap();
+        save(&conn, &fallback_observation).unwrap();
+
+        let this_week = find_observations_by_event_range(&conn, base - Duration::days(7), base)
+            .expect("query current week");
+        assert_eq!(this_week.len(), 1);
+        assert_eq!(this_week[0].id().as_str(), "fallback-observation");
+
+        let last_week = find_observations_by_event_range(
+            &conn,
+            base - Duration::days(14),
+            base - Duration::days(7),
+        )
+        .expect("query previous week");
+        assert_eq!(last_week.len(), 1);
+        assert_eq!(last_week[0].id().as_str(), "linked-observation");
     }
 
     #[test]

--- a/packages/core/src/infra/sqlite/worker.rs
+++ b/packages/core/src/infra/sqlite/worker.rs
@@ -75,6 +75,11 @@ pub(super) enum SqliteCommand {
         end: DateTime<Utc>,
         resp: oneshot::Sender<InfraResult<Vec<Item>>>,
     },
+    FindObservationsByEventRange {
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        resp: oneshot::Sender<InfraResult<Vec<Item>>>,
+    },
     // Document 操作
     DocFindByUrl {
         url: String,
@@ -225,6 +230,9 @@ fn handle_command(conn: &Connection, command: SqliteCommand) {
         }
         SqliteCommand::FindByDateRange { start, end, resp } => {
             let _ = resp.send(ops::find_by_date_range(conn, start, end));
+        }
+        SqliteCommand::FindObservationsByEventRange { start, end, resp } => {
+            let _ = resp.send(ops::find_observations_by_event_range(conn, start, end));
         }
         SqliteCommand::DocFindByUrl { url, resp } => {
             let _ = resp.send(doc_ops::find_by_url(conn, &url));

--- a/packages/core/src/knowledge/repository.rs
+++ b/packages/core/src/knowledge/repository.rs
@@ -52,6 +52,15 @@ pub trait ItemRepository: Send + Sync {
         end: DateTime<Utc>,
     ) -> RepoResult<Vec<Item>>;
 
+    /// 查找事件时间窗口内的 observations。
+    ///
+    /// 会话导入的 item 使用关联 Document.captured_at；缺少关联 Document 的旧数据回退到 item.created_at。
+    async fn find_observations_by_event_range(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> RepoResult<Vec<Item>>;
+
     /// 全文搜索（分页）
     async fn search_text(&self, query: &str, offset: usize, limit: usize) -> RepoResult<Vec<Item>>;
 


### PR DESCRIPTION
## Summary

- persist session `Document.captured_at` from parsed session start time, falling back to file mtime
- add an observation event-time query using `COALESCE(documents.captured_at, items.created_at)`
- switch Mirror Weekly windows to event time so historical session backfills do not inflate the current week

Fixes #131.

## Validation

- `cargo fmt --check`
- `cargo test -p refine-cli ingest_sessions`
- `cargo test -p refine-core find_observations_by_event_range`
- `cargo test -p mirror weekly`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`