### PR TITLE
[codex] Guard extraction status transitions

### DIFF
--- a/apps/server/src/extraction.rs
+++ b/apps/server/src/extraction.rs
@@ -17,8 +17,13 @@ pub fn spawn_extraction(
 ) {
     tokio::spawn(async move {
         if let Err(err) = run_extraction(state.clone(), &conversation_id, &job_id, mode).await {
-            set_conversation_failed(&state, &conversation_id, &err).await;
-            set_job_failed(&state, &job_id, &err).await;
+            if let Err(persist_err) = set_conversation_failed(&state, &conversation_id, &err).await
+            {
+                tracing::warn!("persist failed conversation failed: {}", persist_err);
+            }
+            if let Err(persist_err) = set_job_failed(&state, &job_id, &err).await {
+                tracing::warn!("persist failed job failed: {}", persist_err);
+            }
         }
     });
 }
@@ -29,8 +34,8 @@ async fn run_extraction(
     job_id: &str,
     mode: ExtractionMode,
 ) -> Result<(), String> {
-    set_job_running(&state, job_id).await;
-    set_conversation_status(&state, conversation_id, ConversationStatus::Processing).await;
+    set_job_running(&state, job_id).await?;
+    set_conversation_status(&state, conversation_id, ConversationStatus::Processing).await?;
 
     let conversation = state
         .conversation_repo
@@ -65,8 +70,8 @@ async fn run_extraction(
 
     let item_ids = save_and_index_items(&state, &items).await?;
 
-    set_conversation_processed(&state, conversation_id, item_ids).await;
-    set_job_succeeded(&state, job_id).await;
+    set_conversation_processed(&state, conversation_id, item_ids).await?;
+    set_job_succeeded(&state, job_id).await?;
 
     Ok(())
 }
@@ -154,7 +159,7 @@ fn mode_to_policy(mode: ExtractionMode) -> ExtractionPolicy {
     }
 }
 
-async fn set_job_running(state: &Arc<AppState>, job_id: &str) {
+async fn set_job_running(state: &Arc<AppState>, job_id: &str) -> Result<(), String> {
     update_job(
         state,
         job_id,
@@ -165,10 +170,10 @@ async fn set_job_running(state: &Arc<AppState>, job_id: &str) {
         },
         "running",
     )
-    .await;
+    .await
 }
 
-async fn set_job_succeeded(state: &Arc<AppState>, job_id: &str) {
+async fn set_job_succeeded(state: &Arc<AppState>, job_id: &str) -> Result<(), String> {
     update_job(
         state,
         job_id,
@@ -179,10 +184,10 @@ async fn set_job_succeeded(state: &Arc<AppState>, job_id: &str) {
         },
         "succeeded",
     )
-    .await;
+    .await
 }
 
-async fn set_job_failed(state: &Arc<AppState>, job_id: &str, error: &str) {
+async fn set_job_failed(state: &Arc<AppState>, job_id: &str, error: &str) -> Result<(), String> {
     update_job(
         state,
         job_id,
@@ -193,14 +198,14 @@ async fn set_job_failed(state: &Arc<AppState>, job_id: &str, error: &str) {
         },
         "failed",
     )
-    .await;
+    .await
 }
 
 async fn set_conversation_status(
     state: &Arc<AppState>,
     conversation_id: &str,
     status: ConversationStatus,
-) {
+) -> Result<(), String> {
     update_conversation(
         state,
         conversation_id,
@@ -209,14 +214,14 @@ async fn set_conversation_status(
         },
         "status",
     )
-    .await;
+    .await
 }
 
 async fn set_conversation_processed(
     state: &Arc<AppState>,
     conversation_id: &str,
     item_ids: Vec<String>,
-) {
+) -> Result<(), String> {
     update_conversation(
         state,
         conversation_id,
@@ -227,10 +232,14 @@ async fn set_conversation_processed(
         },
         "processed",
     )
-    .await;
+    .await
 }
 
-async fn set_conversation_failed(state: &Arc<AppState>, conversation_id: &str, error: &str) {
+async fn set_conversation_failed(
+    state: &Arc<AppState>,
+    conversation_id: &str,
+    error: &str,
+) -> Result<(), String> {
     update_conversation(
         state,
         conversation_id,
@@ -240,28 +249,30 @@ async fn set_conversation_failed(state: &Arc<AppState>, conversation_id: &str, e
         },
         "failed",
     )
-    .await;
+    .await
 }
 
-async fn update_job<F>(state: &Arc<AppState>, job_id: &str, mutate: F, phase: &str)
+async fn update_job<F>(
+    state: &Arc<AppState>,
+    job_id: &str,
+    mutate: F,
+    phase: &str,
+) -> Result<(), String>
 where
     F: FnOnce(&mut ExtractionJobRecord),
 {
-    let mut job = match state.job_repo.find_job_by_id(job_id).await {
-        Ok(Some(job)) => job,
-        Ok(None) => {
-            tracing::warn!("persist {} job skipped: not found {}", phase, job_id);
-            return;
-        }
-        Err(err) => {
-            tracing::warn!("persist {} job skipped: load error {}", phase, err);
-            return;
-        }
-    };
+    let mut job = state
+        .job_repo
+        .find_job_by_id(job_id)
+        .await
+        .map_err(|err| format!("persist {} job skipped: load error {}", phase, err))?
+        .ok_or_else(|| format!("persist {} job skipped: not found {}", phase, job_id))?;
     mutate(&mut job);
-    if let Err(err) = state.job_repo.upsert_job(&job).await {
-        tracing::warn!("persist {} job failed: {}", phase, err);
-    }
+    state
+        .job_repo
+        .upsert_job(&job)
+        .await
+        .map_err(|err| format!("persist {} job failed: {}", phase, err))
 }
 
 async fn save_document(
@@ -285,41 +296,32 @@ async fn update_conversation<F>(
     conversation_id: &str,
     mutate: F,
     phase: &str,
-) where
+) -> Result<(), String>
+where
     F: FnOnce(&mut ConversationRecord),
 {
-    let mut conversation = match state
+    let mut conversation = state
         .conversation_repo
         .find_conversation_by_id(conversation_id)
         .await
-    {
-        Ok(Some(conversation)) => conversation,
-        Ok(None) => {
-            tracing::warn!(
+        .map_err(|err| format!("persist {} conversation skipped: load error {}", phase, err))?
+        .ok_or_else(|| {
+            format!(
                 "persist {} conversation skipped: not found {}",
-                phase,
-                conversation_id
-            );
-            return;
-        }
-        Err(err) => {
-            tracing::warn!("persist {} conversation skipped: load error {}", phase, err);
-            return;
-        }
-    };
+                phase, conversation_id
+            )
+        })?;
     mutate(&mut conversation);
-    if let Err(err) = state
+    state
         .conversation_repo
         .upsert_conversation(&conversation)
         .await
-    {
-        tracing::warn!("persist {} conversation failed: {}", phase, err);
-    }
+        .map_err(|err| format!("persist {} conversation failed: {}", phase, err))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::spawn_extraction;
+    use super::{run_extraction, spawn_extraction};
     use crate::models::{
         now_iso, ConversationRecord, ConversationStatus, ExtractionJobRecord, ExtractionMode,
         JobStatus,
@@ -407,6 +409,49 @@ mod tests {
         assert!(
             saved_items.is_empty(),
             "failed extraction left orphan items: {:?}",
+            saved_items
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_job_start_transition_aborts_before_extraction() {
+        let (_tmp, state, persistence, conversation_id, job_id) = build_state_with_failing_index()
+            .await
+            .expect("build test state");
+        let mut job = persistence
+            .find_job_by_id(&job_id)
+            .await
+            .expect("load job")
+            .expect("job exists");
+        job.status = JobStatus::Running;
+        persistence
+            .upsert_job(&job)
+            .await
+            .expect("mark job running");
+        job.status = JobStatus::Succeeded;
+        persistence
+            .upsert_job(&job)
+            .await
+            .expect("mark job succeeded");
+
+        let err = run_extraction(
+            state.clone(),
+            &conversation_id,
+            &job_id,
+            ExtractionMode::Auto,
+        )
+        .await
+        .expect_err("succeeded job must not restart extraction");
+        assert!(
+            err.contains("invalid job status transition"),
+            "unexpected error: {}",
+            err
+        );
+
+        let saved_items = state.store.find_all().await.expect("load saved items");
+        assert!(
+            saved_items.is_empty(),
+            "aborted extraction saved items: {:?}",
             saved_items
         );
     }

--- a/packages/core/src/conversation/record.rs
+++ b/packages/core/src/conversation/record.rs
@@ -47,6 +47,7 @@ impl JobStatus {
         matches!(
             (self, next),
             (Self::Pending, Self::Running)
+                | (Self::Pending, Self::Failed)
                 | (Self::Running, Self::Succeeded)
                 | (Self::Running, Self::Failed)
         )
@@ -135,6 +136,7 @@ mod tests {
     #[test]
     fn job_status_rejects_terminal_regression() {
         assert!(JobStatus::Pending.can_transition_to(&JobStatus::Running));
+        assert!(JobStatus::Pending.can_transition_to(&JobStatus::Failed));
         assert!(JobStatus::Running.can_transition_to(&JobStatus::Succeeded));
         assert!(JobStatus::Running.can_transition_to(&JobStatus::Failed));
         assert!(!JobStatus::Succeeded.can_transition_to(&JobStatus::Pending));

--- a/packages/core/src/conversation/record.rs
+++ b/packages/core/src/conversation/record.rs
@@ -11,6 +11,24 @@ pub enum ConversationStatus {
     Failed,
 }
 
+impl ConversationStatus {
+    pub fn can_transition_to(&self, next: &Self) -> bool {
+        if self == next {
+            return true;
+        }
+
+        matches!(
+            (self, next),
+            (Self::Captured, Self::Queued)
+                | (Self::Queued, Self::Processing)
+                | (Self::Queued, Self::Failed)
+                | (Self::Processing, Self::Processed)
+                | (Self::Processing, Self::Failed)
+                | (Self::Failed, Self::Queued)
+        )
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum JobStatus {
@@ -18,6 +36,21 @@ pub enum JobStatus {
     Running,
     Succeeded,
     Failed,
+}
+
+impl JobStatus {
+    pub fn can_transition_to(&self, next: &Self) -> bool {
+        if self == next {
+            return true;
+        }
+
+        matches!(
+            (self, next),
+            (Self::Pending, Self::Running)
+                | (Self::Running, Self::Succeeded)
+                | (Self::Running, Self::Failed)
+        )
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -83,5 +116,28 @@ pub fn normalize_timestamp(raw: Option<String>) -> String {
             .map(|ts| ts.with_timezone(&Utc).to_rfc3339())
             .unwrap_or_else(|_| now_iso()),
         None => now_iso(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConversationStatus, JobStatus};
+
+    #[test]
+    fn conversation_status_rejects_terminal_regression() {
+        assert!(ConversationStatus::Captured.can_transition_to(&ConversationStatus::Queued));
+        assert!(ConversationStatus::Queued.can_transition_to(&ConversationStatus::Processing));
+        assert!(ConversationStatus::Processing.can_transition_to(&ConversationStatus::Processed));
+        assert!(ConversationStatus::Failed.can_transition_to(&ConversationStatus::Queued));
+        assert!(!ConversationStatus::Processed.can_transition_to(&ConversationStatus::Queued));
+    }
+
+    #[test]
+    fn job_status_rejects_terminal_regression() {
+        assert!(JobStatus::Pending.can_transition_to(&JobStatus::Running));
+        assert!(JobStatus::Running.can_transition_to(&JobStatus::Succeeded));
+        assert!(JobStatus::Running.can_transition_to(&JobStatus::Failed));
+        assert!(!JobStatus::Succeeded.can_transition_to(&JobStatus::Pending));
+        assert!(!JobStatus::Failed.can_transition_to(&JobStatus::Running));
     }
 }

--- a/packages/core/src/infra/sqlite/conversation_ops.rs
+++ b/packages/core/src/infra/sqlite/conversation_ops.rs
@@ -207,10 +207,9 @@ pub(super) fn find_job_by_id(
 }
 
 pub(super) fn upsert_job(conn: &Connection, job: &ExtractionJobRecord) -> InfraResult<()> {
-    validate_job_transition(conn, job)?;
-
-    conn.execute(
-        r#"
+    let affected = conn
+        .execute(
+            r#"
         INSERT INTO extraction_jobs
           (id, conversation_id, mode, status, created_at, updated_at, error)
         VALUES
@@ -222,18 +221,52 @@ pub(super) fn upsert_job(conn: &Connection, job: &ExtractionJobRecord) -> InfraR
           created_at=excluded.created_at,
           updated_at=excluded.updated_at,
           error=excluded.error
+        WHERE extraction_jobs.status = excluded.status
+           OR (extraction_jobs.status = 'pending' AND excluded.status = 'running')
+           OR (extraction_jobs.status = 'running' AND excluded.status IN ('succeeded', 'failed'))
         "#,
-        params![
-            job.id,
-            job.conversation_id,
-            extraction_mode_to_db(&job.mode),
+            params![
+                job.id,
+                job.conversation_id,
+                extraction_mode_to_db(&job.mode),
+                job_status_to_db(&job.status),
+                job.created_at,
+                job.updated_at,
+                job.error,
+            ],
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+
+    if affected == 0 {
+        let existing = conn
+            .query_row(
+                "SELECT status FROM extraction_jobs WHERE id = ?1",
+                [job.id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|e| InfraError::Database(e.to_string()))?
+            .map(|raw| job_status_from_db(raw.as_str()))
+            .transpose()
+            .map_err(InfraError::Database)?;
+
+        if let Some(existing) = existing {
+            return Err(invalid_transition_error(
+                "job",
+                &job.id,
+                job_status_to_db(&existing),
+                job_status_to_db(&job.status),
+            ));
+        }
+
+        return Err(invalid_transition_error(
+            "job",
+            &job.id,
+            "<missing>",
             job_status_to_db(&job.status),
-            job.created_at,
-            job.updated_at,
-            job.error,
-        ],
-    )
-    .map_err(|e| InfraError::Database(e.to_string()))?;
+        ));
+    }
+
     Ok(())
 }
 
@@ -260,33 +293,6 @@ fn validate_conversation_transition(
                 &record.id,
                 conversation_status_to_db(&existing),
                 conversation_status_to_db(&record.status),
-            ));
-        }
-    }
-
-    Ok(())
-}
-
-fn validate_job_transition(conn: &Connection, job: &ExtractionJobRecord) -> InfraResult<()> {
-    let existing = conn
-        .query_row(
-            "SELECT status FROM extraction_jobs WHERE id = ?1",
-            [job.id.as_str()],
-            |row| row.get::<_, String>(0),
-        )
-        .optional()
-        .map_err(|e| InfraError::Database(e.to_string()))?
-        .map(|raw| job_status_from_db(raw.as_str()))
-        .transpose()
-        .map_err(InfraError::Database)?;
-
-    if let Some(existing) = existing {
-        if !existing.can_transition_to(&job.status) {
-            return Err(invalid_transition_error(
-                "job",
-                &job.id,
-                job_status_to_db(&existing),
-                job_status_to_db(&job.status),
             ));
         }
     }

--- a/packages/core/src/infra/sqlite/conversation_ops.rs
+++ b/packages/core/src/infra/sqlite/conversation_ops.rs
@@ -101,15 +101,14 @@ pub(super) fn upsert_conversation(
     conn: &Connection,
     record: &ConversationRecord,
 ) -> InfraResult<()> {
-    validate_conversation_transition(conn, record)?;
-
     let item_ids =
         serde_json::to_string(&record.item_ids).map_err(|e| InfraError::Database(e.to_string()))?;
     let metadata =
         serde_json::to_string(&record.metadata).map_err(|e| InfraError::Database(e.to_string()))?;
 
-    conn.execute(
-        r#"
+    let affected = conn
+        .execute(
+            r#"
         INSERT INTO conversations
           (id, user_id, source, url, title, raw_content, metadata_json,
            captured_at, created_at, status, idempotency_key, item_ids, last_error)
@@ -129,24 +128,60 @@ pub(super) fn upsert_conversation(
           idempotency_key=excluded.idempotency_key,
           item_ids=excluded.item_ids,
           last_error=excluded.last_error
+        WHERE conversations.status = excluded.status
+           OR (conversations.status = 'captured' AND excluded.status = 'queued')
+           OR (conversations.status = 'queued' AND excluded.status IN ('processing', 'failed'))
+           OR (conversations.status = 'processing' AND excluded.status IN ('processed', 'failed'))
+           OR (conversations.status = 'failed' AND excluded.status = 'queued')
         "#,
-        params![
-            record.id,
-            record.user_id,
-            record.source,
-            record.url,
-            record.title,
-            record.raw_content,
-            metadata,
-            record.captured_at,
-            record.created_at,
+            params![
+                record.id,
+                record.user_id,
+                record.source,
+                record.url,
+                record.title,
+                record.raw_content,
+                metadata,
+                record.captured_at,
+                record.created_at,
+                conversation_status_to_db(&record.status),
+                record.idempotency_key,
+                item_ids,
+                record.last_error,
+            ],
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+
+    if affected == 0 {
+        let existing = conn
+            .query_row(
+                "SELECT status FROM conversations WHERE id = ?1",
+                [record.id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|e| InfraError::Database(e.to_string()))?
+            .map(|raw| conversation_status_from_db(raw.as_str()))
+            .transpose()
+            .map_err(InfraError::Database)?;
+
+        if let Some(existing) = existing {
+            return Err(invalid_transition_error(
+                "conversation",
+                &record.id,
+                conversation_status_to_db(&existing),
+                conversation_status_to_db(&record.status),
+            ));
+        }
+
+        return Err(invalid_transition_error(
+            "conversation",
+            &record.id,
+            "<missing>",
             conversation_status_to_db(&record.status),
-            record.idempotency_key,
-            item_ids,
-            record.last_error,
-        ],
-    )
-    .map_err(|e| InfraError::Database(e.to_string()))?;
+        ));
+    }
+
     Ok(())
 }
 
@@ -223,6 +258,7 @@ pub(super) fn upsert_job(conn: &Connection, job: &ExtractionJobRecord) -> InfraR
           error=excluded.error
         WHERE extraction_jobs.status = excluded.status
            OR (extraction_jobs.status = 'pending' AND excluded.status = 'running')
+           OR (extraction_jobs.status = 'pending' AND excluded.status = 'failed')
            OR (extraction_jobs.status = 'running' AND excluded.status IN ('succeeded', 'failed'))
         "#,
             params![
@@ -265,36 +301,6 @@ pub(super) fn upsert_job(conn: &Connection, job: &ExtractionJobRecord) -> InfraR
             "<missing>",
             job_status_to_db(&job.status),
         ));
-    }
-
-    Ok(())
-}
-
-fn validate_conversation_transition(
-    conn: &Connection,
-    record: &ConversationRecord,
-) -> InfraResult<()> {
-    let existing = conn
-        .query_row(
-            "SELECT status FROM conversations WHERE id = ?1",
-            [record.id.as_str()],
-            |row| row.get::<_, String>(0),
-        )
-        .optional()
-        .map_err(|e| InfraError::Database(e.to_string()))?
-        .map(|raw| conversation_status_from_db(raw.as_str()))
-        .transpose()
-        .map_err(InfraError::Database)?;
-
-    if let Some(existing) = existing {
-        if !existing.can_transition_to(&record.status) {
-            return Err(invalid_transition_error(
-                "conversation",
-                &record.id,
-                conversation_status_to_db(&existing),
-                conversation_status_to_db(&record.status),
-            ));
-        }
     }
 
     Ok(())

--- a/packages/core/src/infra/sqlite/conversation_ops.rs
+++ b/packages/core/src/infra/sqlite/conversation_ops.rs
@@ -101,6 +101,8 @@ pub(super) fn upsert_conversation(
     conn: &Connection,
     record: &ConversationRecord,
 ) -> InfraResult<()> {
+    validate_conversation_transition(conn, record)?;
+
     let item_ids =
         serde_json::to_string(&record.item_ids).map_err(|e| InfraError::Database(e.to_string()))?;
     let metadata =
@@ -205,6 +207,8 @@ pub(super) fn find_job_by_id(
 }
 
 pub(super) fn upsert_job(conn: &Connection, job: &ExtractionJobRecord) -> InfraResult<()> {
+    validate_job_transition(conn, job)?;
+
     conn.execute(
         r#"
         INSERT INTO extraction_jobs
@@ -231,6 +235,69 @@ pub(super) fn upsert_job(conn: &Connection, job: &ExtractionJobRecord) -> InfraR
     )
     .map_err(|e| InfraError::Database(e.to_string()))?;
     Ok(())
+}
+
+fn validate_conversation_transition(
+    conn: &Connection,
+    record: &ConversationRecord,
+) -> InfraResult<()> {
+    let existing = conn
+        .query_row(
+            "SELECT status FROM conversations WHERE id = ?1",
+            [record.id.as_str()],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|e| InfraError::Database(e.to_string()))?
+        .map(|raw| conversation_status_from_db(raw.as_str()))
+        .transpose()
+        .map_err(InfraError::Database)?;
+
+    if let Some(existing) = existing {
+        if !existing.can_transition_to(&record.status) {
+            return Err(invalid_transition_error(
+                "conversation",
+                &record.id,
+                conversation_status_to_db(&existing),
+                conversation_status_to_db(&record.status),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_job_transition(conn: &Connection, job: &ExtractionJobRecord) -> InfraResult<()> {
+    let existing = conn
+        .query_row(
+            "SELECT status FROM extraction_jobs WHERE id = ?1",
+            [job.id.as_str()],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|e| InfraError::Database(e.to_string()))?
+        .map(|raw| job_status_from_db(raw.as_str()))
+        .transpose()
+        .map_err(InfraError::Database)?;
+
+    if let Some(existing) = existing {
+        if !existing.can_transition_to(&job.status) {
+            return Err(invalid_transition_error(
+                "job",
+                &job.id,
+                job_status_to_db(&existing),
+                job_status_to_db(&job.status),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn invalid_transition_error(kind: &str, id: &str, from: &str, to: &str) -> InfraError {
+    let message = format!("invalid {kind} status transition for {id}: {from} -> {to}");
+    tracing::error!("{message}");
+    InfraError::Database(message)
 }
 
 pub(super) fn insert_event(conn: &Connection, event: &EventRecord) -> InfraResult<()> {
@@ -622,6 +689,48 @@ mod tests {
             .expect("job should exist");
         assert_eq!(loaded.id, job.id);
         assert_eq!(loaded.status, JobStatus::Pending);
+        cleanup(&path);
+    }
+
+    #[tokio::test]
+    async fn upsert_job_rejects_invalid_status_regression() {
+        let path = temp_db_path();
+        let store = SqliteStore::open(&path).expect("store init");
+        let store: Arc<dyn JobRepository> = Arc::new(store);
+        let now = now_iso();
+        let mut job = ExtractionJobRecord {
+            id: Uuid::new_v4().to_string(),
+            conversation_id: "c1".to_string(),
+            mode: ExtractionMode::Auto,
+            status: JobStatus::Pending,
+            created_at: now.clone(),
+            updated_at: now,
+            error: None,
+        };
+
+        store.upsert_job(&job).await.expect("insert pending job");
+        job.status = JobStatus::Running;
+        store.upsert_job(&job).await.expect("mark job running");
+        job.status = JobStatus::Succeeded;
+        store.upsert_job(&job).await.expect("mark job succeeded");
+
+        job.status = JobStatus::Pending;
+        let err = store
+            .upsert_job(&job)
+            .await
+            .expect_err("succeeded jobs must not regress to pending");
+        assert!(
+            err.to_string().contains("invalid job status transition"),
+            "unexpected error: {}",
+            err
+        );
+
+        let loaded = store
+            .find_job_by_id(&job.id)
+            .await
+            .expect("find job")
+            .expect("job should exist");
+        assert_eq!(loaded.status, JobStatus::Succeeded);
         cleanup(&path);
     }
 

--- a/packages/core/tests/sqlite_roundtrip.rs
+++ b/packages/core/tests/sqlite_roundtrip.rs
@@ -1,9 +1,14 @@
 use chrono::{Duration, TimeZone, Utc};
+use refine_core::conversation::{
+    now_iso, ConversationRecord, ConversationRepository, ConversationStatus, ExtractionJobRecord,
+    ExtractionMode, JobRepository, JobStatus,
+};
 use refine_core::infra::SqliteStore;
 use refine_core::knowledge::{
     Document, DocumentId, Item, ItemId, ItemRepository, ItemType, RestoreDocumentParams,
     RestoreParams, Source, Tag,
 };
+use serde_json::json;
 use std::collections::HashSet;
 
 #[tokio::test]
@@ -285,4 +290,96 @@ async fn find_recent_and_count_items_respect_type_and_pagination() {
         .await
         .expect("find_recent all failed");
     assert_eq!(paged_all.len(), 2);
+}
+
+#[tokio::test]
+async fn conversation_upsert_rejects_invalid_status_regression() {
+    let store = SqliteStore::in_memory().expect("failed to create sqlite store");
+    let mut conversation =
+        build_conversation("conv-invalid-transition", ConversationStatus::Processed);
+
+    store
+        .upsert_conversation(&conversation)
+        .await
+        .expect("insert processed conversation");
+
+    conversation.status = ConversationStatus::Queued;
+    let err = store
+        .upsert_conversation(&conversation)
+        .await
+        .expect_err("processed conversations must not regress to queued");
+    assert!(
+        err.to_string()
+            .contains("invalid conversation status transition"),
+        "unexpected error: {}",
+        err
+    );
+
+    let loaded = store
+        .find_conversation_by_id(&conversation.id)
+        .await
+        .expect("find conversation")
+        .expect("conversation should exist");
+    assert_eq!(loaded.status, ConversationStatus::Processed);
+}
+
+#[tokio::test]
+async fn pending_job_can_record_startup_failure_without_regressing_terminal_state() {
+    let store = SqliteStore::in_memory().expect("failed to create sqlite store");
+    let now = now_iso();
+    let mut job = ExtractionJobRecord {
+        id: "job-startup-failure".to_string(),
+        conversation_id: "conv-startup-failure".to_string(),
+        mode: ExtractionMode::Auto,
+        status: JobStatus::Pending,
+        created_at: now.clone(),
+        updated_at: now,
+        error: None,
+    };
+
+    store.upsert_job(&job).await.expect("insert pending job");
+    job.status = JobStatus::Failed;
+    job.error = Some("startup failed".to_string());
+    store
+        .upsert_job(&job)
+        .await
+        .expect("pending job should record startup failure");
+
+    job.status = JobStatus::Running;
+    let err = store
+        .upsert_job(&job)
+        .await
+        .expect_err("failed jobs must not regress to running");
+    assert!(
+        err.to_string().contains("invalid job status transition"),
+        "unexpected error: {}",
+        err
+    );
+
+    let loaded = store
+        .find_job_by_id(&job.id)
+        .await
+        .expect("find job")
+        .expect("job should exist");
+    assert_eq!(loaded.status, JobStatus::Failed);
+    assert_eq!(loaded.error.as_deref(), Some("startup failed"));
+}
+
+fn build_conversation(id: &str, status: ConversationStatus) -> ConversationRecord {
+    let now = now_iso();
+    ConversationRecord {
+        id: id.to_string(),
+        user_id: "test-user".to_string(),
+        source: "test".to_string(),
+        url: format!("https://example.com/{}", id),
+        title: Some("test conversation".to_string()),
+        raw_content: "Human: hello\nAssistant: world".to_string(),
+        metadata: json!({}),
+        captured_at: now.clone(),
+        created_at: now,
+        status,
+        idempotency_key: format!("idempotency-{}", id),
+        item_ids: Vec::new(),
+        last_error: None,
+    }
 }


### PR DESCRIPTION
## Summary

- Add explicit transition tables for `ConversationStatus` and `JobStatus`.
- Reject invalid SQLite upsert status overwrites before updating existing rows.
- Add regression coverage for terminal job status rollback and domain transition rules.

## Issue

Handles the HI-2 state-machine validation slice from refine issue 98.

The parent issue should remain open for CR-5 foreign keys and HI-1 transaction boundaries.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test`
