### PR TITLE
feat(cli): consume remem raw sessions as sole facet input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Switched normal session facet ingestion to remem's exact-tuple, snapshot-paginated raw archive provider; replacement facets and deletion of matching local path-keyed Documents/items now commit in one transaction, preventing duplicate downstream observations. Direct transcript scanning remains available only through the temporary `--legacy-local-scan` rollback switch.
+
 ## [0.1.3] - 2026-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ln -s "$(pwd)/skills/cognitive-portrait" ~/.claude/skills/cognitive-portrait
 # If ~/.claude/skills/cognitive-portrait already exists as a directory (old copy),
 # delete it first: rm -rf ~/.claude/skills/cognitive-portrait
 
-# Import your AI coding sessions
+# Import sessions from remem's raw archive
 refine ingest-sessions
 
 # See your cognitive snapshot
@@ -145,7 +145,7 @@ friction_green = 1.0         # friction < 1.0/session = green
 ### Data Flow
 
 ```
-~/.claude/projects/*.jsonl          ← Claude Code sessions
+remem raw sessions/messages         ← Claude Code + Codex raw archive
     │
     ▼ refine ingest-sessions        (12-dimension facet extraction via LLM)
     │
@@ -160,12 +160,24 @@ SQLite (observations, documents)    ← Shared data store
 
 ## Refine CLI Commands
 
+`refine ingest-sessions` requires a compatible `remem` binary on `PATH`. Set
+`REFINE_REMEM_BIN` to an explicit binary path when needed. The normal path
+enumerates exact tuples with `remem raw sessions --json`, reads every snapshot-
+paginated `remem raw messages --json` page, and fails visibly on provider or
+contract errors. During the switch, a matching local path-keyed Document/items
+and its remem replacement facets are changed in one transaction;
+ambiguous legacy identity fails closed. Direct transcript scanning is disabled by default;
+`--legacy-local-scan` is a temporary one-release rollback switch and reuses a
+matching remem identity instead of creating a second active facet set.
+
 ### Session Analysis
 
 ```bash
-refine ingest-sessions                  # Import all sessions (incremental)
-refine ingest-sessions --source claude  # Claude Code only
+refine ingest-sessions                  # Import complete sessions from remem
+refine ingest-sessions --latest 20      # Most recent 20 remem sessions
 refine ingest-sessions --dry-run        # Preview without LLM calls
+refine ingest-sessions --legacy-local-scan --source claude
+                                        # One-release rollback to filesystem discovery
 refine insights --prescription          # L1-L4 cognitive report
 mirror dashboard                        # Cognitive growth dashboard
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,6 +8,15 @@
 
 ## 核心功能
 
+`refine ingest-sessions` 默认要求 `PATH` 中存在兼容的 `remem`，也可通过
+`REFINE_REMEM_BIN` 指定二进制路径。正常路径使用 `remem raw sessions --json`
+枚举精确 tuple，并读取全部 `remem raw messages --json` 快照分页；子进程失败、
+JSON/selector/order/cursor 契约异常都会显式报错，不会降级为空会话。直接扫描
+transcript 仅由临时的 `--legacy-local-scan` 回滚开关启用。切换期间，匹配的本地旧
+Document/items 删除与 remem 替代 facets 保存会在同一事务提交；身份匹配不唯一时
+命令会显式失败，避免下游重复计数或误删。回滚扫描也会复用匹配的 remem identity，
+不会重新建立第二套有效 facets。
+
 - **跨平台知识同步（主线）** — 把 ChatGPT、Claude、Gemini、Grok、Claude Code、Codex 的对话知识统一同步
 - **会话存储与可追溯** — 原文文档入库，并可回溯到对应提炼结果
 - **智能提炼（可选能力层）** — 从已同步对话中提取知识卡片、技能、代码片段
@@ -47,7 +56,7 @@ REFINE_OPENAI_BASE_URL=https://api.openai.com
 REFINE_OPENAI_MODEL=gpt-4o
 EOF
 
-# 导入会话（扫描 ~/.claude/projects/ 和 ~/.codex/sessions/）
+# 导入会话（从 remem raw archive 读取）
 refine ingest-sessions
 
 # 生成认知报告
@@ -62,10 +71,11 @@ mirror dashboard
 ### Session Insights（认知分析）
 
 ```bash
-refine ingest-sessions                  # 导入全部会话（增量，自动跳过已处理的）
-refine ingest-sessions --source claude  # 只导入 Claude Code
-refine ingest-sessions --limit 100      # 限制数量
+refine ingest-sessions                  # 从 remem raw archive 导入完整会话
+refine ingest-sessions --latest 20      # 只处理 remem 中最近的 20 个会话
 refine ingest-sessions --dry-run        # 预览，不调 LLM
+refine ingest-sessions --legacy-local-scan --source claude
+                                        # 一个发布周期内的文件扫描回滚开关
 
 refine insights                         # 生成 L1-L3 报告
 refine insights --prescription          # 含 L4 成长处方
@@ -96,11 +106,11 @@ refine doc-search "query"               # 搜索原文文档
 ## 架构
 
 ```
-Claude Code / Codex 会话文件 (.jsonl)
+remem raw archive（精确 source_root/project/session_id tuple）
     │
     ▼ refine ingest-sessions
-    解析 → 过滤 → 12 维度 facet 提取 → SQLite
-    （3 路并发，断点续传，指数退避重试）
+    契约校验 → 过滤 → 12 维度 facet 提取 → SQLite
+    （默认串行，可配置并发，指数退避重试）
     │
     ▼ refine insights
     本地聚类（按项目分组）→ 10 路并发 LLM 分析 → 合并报告
@@ -134,8 +144,8 @@ refine/
 │   ├── knowledge/       # 知识管理（Item, Document, Repository）
 │   ├── refinement/      # 知识提炼（Conversation, Extractor）
 │   ├── session/         # 会话分析
-│   │   ├── discovery.rs     # 会话文件发现
-│   │   ├── parser.rs        # JSONL 解析（Claude Code + Codex）
+│   │   ├── discovery.rs     # 临时回滚路径的会话文件发现
+│   │   ├── parser.rs        # 临时回滚路径的 JSONL 解析
 │   │   ├── facets.rs        # 12 维度 facet 提取
 │   │   ├── clustering.rs    # 本地聚类（按项目分组）
 │   │   ├── analysis_routes.rs # 10 路 LLM 分析任务

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -73,8 +73,8 @@ pub enum Commands {
     },
     /// 从 AI 编程会话中提取认知观测
     IngestSessions {
-        /// 来源过滤 (claude, codex)
-        #[arg(long)]
+        /// Legacy local-scan source filter (claude, codex); requires --legacy-local-scan.
+        #[arg(long, requires = "legacy_local_scan")]
         source: Option<String>,
         /// 限制处理数量（按路径顺序取前 N 个），与 --latest 互斥
         #[arg(short, long, conflicts_with = "latest")]
@@ -85,6 +85,9 @@ pub enum Commands {
         /// 仅预览，不实际处理
         #[arg(long)]
         dry_run: bool,
+        /// Temporarily use the legacy filesystem scanner instead of remem (one-release rollback).
+        #[arg(long)]
+        legacy_local_scan: bool,
     },
     /// 生成认知洞察报告
     Insights {

--- a/apps/cli/src/handlers.rs
+++ b/apps/cli/src/handlers.rs
@@ -36,8 +36,15 @@ pub async fn run(
             limit,
             latest,
             dry_run,
+            legacy_local_scan,
         } => {
-            let source_filter = source.as_deref().and_then(parse_session_source);
+            let source_filter = source
+                .as_deref()
+                .map(|raw| {
+                    parse_session_source(raw)
+                        .with_context(|| format!("invalid session source {raw:?}"))
+                })
+                .transpose()?;
             let llm_client = if dry_run {
                 None
             } else {
@@ -50,6 +57,7 @@ pub async fn run(
                     limit,
                     latest,
                     dry_run,
+                    legacy_local_scan,
                 },
                 db_path,
                 doc_store,

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -1,7 +1,8 @@
 //! ingest-sessions 命令实现
 //!
-//! 支持 3 路并发 + 断点续传 + API 限流重试
+//! 默认从 remem raw archive 读取；支持可配置并发、断点续传和 API 限流重试
 
+use crate::remem_sessions::load_remem_sessions;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use refine_core::error::InfraError;
@@ -11,11 +12,14 @@ use refine_core::session::{
     build_facet_prompt, chunk_session, discover_sessions, facets_to_items, needs_chunking,
     parse_facet_response, parse_session_file, FilterConfig, SessionSource, FACET_SYSTEM_PROMPT,
 };
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::sync::Semaphore;
+
+mod legacy_migration;
 
 const DEFAULT_CONCURRENCY: usize = 1;
 
@@ -33,6 +37,7 @@ pub struct IngestOptions {
     /// 按 mtime 降序取最近 N 个会话，与 limit 互斥
     pub latest: Option<usize>,
     pub dry_run: bool,
+    pub legacy_local_scan: bool,
 }
 
 /// 待处理的会话（已通过去重和过滤）
@@ -48,6 +53,7 @@ struct PendingSession {
     needs_chunk: bool,
     chunks: Vec<String>,
     existing_document: Option<Document>,
+    legacy_documents_to_delete: Vec<refine_core::knowledge::DocumentId>,
 }
 
 fn project_for_ingest(
@@ -75,6 +81,7 @@ fn incremental_cursor_path(home: &Path, source: Option<&SessionSource>, db_path:
     let source_key = match source {
         Some(SessionSource::ClaudeCode) => "claude-code",
         Some(SessionSource::Codex) => "codex",
+        Some(SessionSource::RememRaw) => "remem-raw",
         None => "all",
     };
     let db_key = encode_path_for_filename(db_path);
@@ -123,6 +130,139 @@ pub async fn handle_ingest_sessions(
     doc_store: Arc<dyn DocumentRepository>,
     llm_client: Option<Arc<dyn LlmClient>>,
 ) -> Result<()> {
+    if options.legacy_local_scan {
+        return handle_legacy_ingest_sessions(options, db_path, doc_store, llm_client).await;
+    }
+    handle_remem_ingest_sessions(options, doc_store, llm_client).await
+}
+
+async fn handle_remem_ingest_sessions(
+    options: IngestOptions,
+    doc_store: Arc<dyn DocumentRepository>,
+    llm_client: Option<Arc<dyn LlmClient>>,
+) -> Result<()> {
+    if options.source.is_some() {
+        anyhow::bail!(
+            "--source cannot be used with the remem provider because its contract does not expose a trustworthy Claude/Codex source; use --legacy-local-scan --source <claude|codex> only for rollback"
+        );
+    }
+
+    let sessions = load_remem_sessions(options.limit, options.latest)
+        .context("failed to load sessions from remem")?;
+    println!("remem 返回 {} 个会话", sessions.len());
+
+    let total = sessions.len();
+    let filter_config = FilterConfig::default();
+    let document_count = doc_store.count().await?;
+    let existing_documents = doc_store.find_recent(0, document_count).await?;
+    let mut claimed_legacy_documents = HashSet::new();
+    let mut pending = Vec::new();
+    let mut skipped_dup = 0usize;
+    let mut skipped_filter = 0usize;
+    let mut stale_refresh = 0usize;
+
+    for (idx, remem_session) in sessions.into_iter().enumerate() {
+        let url = remem_session.stable_document_url();
+        let raw_content = remem_session.session.to_document_content();
+        let legacy_documents_to_delete = legacy_migration::matching_legacy_document_ids(
+            &existing_documents,
+            &remem_session,
+            &raw_content,
+        )?;
+        for document_id in &legacy_documents_to_delete {
+            if !claimed_legacy_documents.insert(document_id.clone()) {
+                anyhow::bail!(
+                    "legacy document {document_id} matched more than one remem tuple; refusing destructive cleanup"
+                );
+            }
+        }
+        let existing_document = doc_store.find_by_url(&url).await?;
+        if let Some(existing_doc) = existing_document.as_ref() {
+            if existing_doc.raw_content() == raw_content {
+                if options.dry_run && !legacy_documents_to_delete.is_empty() {
+                    println!(
+                        "  [dry-run] {} | would remove {} superseded legacy document(s)",
+                        url,
+                        legacy_documents_to_delete.len()
+                    );
+                } else {
+                    doc_store
+                        .delete_documents_with_items(&legacy_documents_to_delete)
+                        .await
+                        .context("delete superseded legacy documents and facets")?;
+                }
+                skipped_dup += 1;
+                continue;
+            }
+            stale_refresh += 1;
+        }
+
+        if !refine_core::session::passes_filter(&remem_session.session, &filter_config) {
+            skipped_filter += 1;
+            continue;
+        }
+
+        if options.dry_run {
+            println!(
+                "  [dry-run] {} | {} msgs | {} chars | remem",
+                url,
+                remem_session.session.messages.len(),
+                remem_session.session.char_count(),
+            );
+            continue;
+        }
+
+        let captured_at = DateTime::<Utc>::from_timestamp(remem_session.first_epoch, 0)
+            .with_context(|| {
+                format!(
+                    "remem session {} has invalid first_epoch {}",
+                    remem_session.session_id, remem_session.first_epoch
+                )
+            })?;
+        let chunks = if needs_chunking(&remem_session.session) {
+            chunk_session(&remem_session.session)
+                .into_iter()
+                .map(|chunk| chunk.content)
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        pending.push(PendingSession {
+            idx,
+            total,
+            url,
+            source: remem_session.session.source,
+            project: Some(remem_session.project),
+            captured_at,
+            has_embedded_timestamp: true,
+            raw_content,
+            needs_chunk: !chunks.is_empty(),
+            chunks,
+            existing_document,
+            legacy_documents_to_delete,
+        });
+    }
+
+    process_pending_sessions(
+        pending,
+        total,
+        skipped_dup,
+        skipped_filter,
+        stale_refresh,
+        options.dry_run,
+        doc_store,
+        llm_client,
+    )
+    .await
+}
+
+async fn handle_legacy_ingest_sessions(
+    options: IngestOptions,
+    db_path: &Path,
+    doc_store: Arc<dyn DocumentRepository>,
+    llm_client: Option<Arc<dyn LlmClient>>,
+) -> Result<()> {
     // Incremental scan: only active for full (no --limit/--latest) non-dry-run runs.
     // 1-hour overlap on the cutoff absorbs clock skew and files modified near the boundary.
     let incremental = options.limit.is_none() && options.latest.is_none() && !options.dry_run;
@@ -158,6 +298,9 @@ pub async fn handle_ingest_sessions(
 
     let total = sessions_to_process.len();
     let filter_config = FilterConfig::default();
+    let document_count = doc_store.count().await?;
+    let existing_documents = doc_store.find_recent(0, document_count).await?;
+    let mut claimed_remem_documents = HashSet::new();
     let mut pending = Vec::new();
     let mut skipped_dup = 0usize;
     let mut skipped_filter = 0usize;
@@ -165,24 +308,69 @@ pub async fn handle_ingest_sessions(
 
     // 阶段 1: 串行做去重 + 过滤 + 解析（快，不需要 LLM）
     for (idx, ds) in sessions_to_process.iter().enumerate() {
-        let url = ds.path.to_string_lossy().to_string();
-
-        let existing_document = doc_store.find_by_url(&url).await?;
-        if let Some(existing_doc) = existing_document.as_ref() {
-            if session_needs_refresh(existing_doc, ds.modified_at) {
-                stale_refresh += 1;
-            } else {
-                skipped_dup += 1;
-                continue;
-            }
-        }
+        let legacy_url = ds.path.to_string_lossy().to_string();
+        let legacy_document = doc_store.find_by_url(&legacy_url).await?;
 
         let session = match parse_session_file(&ds.path, ds.source.clone()) {
             Ok(s) => s,
             Err(e) => {
-                tracing::warn!("解析失败 {}: {}", url, e);
+                tracing::warn!("解析失败 {}: {}", legacy_url, e);
                 continue;
             }
+        };
+
+        let project = project_for_ingest(ds.project.as_deref(), session.meta.project.as_deref());
+        let has_embedded_timestamp = session.meta.started_at.is_some();
+        let captured_at = session_captured_at(session.meta.started_at, ds.modified_at);
+        let raw_content = session.to_document_content();
+        let remem_document = legacy_migration::matching_remem_document(
+            &existing_documents,
+            &ds.path,
+            captured_at,
+            &raw_content,
+        )?;
+
+        let mut legacy_documents_to_delete = Vec::new();
+        let (url, effective_source, existing_document) = if let Some(remem_doc) = remem_document {
+            legacy_migration::claim_remem_document_once(
+                &mut claimed_remem_documents,
+                &remem_doc,
+                &ds.path,
+            )?;
+            if let Some(legacy_doc) = legacy_document.as_ref() {
+                legacy_documents_to_delete.push(legacy_doc.id().clone());
+            }
+            if remem_doc.raw_content() == raw_content {
+                if options.dry_run && !legacy_documents_to_delete.is_empty() {
+                    println!(
+                        "  [dry-run] {} | would remove superseded legacy document",
+                        legacy_url
+                    );
+                } else {
+                    doc_store
+                        .delete_documents_with_items(&legacy_documents_to_delete)
+                        .await
+                        .context("delete superseded legacy documents and facets")?;
+                }
+                skipped_dup += 1;
+                continue;
+            }
+            stale_refresh += 1;
+            (
+                remem_doc.url().to_string(),
+                SessionSource::RememRaw,
+                Some(remem_doc),
+            )
+        } else {
+            if let Some(existing_doc) = legacy_document.as_ref() {
+                if session_needs_refresh(existing_doc, ds.modified_at) {
+                    stale_refresh += 1;
+                } else {
+                    skipped_dup += 1;
+                    continue;
+                }
+            }
+            (legacy_url, ds.source.clone(), legacy_document)
         };
 
         if !refine_core::session::passes_filter(&session, &filter_config) {
@@ -196,16 +384,10 @@ pub async fn handle_ingest_sessions(
                 url,
                 session.messages.len(),
                 session.char_count(),
-                ds.source,
+                effective_source,
             );
             continue;
         }
-
-        let project = project_for_ingest(ds.project.as_deref(), session.meta.project.as_deref());
-        let has_embedded_timestamp = session.meta.started_at.is_some();
-        let captured_at = session_captured_at(session.meta.started_at, ds.modified_at);
-
-        let raw_content = session.to_document_content();
         let chunks = if needs_chunking(&session) {
             let cs = chunk_session(&session);
             cs.iter().map(|c| c.content.clone()).collect()
@@ -217,7 +399,7 @@ pub async fn handle_ingest_sessions(
             idx,
             total,
             url,
-            source: ds.source.clone(),
+            source: effective_source,
             project,
             captured_at,
             has_embedded_timestamp,
@@ -225,10 +407,42 @@ pub async fn handle_ingest_sessions(
             needs_chunk: !chunks.is_empty(),
             chunks,
             existing_document,
+            legacy_documents_to_delete,
         });
     }
 
-    if options.dry_run {
+    process_pending_sessions(
+        pending,
+        total,
+        skipped_dup,
+        skipped_filter,
+        stale_refresh,
+        options.dry_run,
+        doc_store,
+        llm_client,
+    )
+    .await?;
+
+    // Advance the incremental scan cursor so the next run only sees newer files.
+    if incremental {
+        write_last_ingest_mtime(source.as_ref(), db_path, scan_start);
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn process_pending_sessions(
+    pending: Vec<PendingSession>,
+    total: usize,
+    skipped_dup: usize,
+    skipped_filter: usize,
+    stale_refresh: usize,
+    dry_run: bool,
+    doc_store: Arc<dyn DocumentRepository>,
+    llm_client: Option<Arc<dyn LlmClient>>,
+) -> Result<()> {
+    if dry_run {
         let dry_count = total - skipped_dup - skipped_filter;
         println!(
             "\n[dry-run] 可处理 {}, 跳过重复 {}, 过滤 {}, 刷新过期 {}",
@@ -246,21 +460,17 @@ pub async fn handle_ingest_sessions(
         stale_refresh,
         concurrency,
     );
-
     if pending.is_empty() {
         println!("全部已处理完毕。");
         return Ok(());
     }
 
-    // 阶段 2: 并发做 LLM 提取 + 保存
     let client = llm_client.ok_or_else(|| anyhow::anyhow!("非 dry-run 模式需要 LLM API Key"))?;
     let semaphore = Arc::new(Semaphore::new(concurrency));
     let processed = Arc::new(AtomicUsize::new(0));
     let failed = Arc::new(AtomicUsize::new(0));
     let total_items = Arc::new(AtomicUsize::new(0));
-    // Shared flag: when any worker hits RateLimited, all others abort pending retries.
     let quota_hit = Arc::new(AtomicBool::new(false));
-
     let mut handles = Vec::new();
 
     for ps in pending {
@@ -271,49 +481,36 @@ pub async fn handle_ingest_sessions(
         let failed = failed.clone();
         let total_items = total_items.clone();
         let quota_hit = quota_hit.clone();
-
-        let handle = tokio::spawn(async move {
+        handles.push(tokio::spawn(async move {
             let _permit = sem.acquire().await.expect("semaphore closed");
-
-            let result = process_single_session(&ps, &client, &doc_store, &quota_hit).await;
-
-            match result {
+            match process_single_session(&ps, &client, &doc_store, &quota_hit).await {
                 Ok(item_count) => {
                     processed.fetch_add(1, Ordering::Relaxed);
                     total_items.fetch_add(item_count, Ordering::Relaxed);
                 }
-                Err(e) => {
-                    eprintln!("  ✗ [{}/{}] 失败: {}", ps.idx + 1, ps.total, e);
+                Err(error) => {
+                    eprintln!("  ✗ [{}/{}] 失败: {}", ps.idx + 1, ps.total, error);
                     failed.fetch_add(1, Ordering::Relaxed);
                 }
             }
-        });
-
-        handles.push(handle);
+        }));
     }
 
     for handle in handles {
-        let _ = handle.await;
+        handle.await.context("session ingest worker panicked")?;
     }
 
     let processed = processed.load(Ordering::Relaxed);
     let failed = failed.load(Ordering::Relaxed);
     let total_items = total_items.load(Ordering::Relaxed);
-
     println!(
         "\n完成: 处理 {}, 跳过重复 {}, 过滤 {}, 刷新过期 {}, 失败 {}, 生成 {} 条观测",
         processed, skipped_dup, skipped_filter, stale_refresh, failed, total_items
     );
     if failed > 0 {
         eprintln!("提示: 重新运行即可续传失败的会话");
-        return Err(anyhow::anyhow!("{} 个会话提取失败", failed));
+        anyhow::bail!("{} 个会话提取失败", failed);
     }
-
-    // Advance the incremental scan cursor so the next run only sees newer files.
-    if incremental {
-        write_last_ingest_mtime(source.as_ref(), db_path, scan_start);
-    }
-
     Ok(())
 }
 
@@ -350,9 +547,9 @@ async fn process_single_session(
     let items = facets_to_items(&facet_response, doc.id(), ps.project.as_deref());
     let item_count = items.len();
     doc_store
-        .save_with_replaced_items(&doc, &items)
+        .save_with_replaced_items_and_delete_documents(&doc, &items, &ps.legacy_documents_to_delete)
         .await
-        .context("保存 Document/Items 失败")?;
+        .context("保存 Document/Items 并清理旧会话失败")?;
 
     println!(
         "  + [{}/{}] {} | {} items",
@@ -442,304 +639,5 @@ async fn extract_and_parse_facets_with_retry(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use async_trait::async_trait;
-    use chrono::TimeZone;
-    use refine_core::error::InfraResult;
-    use refine_core::infra::SqliteStore;
-    use refine_core::knowledge::{DocumentRepository, Item, ItemRepository};
-    use refine_core::session::discover_sessions_in;
-    use std::fs;
-
-    struct StaticLlmClient {
-        response: String,
-    }
-
-    #[async_trait]
-    impl LlmClient for StaticLlmClient {
-        async fn complete(&self, _prompt: &str, _system: Option<&str>) -> InfraResult<String> {
-            Ok(self.response.clone())
-        }
-    }
-
-    #[test]
-    fn project_for_ingest_prefers_discovered_project_then_session_metadata() {
-        assert_eq!(
-            project_for_ingest(Some("claude-project"), Some("codex-cwd")).as_deref(),
-            Some("claude-project")
-        );
-        assert_eq!(
-            project_for_ingest(None, Some("codex-cwd")).as_deref(),
-            Some("codex-cwd")
-        );
-        assert_eq!(project_for_ingest(None, None), None);
-    }
-
-    #[test]
-    fn session_captured_at_prefers_session_started_at_then_file_mtime() {
-        let started_at = Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap();
-        let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(42);
-        assert_eq!(session_captured_at(Some(started_at), mtime), started_at);
-
-        let fallback = session_captured_at(None, mtime);
-        assert_eq!(fallback, DateTime::<Utc>::from(mtime));
-    }
-
-    #[test]
-    fn session_needs_refresh_when_file_mtime_is_newer_than_saved_document() {
-        let mut doc = Document::new("codex-session", "raw");
-        doc.set_url("file:///tmp/session.jsonl");
-
-        let old_mtime = SystemTime::now()
-            .checked_sub(Duration::from_secs(60))
-            .unwrap();
-        assert!(!session_needs_refresh(&doc, old_mtime));
-
-        let new_mtime = SystemTime::now() + Duration::from_millis(200);
-        assert!(session_needs_refresh(&doc, new_mtime));
-    }
-
-    #[test]
-    fn scoped_cursor_keeps_other_sources_discoverable() {
-        let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
-        let db_path = tmp.path().join("refine.db");
-        fs::write(&db_path, "").unwrap();
-
-        let claude_dir = home.join(".claude/projects/proj");
-        fs::create_dir_all(&claude_dir).unwrap();
-        let claude_path = claude_dir.join("claude.jsonl");
-        fs::write(&claude_path, "{}").unwrap();
-        filetime::set_file_mtime(&claude_path, filetime::FileTime::from_unix_time(20_000, 0))
-            .unwrap();
-
-        let codex_dir = home.join(".codex/sessions");
-        fs::create_dir_all(&codex_dir).unwrap();
-        let codex_path = codex_dir.join("codex.jsonl");
-        fs::write(&codex_path, "{}").unwrap();
-        filetime::set_file_mtime(&codex_path, filetime::FileTime::from_unix_time(1_000, 0))
-            .unwrap();
-
-        write_last_ingest_mtime_at(
-            home,
-            Some(&SessionSource::ClaudeCode),
-            &db_path,
-            SystemTime::UNIX_EPOCH + Duration::from_secs(10_000),
-        );
-
-        let claude_cutoff =
-            read_last_ingest_mtime_at(home, Some(&SessionSource::ClaudeCode), &db_path)
-                .unwrap()
-                .checked_sub(Duration::from_secs(3600))
-                .unwrap();
-        let claude_discovered =
-            discover_sessions_in(home, Some(SessionSource::ClaudeCode), Some(claude_cutoff));
-        assert_eq!(claude_discovered.len(), 1);
-
-        let codex_cutoff = read_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_path)
-            .map(|last| last.checked_sub(Duration::from_secs(3600)).unwrap());
-        assert!(codex_cutoff.is_none());
-
-        let codex_discovered = discover_sessions_in(home, Some(SessionSource::Codex), codex_cutoff);
-        assert_eq!(codex_discovered.len(), 1);
-        assert_eq!(codex_discovered[0].path, codex_path);
-    }
-
-    #[test]
-    fn cursor_is_partitioned_by_database_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        let home = tmp.path();
-        let db_a = tmp.path().join("a.db");
-        let db_b = tmp.path().join("b.db");
-        fs::write(&db_a, "").unwrap();
-        fs::write(&db_b, "").unwrap();
-
-        let when = SystemTime::UNIX_EPOCH + Duration::from_secs(42);
-        write_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_a, when);
-
-        assert_eq!(
-            read_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_a),
-            Some(when)
-        );
-        assert_eq!(
-            read_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_b),
-            None
-        );
-        assert_ne!(
-            incremental_cursor_path(home, Some(&SessionSource::Codex), &db_a),
-            incremental_cursor_path(home, Some(&SessionSource::Codex), &db_b)
-        );
-    }
-
-    fn read_last_ingest_mtime_at(
-        home: &Path,
-        source: Option<&SessionSource>,
-        db_path: &Path,
-    ) -> Option<SystemTime> {
-        let path = incremental_cursor_path(home, source, db_path);
-        let secs: u64 = std::fs::read_to_string(path).ok()?.trim().parse().ok()?;
-        Some(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
-    }
-
-    fn write_last_ingest_mtime_at(
-        home: &Path,
-        source: Option<&SessionSource>,
-        db_path: &Path,
-        t: SystemTime,
-    ) {
-        let path = incremental_cursor_path(home, source, db_path);
-        let dir = path.parent().unwrap();
-        fs::create_dir_all(dir).unwrap();
-        let dur = t.duration_since(SystemTime::UNIX_EPOCH).unwrap();
-        fs::write(path, dur.as_secs().to_string()).unwrap();
-    }
-
-    #[tokio::test]
-    async fn process_single_session_links_items_to_saved_document_id() {
-        let store = Arc::new(SqliteStore::in_memory().expect("in-memory sqlite store"));
-        let doc_store: Arc<dyn DocumentRepository> = store.clone();
-        let client: Arc<dyn LlmClient> = Arc::new(StaticLlmClient {
-            response: r#"{
-                "session_summary": "修复文档关联",
-                "cognitive_level": "proficient",
-                "collaboration_mode": "pair_programming",
-                "decisions": ["使用保存后的文档 ID"],
-                "bugs_fixed": ["修复会话导入的 shadow document id"],
-                "patterns": [],
-                "friction": [],
-                "project_progress": [],
-                "questions": [],
-                "knowledge_gained": [],
-                "tools_discovered": [],
-                "architecture": [],
-                "code_artifacts": []
-            }"#
-            .to_string(),
-        });
-        let quota_hit = Arc::new(AtomicBool::new(false));
-        let pending = PendingSession {
-            idx: 0,
-            total: 1,
-            url: "file:///tmp/session.jsonl".to_string(),
-            source: SessionSource::Codex,
-            project: Some("refine".to_string()),
-            captured_at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
-            has_embedded_timestamp: true,
-            raw_content: "User: fix the ingest bug".to_string(),
-            needs_chunk: false,
-            chunks: Vec::new(),
-            existing_document: None,
-        };
-
-        let item_count = process_single_session(&pending, &client, &doc_store, &quota_hit)
-            .await
-            .expect("session ingest should succeed");
-        assert_eq!(item_count, 3);
-
-        let docs = DocumentRepository::find_recent(store.as_ref(), 0, 10)
-            .await
-            .expect("documents should load");
-        assert_eq!(docs.len(), 1);
-        let saved_doc = &docs[0];
-        assert_eq!(saved_doc.captured_at(), pending.captured_at);
-
-        let linked_items = store
-            .find_by_document_id(saved_doc.id())
-            .await
-            .expect("items should be queryable by saved document id");
-        assert_eq!(linked_items.len(), item_count);
-        assert!(linked_items
-            .iter()
-            .all(|item| item.document_id() == Some(saved_doc.id())));
-    }
-
-    #[tokio::test]
-    async fn process_single_session_refresh_replaces_old_items_and_preserves_raw_transcript() {
-        let store = Arc::new(SqliteStore::in_memory().expect("in-memory sqlite store"));
-        let item_store: Arc<dyn ItemRepository> = store.clone();
-        let doc_store: Arc<dyn DocumentRepository> = store.clone();
-
-        let mut existing_doc = Document::new("codex-session", "old raw");
-        existing_doc.set_url("file:///tmp/session.jsonl");
-        doc_store
-            .save(&existing_doc)
-            .await
-            .expect("existing document should save");
-
-        let mut old_item = Item::new_observation("old", "old");
-        old_item.set_document_id(existing_doc.id().clone());
-        item_store
-            .save(&old_item)
-            .await
-            .expect("old item should save");
-
-        let client: Arc<dyn LlmClient> = Arc::new(StaticLlmClient {
-            response: r#"{
-                "session_summary": "刷新后的会话",
-                "cognitive_level": "proficient",
-                "collaboration_mode": "pair_programming",
-                "decisions": ["保留原始 transcript"],
-                "bugs_fixed": ["替换 stale session 的旧 items"],
-                "patterns": [],
-                "friction": [],
-                "project_progress": [],
-                "questions": [],
-                "knowledge_gained": [],
-                "tools_discovered": [],
-                "architecture": [],
-                "code_artifacts": []
-            }"#
-            .to_string(),
-        });
-        let quota_hit = Arc::new(AtomicBool::new(false));
-        let pending = PendingSession {
-            idx: 0,
-            total: 1,
-            url: existing_doc.url().to_string(),
-            source: SessionSource::Codex,
-            project: Some("refine".to_string()),
-            captured_at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
-            has_embedded_timestamp: false,
-            raw_content: "User: original transcript\nAssistant: final answer\n".to_string(),
-            needs_chunk: true,
-            chunks: vec!["chunk summary input".to_string()],
-            existing_document: Some(existing_doc.clone()),
-        };
-
-        let item_count = process_single_session(&pending, &client, &doc_store, &quota_hit)
-            .await
-            .expect("session refresh should succeed");
-        assert_eq!(item_count, 3);
-
-        let saved_doc = doc_store
-            .find_by_url(&pending.url)
-            .await
-            .expect("document query should succeed")
-            .expect("document should exist");
-        assert_eq!(saved_doc.id(), existing_doc.id());
-        assert_eq!(saved_doc.raw_content(), pending.raw_content);
-        assert_eq!(saved_doc.title(), Some("刷新后的会话"));
-        assert_eq!(saved_doc.captured_at(), existing_doc.captured_at());
-
-        let linked_items = store
-            .find_by_document_id(existing_doc.id())
-            .await
-            .expect("items should be queryable by saved document id");
-        assert_eq!(linked_items.len(), item_count);
-        assert!(linked_items.iter().all(|item| item.title() != "old"));
-    }
-
-    #[tokio::test]
-    async fn quota_hit_short_circuits_before_llm_call() {
-        use refine_core::infra::ClaudeClient;
-        let client: Arc<dyn LlmClient> = Arc::new(ClaudeClient::new("test-key"));
-        let quota_hit = Arc::new(AtomicBool::new(true));
-
-        let err = llm_call_with_retry(&client, "content", &quota_hit)
-            .await
-            .expect_err("quota flag should skip the call");
-
-        assert!(err.to_string().contains("LLM 配额已耗尽"));
-    }
-}
+#[path = "ingest_sessions/tests.rs"]
+mod tests;

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -555,7 +555,7 @@ async fn process_single_session(
         "  + [{}/{}] {} | {} items",
         ps.idx + 1,
         ps.total,
-        &facet_response.session_summary,
+        facet_response.session_summary,
         item_count,
     );
 

--- a/apps/cli/src/ingest_sessions/legacy_migration.rs
+++ b/apps/cli/src/ingest_sessions/legacy_migration.rs
@@ -1,0 +1,358 @@
+use crate::remem_sessions::RememSession;
+use anyhow::{bail, Result};
+use chrono::{DateTime, Utc};
+use refine_core::knowledge::{Document, DocumentId};
+use std::collections::HashSet;
+use std::path::Path;
+
+const LOCAL_SOURCE_ROOT: &str = "local";
+const LOCAL_SOURCE_ROOT_HEX: &str = "6c6f63616c";
+const LEGACY_SOURCES: [&str; 2] = ["claude-code-session", "codex-session"];
+
+pub(super) fn matching_legacy_document_ids(
+    documents: &[Document],
+    remem_session: &RememSession,
+    raw_content: &str,
+) -> Result<Vec<DocumentId>> {
+    if remem_session.source_root != LOCAL_SOURCE_ROOT {
+        return Ok(Vec::new());
+    }
+
+    let legacy: Vec<&Document> = documents
+        .iter()
+        .filter(|document| LEGACY_SOURCES.contains(&document.source()))
+        .collect();
+
+    let filename_and_content: Vec<&Document> = legacy
+        .iter()
+        .copied()
+        .filter(|document| {
+            url_matches_session_id(document.url(), &remem_session.session_id)
+                && content_matches(document.raw_content(), raw_content)
+        })
+        .collect();
+    if !filename_and_content.is_empty() {
+        return unique_match(filename_and_content, remem_session);
+    }
+
+    let epoch_and_content: Vec<&Document> = legacy
+        .iter()
+        .copied()
+        .filter(|document| {
+            document.captured_at().timestamp() == remem_session.first_epoch
+                && content_matches(document.raw_content(), raw_content)
+        })
+        .collect();
+    if !epoch_and_content.is_empty() {
+        return unique_match(epoch_and_content, remem_session);
+    }
+
+    Ok(Vec::new())
+}
+
+fn unique_match(matches: Vec<&Document>, remem_session: &RememSession) -> Result<Vec<DocumentId>> {
+    match matches.as_slice() {
+        [] => Ok(Vec::new()),
+        [document] => Ok(vec![document.id().clone()]),
+        _ => bail!(
+            "ambiguous legacy identity for remem tuple ({:?}, {:?}, {:?}): {} candidates",
+            remem_session.source_root,
+            remem_session.project,
+            remem_session.session_id,
+            matches.len()
+        ),
+    }
+}
+
+fn url_matches_session_id(url: &str, session_id: &str) -> bool {
+    let Some(stem) = Path::new(url).file_stem().and_then(|stem| stem.to_str()) else {
+        return false;
+    };
+    stem == session_id || stem.ends_with(&format!("-{session_id}"))
+}
+
+fn content_matches(legacy: &str, current: &str) -> bool {
+    legacy == current || current.starts_with(legacy)
+}
+
+pub(super) fn matching_remem_document(
+    documents: &[Document],
+    legacy_path: &Path,
+    captured_at: DateTime<Utc>,
+    raw_content: &str,
+) -> Result<Option<Document>> {
+    let remem_documents: Vec<&Document> = documents
+        .iter()
+        .filter(|document| {
+            document.source() == "remem-raw-session" && is_local_remem_url(document.url())
+        })
+        .collect();
+    let session_ids = session_id_candidates(legacy_path);
+
+    let url_and_content: Vec<&Document> = remem_documents
+        .iter()
+        .copied()
+        .filter(|document| {
+            session_ids
+                .iter()
+                .any(|session_id| document.url().ends_with(&hex_component(session_id)))
+                && contents_overlap(document.raw_content(), raw_content)
+        })
+        .collect();
+    if !url_and_content.is_empty() {
+        return unique_remem_match(url_and_content, legacy_path);
+    }
+
+    let epoch_and_content: Vec<&Document> = remem_documents
+        .iter()
+        .copied()
+        .filter(|document| {
+            document.captured_at().timestamp() == captured_at.timestamp()
+                && contents_overlap(document.raw_content(), raw_content)
+        })
+        .collect();
+    unique_remem_match(epoch_and_content, legacy_path)
+}
+
+pub(super) fn claim_remem_document_once(
+    claimed: &mut HashSet<DocumentId>,
+    document: &Document,
+    legacy_path: &Path,
+) -> Result<()> {
+    if claimed.insert(document.id().clone()) {
+        return Ok(());
+    }
+    bail!(
+        "remem document {} matched more than one legacy path; second claimant {:?}",
+        document.id(),
+        legacy_path
+    )
+}
+
+fn unique_remem_match(matches: Vec<&Document>, legacy_path: &Path) -> Result<Option<Document>> {
+    match matches.as_slice() {
+        [] => Ok(None),
+        [document] => Ok(Some((*document).clone())),
+        _ => bail!(
+            "ambiguous remem identity for legacy session {:?}: {} candidates",
+            legacy_path,
+            matches.len()
+        ),
+    }
+}
+
+fn session_id_candidates(path: &Path) -> Vec<String> {
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return Vec::new();
+    };
+    let mut candidates = vec![stem.to_string()];
+    if stem.len() >= 36 {
+        let suffix = &stem[stem.len() - 36..];
+        if suffix.as_bytes().get(8) == Some(&b'-')
+            && suffix.as_bytes().get(13) == Some(&b'-')
+            && suffix.as_bytes().get(18) == Some(&b'-')
+            && suffix.as_bytes().get(23) == Some(&b'-')
+        {
+            candidates.push(suffix.to_string());
+        }
+    }
+    candidates
+}
+
+fn hex_component(value: &str) -> String {
+    value
+        .as_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn contents_overlap(left: &str, right: &str) -> bool {
+    left == right || left.starts_with(right) || right.starts_with(left)
+}
+
+fn is_local_remem_url(url: &str) -> bool {
+    url.strip_prefix("remem-raw://v1/")
+        .and_then(|rest| rest.split('/').next())
+        == Some(LOCAL_SOURCE_ROOT_HEX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use refine_core::knowledge::RestoreDocumentParams;
+    use refine_core::session::{Session, SessionMeta, SessionSource};
+    use std::path::PathBuf;
+
+    fn document(source: &str, url: &str, content: &str, epoch: i64) -> Document {
+        let original = Document::new(source, content);
+        let captured_at = Utc.timestamp_opt(epoch, 0).unwrap();
+        Document::restore(RestoreDocumentParams {
+            id: original.id().clone(),
+            title: None,
+            raw_content: content.to_string(),
+            source: source.to_string(),
+            url: url.to_string(),
+            captured_at,
+            created_at: original.created_at(),
+            updated_at: original.updated_at(),
+        })
+    }
+
+    fn remem(source_root: &str, session_id: &str) -> RememSession {
+        RememSession {
+            source_root: source_root.to_string(),
+            project: "/repo".to_string(),
+            session_id: session_id.to_string(),
+            first_epoch: 10,
+            session: Session {
+                source: SessionSource::RememRaw,
+                file_path: PathBuf::new(),
+                messages: Vec::new(),
+                meta: SessionMeta::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn matches_local_filename_or_epoch_content_but_not_remote() {
+        let filename = document("claude-code-session", "/tmp/session-1.jsonl", "old", 5);
+        let epoch = document("codex-session", "/tmp/other.jsonl", "prefix", 10);
+        let documents = vec![filename.clone(), epoch.clone()];
+
+        let matched =
+            matching_legacy_document_ids(&documents, &remem("local", "session-1"), "old appended")
+                .unwrap();
+        assert_eq!(matched, vec![filename.id().clone()]);
+
+        let matched = matching_legacy_document_ids(
+            &[epoch.clone()],
+            &remem("local", "canonical-id"),
+            "prefix plus append",
+        )
+        .unwrap();
+        assert_eq!(matched, vec![epoch.id().clone()]);
+
+        assert!(
+            matching_legacy_document_ids(&[filename], &remem("remote", "session-1"), "old",)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_content_fallback() {
+        let documents = vec![
+            document("claude-code-session", "/tmp/a.jsonl", "same", 10),
+            document("codex-session", "/tmp/b.jsonl", "same", 10),
+        ];
+        assert!(
+            matching_legacy_document_ids(&documents, &remem("local", "canonical-id"), "same",)
+                .unwrap_err()
+                .to_string()
+                .contains("ambiguous legacy identity")
+        );
+    }
+
+    #[test]
+    fn rollback_finds_remem_identity_by_uuid_suffix() {
+        let raw = "User: same\n";
+        let session_id = "12345678-1234-1234-1234-123456789abc";
+        let remem_doc = document(
+            "remem-raw-session",
+            &format!(
+                "remem-raw://v1/{}/{}/{}",
+                LOCAL_SOURCE_ROOT_HEX,
+                hex_component("/repo"),
+                hex_component(session_id)
+            ),
+            raw,
+            10,
+        );
+        let path = Path::new(
+            "/tmp/rollout-2026-07-20T00-00-00-12345678-1234-1234-1234-123456789abc.jsonl",
+        );
+        let matched = matching_remem_document(
+            &[remem_doc.clone()],
+            path,
+            Utc.timestamp_opt(10, 0).unwrap(),
+            raw,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(matched.id(), remem_doc.id());
+    }
+
+    #[test]
+    fn rollback_never_reuses_remote_remem_identity() {
+        let raw = "User: same\n";
+        let session_id = "12345678-1234-1234-1234-123456789abc";
+        let remote = document(
+            "remem-raw-session",
+            &format!(
+                "remem-raw://v1/{}/repo/{}",
+                hex_component("remote"),
+                hex_component(session_id)
+            ),
+            raw,
+            10,
+        );
+        let path = Path::new(
+            "/tmp/rollout-2026-07-20T00-00-00-12345678-1234-1234-1234-123456789abc.jsonl",
+        );
+        assert!(
+            matching_remem_document(&[remote], path, Utc.timestamp_opt(10, 0).unwrap(), raw,)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn filename_without_content_or_epoch_corroboration_is_not_destructive() {
+        let legacy = document(
+            "claude-code-session",
+            "/other/project/session-1.jsonl",
+            "unrelated",
+            5,
+        );
+        assert!(
+            matching_legacy_document_ids(&[legacy], &remem("local", "session-1"), "different",)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn exact_content_without_identity_corroboration_is_not_destructive() {
+        let legacy = document(
+            "claude-code-session",
+            "/other/project/unrelated.jsonl",
+            "same",
+            5,
+        );
+        assert!(
+            matching_legacy_document_ids(&[legacy], &remem("local", "session-1"), "same",)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn rollback_rejects_a_second_path_claiming_the_same_remem_document() {
+        let remem_doc = document(
+            "remem-raw-session",
+            "remem-raw://v1/6c6f63616c/repo/session",
+            "same",
+            10,
+        );
+        let mut claimed = HashSet::new();
+        claim_remem_document_once(&mut claimed, &remem_doc, Path::new("/tmp/one.jsonl")).unwrap();
+        assert!(
+            claim_remem_document_once(&mut claimed, &remem_doc, Path::new("/tmp/two.jsonl"),)
+                .unwrap_err()
+                .to_string()
+                .contains("more than one legacy path")
+        );
+    }
+}

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -1,0 +1,426 @@
+use super::*;
+use async_trait::async_trait;
+use chrono::TimeZone;
+use refine_core::error::InfraResult;
+use refine_core::infra::SqliteStore;
+use refine_core::knowledge::{DocumentId, DocumentRepository, Item, ItemRepository, ItemType};
+use refine_core::session::discover_sessions_in;
+use std::fs;
+
+struct StaticLlmClient {
+    response: String,
+}
+
+#[tokio::test]
+async fn source_filter_is_rejected_without_explicit_legacy_rollback() {
+    let store = Arc::new(SqliteStore::in_memory().expect("in-memory sqlite store"));
+    let doc_store: Arc<dyn DocumentRepository> = store;
+    let error = handle_ingest_sessions(
+        IngestOptions {
+            source: Some(SessionSource::ClaudeCode),
+            limit: None,
+            latest: None,
+            dry_run: true,
+            legacy_local_scan: false,
+        },
+        Path::new("/tmp/refine-test.db"),
+        doc_store,
+        None,
+    )
+    .await
+    .expect_err("source filtering must not guess a platform in remem mode");
+
+    assert!(error.to_string().contains("--legacy-local-scan"));
+}
+
+#[async_trait]
+impl LlmClient for StaticLlmClient {
+    async fn complete(&self, _prompt: &str, _system: Option<&str>) -> InfraResult<String> {
+        Ok(self.response.clone())
+    }
+}
+
+#[test]
+fn project_for_ingest_prefers_discovered_project_then_session_metadata() {
+    assert_eq!(
+        project_for_ingest(Some("claude-project"), Some("codex-cwd")).as_deref(),
+        Some("claude-project")
+    );
+    assert_eq!(
+        project_for_ingest(None, Some("codex-cwd")).as_deref(),
+        Some("codex-cwd")
+    );
+    assert_eq!(project_for_ingest(None, None), None);
+}
+
+#[test]
+fn session_captured_at_prefers_session_started_at_then_file_mtime() {
+    let started_at = Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap();
+    let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(42);
+    assert_eq!(session_captured_at(Some(started_at), mtime), started_at);
+
+    let fallback = session_captured_at(None, mtime);
+    assert_eq!(fallback, DateTime::<Utc>::from(mtime));
+}
+
+#[test]
+fn session_needs_refresh_when_file_mtime_is_newer_than_saved_document() {
+    let mut doc = Document::new("codex-session", "raw");
+    doc.set_url("file:///tmp/session.jsonl");
+
+    let old_mtime = SystemTime::now()
+        .checked_sub(Duration::from_secs(60))
+        .unwrap();
+    assert!(!session_needs_refresh(&doc, old_mtime));
+
+    let new_mtime = SystemTime::now() + Duration::from_millis(200);
+    assert!(session_needs_refresh(&doc, new_mtime));
+}
+
+#[test]
+fn scoped_cursor_keeps_other_sources_discoverable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let db_path = tmp.path().join("refine.db");
+    fs::write(&db_path, "").unwrap();
+
+    let claude_dir = home.join(".claude/projects/proj");
+    fs::create_dir_all(&claude_dir).unwrap();
+    let claude_path = claude_dir.join("claude.jsonl");
+    fs::write(&claude_path, "{}").unwrap();
+    filetime::set_file_mtime(&claude_path, filetime::FileTime::from_unix_time(20_000, 0)).unwrap();
+
+    let codex_dir = home.join(".codex/sessions");
+    fs::create_dir_all(&codex_dir).unwrap();
+    let codex_path = codex_dir.join("codex.jsonl");
+    fs::write(&codex_path, "{}").unwrap();
+    filetime::set_file_mtime(&codex_path, filetime::FileTime::from_unix_time(1_000, 0)).unwrap();
+
+    write_last_ingest_mtime_at(
+        home,
+        Some(&SessionSource::ClaudeCode),
+        &db_path,
+        SystemTime::UNIX_EPOCH + Duration::from_secs(10_000),
+    );
+
+    let claude_cutoff = read_last_ingest_mtime_at(home, Some(&SessionSource::ClaudeCode), &db_path)
+        .unwrap()
+        .checked_sub(Duration::from_secs(3600))
+        .unwrap();
+    let claude_discovered =
+        discover_sessions_in(home, Some(SessionSource::ClaudeCode), Some(claude_cutoff));
+    assert_eq!(claude_discovered.len(), 1);
+
+    let codex_cutoff = read_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_path)
+        .map(|last| last.checked_sub(Duration::from_secs(3600)).unwrap());
+    assert!(codex_cutoff.is_none());
+
+    let codex_discovered = discover_sessions_in(home, Some(SessionSource::Codex), codex_cutoff);
+    assert_eq!(codex_discovered.len(), 1);
+    assert_eq!(codex_discovered[0].path, codex_path);
+}
+
+#[test]
+fn cursor_is_partitioned_by_database_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let db_a = tmp.path().join("a.db");
+    let db_b = tmp.path().join("b.db");
+    fs::write(&db_a, "").unwrap();
+    fs::write(&db_b, "").unwrap();
+
+    let when = SystemTime::UNIX_EPOCH + Duration::from_secs(42);
+    write_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_a, when);
+
+    assert_eq!(
+        read_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_a),
+        Some(when)
+    );
+    assert_eq!(
+        read_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_b),
+        None
+    );
+    assert_ne!(
+        incremental_cursor_path(home, Some(&SessionSource::Codex), &db_a),
+        incremental_cursor_path(home, Some(&SessionSource::Codex), &db_b)
+    );
+}
+
+fn read_last_ingest_mtime_at(
+    home: &Path,
+    source: Option<&SessionSource>,
+    db_path: &Path,
+) -> Option<SystemTime> {
+    let path = incremental_cursor_path(home, source, db_path);
+    let secs: u64 = std::fs::read_to_string(path).ok()?.trim().parse().ok()?;
+    Some(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
+}
+
+fn write_last_ingest_mtime_at(
+    home: &Path,
+    source: Option<&SessionSource>,
+    db_path: &Path,
+    t: SystemTime,
+) {
+    let path = incremental_cursor_path(home, source, db_path);
+    let dir = path.parent().unwrap();
+    fs::create_dir_all(dir).unwrap();
+    let dur = t.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+    fs::write(path, dur.as_secs().to_string()).unwrap();
+}
+
+#[tokio::test]
+async fn process_single_session_links_items_to_saved_document_id() {
+    let store = Arc::new(SqliteStore::in_memory().expect("in-memory sqlite store"));
+    let doc_store: Arc<dyn DocumentRepository> = store.clone();
+    let client: Arc<dyn LlmClient> = Arc::new(StaticLlmClient {
+        response: r#"{
+            "session_summary": "修复文档关联",
+            "cognitive_level": "proficient",
+            "collaboration_mode": "pair_programming",
+            "decisions": ["使用保存后的文档 ID"],
+            "bugs_fixed": ["修复会话导入的 shadow document id"],
+            "patterns": [],
+            "friction": [],
+            "project_progress": [],
+            "questions": [],
+            "knowledge_gained": [],
+            "tools_discovered": [],
+            "architecture": [],
+            "code_artifacts": []
+        }"#
+        .to_string(),
+    });
+    let quota_hit = Arc::new(AtomicBool::new(false));
+    let pending = PendingSession {
+        idx: 0,
+        total: 1,
+        url: "file:///tmp/session.jsonl".to_string(),
+        source: SessionSource::Codex,
+        project: Some("refine".to_string()),
+        captured_at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
+        has_embedded_timestamp: true,
+        raw_content: "User: fix the ingest bug".to_string(),
+        needs_chunk: false,
+        chunks: Vec::new(),
+        existing_document: None,
+        legacy_documents_to_delete: Vec::new(),
+    };
+
+    let item_count = process_single_session(&pending, &client, &doc_store, &quota_hit)
+        .await
+        .expect("session ingest should succeed");
+    assert_eq!(item_count, 3);
+
+    let docs = DocumentRepository::find_recent(store.as_ref(), 0, 10)
+        .await
+        .expect("documents should load");
+    assert_eq!(docs.len(), 1);
+    let saved_doc = &docs[0];
+    assert_eq!(saved_doc.captured_at(), pending.captured_at);
+
+    let linked_items = store
+        .find_by_document_id(saved_doc.id())
+        .await
+        .expect("items should be queryable by saved document id");
+    assert_eq!(linked_items.len(), item_count);
+    assert!(linked_items
+        .iter()
+        .all(|item| item.document_id() == Some(saved_doc.id())));
+}
+
+#[tokio::test]
+async fn process_single_session_refresh_replaces_old_items_and_preserves_raw_transcript() {
+    let store = Arc::new(SqliteStore::in_memory().expect("in-memory sqlite store"));
+    let item_store: Arc<dyn ItemRepository> = store.clone();
+    let doc_store: Arc<dyn DocumentRepository> = store.clone();
+
+    let mut existing_doc = Document::new("codex-session", "old raw");
+    existing_doc.set_url("file:///tmp/session.jsonl");
+    doc_store
+        .save(&existing_doc)
+        .await
+        .expect("existing document should save");
+
+    let mut old_item = Item::new_observation("old", "old");
+    old_item.set_document_id(existing_doc.id().clone());
+    item_store
+        .save(&old_item)
+        .await
+        .expect("old item should save");
+
+    let client: Arc<dyn LlmClient> = Arc::new(StaticLlmClient {
+        response: r#"{
+            "session_summary": "刷新后的会话",
+            "cognitive_level": "proficient",
+            "collaboration_mode": "pair_programming",
+            "decisions": ["保留原始 transcript"],
+            "bugs_fixed": ["替换 stale session 的旧 items"],
+            "patterns": [],
+            "friction": [],
+            "project_progress": [],
+            "questions": [],
+            "knowledge_gained": [],
+            "tools_discovered": [],
+            "architecture": [],
+            "code_artifacts": []
+        }"#
+        .to_string(),
+    });
+    let quota_hit = Arc::new(AtomicBool::new(false));
+    let pending = PendingSession {
+        idx: 0,
+        total: 1,
+        url: existing_doc.url().to_string(),
+        source: SessionSource::Codex,
+        project: Some("refine".to_string()),
+        captured_at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
+        has_embedded_timestamp: false,
+        raw_content: "User: original transcript\nAssistant: final answer\n".to_string(),
+        needs_chunk: true,
+        chunks: vec!["chunk summary input".to_string()],
+        existing_document: Some(existing_doc.clone()),
+        legacy_documents_to_delete: Vec::new(),
+    };
+
+    let item_count = process_single_session(&pending, &client, &doc_store, &quota_hit)
+        .await
+        .expect("session refresh should succeed");
+    assert_eq!(item_count, 3);
+
+    let saved_doc = doc_store
+        .find_by_url(&pending.url)
+        .await
+        .expect("document query should succeed")
+        .expect("document should exist");
+    assert_eq!(saved_doc.id(), existing_doc.id());
+    assert_eq!(saved_doc.raw_content(), pending.raw_content);
+    assert_eq!(saved_doc.title(), Some("刷新后的会话"));
+    assert_eq!(saved_doc.captured_at(), existing_doc.captured_at());
+
+    let linked_items = store
+        .find_by_document_id(existing_doc.id())
+        .await
+        .expect("items should be queryable by saved document id");
+    assert_eq!(linked_items.len(), item_count);
+    assert!(linked_items.iter().all(|item| item.title() != "old"));
+}
+
+#[tokio::test]
+async fn remem_save_removes_superseded_legacy_document_and_facets() {
+    let store = Arc::new(SqliteStore::in_memory().expect("in-memory sqlite store"));
+    let item_store: Arc<dyn ItemRepository> = store.clone();
+    let doc_store: Arc<dyn DocumentRepository> = store.clone();
+
+    let mut legacy_doc = Document::new("codex-session", "User: old\n");
+    legacy_doc.set_url("/tmp/rollout-2026-session-1.jsonl");
+    doc_store.save(&legacy_doc).await.unwrap();
+    let mut legacy_item = Item::new_observation("legacy", "legacy");
+    legacy_item.set_document_id(legacy_doc.id().clone());
+    item_store.save(&legacy_item).await.unwrap();
+    let legacy_item_id = legacy_item.id().clone();
+
+    let client: Arc<dyn LlmClient> = Arc::new(StaticLlmClient {
+        response: r#"{
+            "session_summary": "remem replacement",
+            "cognitive_level": "proficient",
+            "collaboration_mode": "pair_programming",
+            "decisions": ["use remem identity"],
+            "bugs_fixed": [], "patterns": [], "friction": [],
+            "project_progress": [], "questions": [], "knowledge_gained": [],
+            "tools_discovered": [], "architecture": [], "code_artifacts": []
+        }"#
+        .to_string(),
+    });
+    let pending = PendingSession {
+        idx: 0,
+        total: 1,
+        url: "remem-raw://v1/local/repo/session-1".to_string(),
+        source: SessionSource::RememRaw,
+        project: Some("refine".to_string()),
+        captured_at: Utc.with_ymd_and_hms(2026, 7, 20, 0, 0, 0).unwrap(),
+        has_embedded_timestamp: true,
+        raw_content: "User: old\nAssistant: new\n".to_string(),
+        needs_chunk: false,
+        chunks: Vec::new(),
+        existing_document: None,
+        legacy_documents_to_delete: vec![legacy_doc.id().clone()],
+    };
+
+    let replacement_item_count = process_single_session(
+        &pending,
+        &client,
+        &doc_store,
+        &Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    assert!(doc_store
+        .find_by_id(legacy_doc.id())
+        .await
+        .unwrap()
+        .is_none());
+    let replacement = doc_store
+        .find_by_url(&pending.url)
+        .await
+        .unwrap()
+        .expect("remem replacement document");
+    assert_eq!(doc_store.count().await.unwrap(), 1);
+    assert!(item_store
+        .find_by_document_id(legacy_doc.id())
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(!item_store
+        .find_by_document_id(replacement.id())
+        .await
+        .unwrap()
+        .is_empty());
+    let observations = item_store
+        .find_by_type(ItemType::Observation)
+        .await
+        .unwrap();
+    assert_eq!(observations.len(), replacement_item_count);
+    assert!(observations.iter().all(|item| item.id() != &legacy_item_id));
+}
+
+#[tokio::test]
+async fn replacement_and_legacy_cleanup_roll_back_as_one_transaction() {
+    let store = Arc::new(SqliteStore::in_memory().expect("in-memory sqlite store"));
+    let doc_store: Arc<dyn DocumentRepository> = store.clone();
+    let item_store: Arc<dyn ItemRepository> = store;
+    let mut replacement = Document::new("remem-raw-session", "replacement");
+    replacement.set_url("remem-raw://v1/local/repo/session-1");
+    let mut item = Item::new_observation("replacement", "replacement");
+    item.set_document_id(replacement.id().clone());
+
+    let error = doc_store
+        .save_with_replaced_items_and_delete_documents(
+            &replacement,
+            &[item.clone()],
+            &[DocumentId::from("missing-legacy-document")],
+        )
+        .await
+        .expect_err("missing obsolete identity must roll back the whole transaction");
+    assert!(error.to_string().contains("does not exist"));
+    assert!(doc_store
+        .find_by_url(replacement.url())
+        .await
+        .unwrap()
+        .is_none());
+    assert!(!item_store.exists(item.id()).await.unwrap());
+}
+
+#[tokio::test]
+async fn quota_hit_short_circuits_before_llm_call() {
+    use refine_core::infra::ClaudeClient;
+    let client: Arc<dyn LlmClient> = Arc::new(ClaudeClient::new("test-key"));
+    let quota_hit = Arc::new(AtomicBool::new(true));
+
+    let err = llm_call_with_retry(&client, "content", &quota_hit)
+        .await
+        .expect_err("quota flag should skip the call");
+
+    assert!(err.to_string().contains("LLM 配额已耗尽"));
+}

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -6,6 +6,7 @@ mod cli;
 mod handlers;
 mod ingest_sessions;
 mod insights;
+mod remem_sessions;
 mod support;
 
 use anyhow::{Context, Result};

--- a/apps/cli/src/remem_sessions.rs
+++ b/apps/cli/src/remem_sessions.rs
@@ -1,0 +1,662 @@
+use anyhow::{bail, ensure, Context, Result};
+use chrono::{DateTime, Utc};
+use refine_core::session::{MessageRole, Session, SessionMessage, SessionMeta, SessionSource};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::process::Command;
+
+const RAW_SOURCE_TYPE: &str = "raw_archive";
+const RAW_MESSAGE_ORDER: &str = "created_at_epoch_asc_id_asc";
+const RAW_MESSAGE_LIMIT: &str = "2000";
+
+#[derive(Debug)]
+pub(crate) struct RememSession {
+    pub source_root: String,
+    pub project: String,
+    pub session_id: String,
+    pub first_epoch: i64,
+    pub session: Session,
+}
+
+impl RememSession {
+    pub(crate) fn stable_document_url(&self) -> String {
+        format!(
+            "remem-raw://v1/{}/{}/{}",
+            hex_component(&self.source_root),
+            hex_component(&self.project),
+            hex_component(&self.session_id)
+        )
+    }
+}
+
+pub(crate) fn load_remem_sessions(
+    limit: Option<usize>,
+    latest: Option<usize>,
+) -> Result<Vec<RememSession>> {
+    load_remem_sessions_with_runner(&ProcessRunner, limit, latest)
+}
+
+fn hex_component(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(value.len() * 2);
+    for byte in value.as_bytes() {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+struct CommandResult {
+    success: bool,
+    code: Option<i32>,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+trait Runner {
+    fn run(&self, args: &[String]) -> Result<CommandResult>;
+}
+
+struct ProcessRunner;
+
+impl Runner for ProcessRunner {
+    fn run(&self, args: &[String]) -> Result<CommandResult> {
+        let binary = std::env::var("REFINE_REMEM_BIN")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "remem".to_string());
+        let output = Command::new(&binary)
+            .args(args)
+            .output()
+            .with_context(|| format!("run remem provider binary {binary:?}"))?;
+        Ok(CommandResult {
+            success: output.status.success(),
+            code: output.status.code(),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionsEnvelope {
+    since_epoch: Value,
+    until_epoch: Value,
+    project: Value,
+    sample: i64,
+    count: usize,
+    sessions: Vec<SessionSummary>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionSummary {
+    source_root: String,
+    project: String,
+    session_id: String,
+    first_epoch: i64,
+    last_epoch: i64,
+    message_count: i64,
+    user_message_count: i64,
+    assistant_message_count: i64,
+    user_message_samples: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MessagesEnvelope {
+    source_type: String,
+    source_root: String,
+    project: String,
+    session_id: String,
+    order: String,
+    limit: i64,
+    count: usize,
+    has_more: bool,
+    next_cursor: Value,
+    messages: Vec<RawMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMessage {
+    id: i64,
+    role: String,
+    content: String,
+    source: String,
+    branch: Value,
+    cwd: Value,
+    created_at_epoch: i64,
+}
+
+fn load_remem_sessions_with_runner<R: Runner>(
+    runner: &R,
+    limit: Option<usize>,
+    latest: Option<usize>,
+) -> Result<Vec<RememSession>> {
+    ensure!(
+        limit.is_none() || latest.is_none(),
+        "limit and latest cannot be used together"
+    );
+    let args = strings(&["raw", "sessions", "--sample", "0", "--json"]);
+    let mut summaries = read_session_summaries(runner, &args)?;
+    if latest.is_some() {
+        summaries.sort_by(|left, right| {
+            right
+                .last_epoch
+                .cmp(&left.last_epoch)
+                .then_with(|| left.source_root.cmp(&right.source_root))
+                .then_with(|| left.project.cmp(&right.project))
+                .then_with(|| left.session_id.cmp(&right.session_id))
+        });
+    }
+    if let Some(max) = latest.or(limit) {
+        summaries.truncate(max);
+    }
+    summaries
+        .into_iter()
+        .map(|summary| load_one_session(runner, summary))
+        .collect()
+}
+
+fn read_session_summaries<R: Runner>(runner: &R, args: &[String]) -> Result<Vec<SessionSummary>> {
+    let envelope: SessionsEnvelope = run_json(runner, args, "raw sessions")?;
+    validate_nullable_i64(&envelope.since_epoch, "raw sessions since_epoch")?;
+    validate_nullable_i64(&envelope.until_epoch, "raw sessions until_epoch")?;
+    validate_nullable_string(&envelope.project, "raw sessions project")?;
+    ensure!(envelope.sample == 0, "raw sessions sample drifted from 0");
+    ensure!(
+        envelope.count == envelope.sessions.len(),
+        "raw sessions count mismatch: declared {}, received {}",
+        envelope.count,
+        envelope.sessions.len()
+    );
+    let mut tuples = HashSet::new();
+    for summary in &envelope.sessions {
+        ensure!(
+            !summary.source_root.is_empty(),
+            "raw session source_root is empty"
+        );
+        ensure!(!summary.project.is_empty(), "raw session project is empty");
+        ensure!(
+            !summary.session_id.is_empty(),
+            "raw session session_id is empty"
+        );
+        ensure!(
+            summary.first_epoch <= summary.last_epoch,
+            "raw session epoch order is invalid"
+        );
+        ensure!(
+            summary.message_count > 0,
+            "raw session message_count must be positive"
+        );
+        ensure!(
+            summary.user_message_count >= 0,
+            "raw session user count is negative"
+        );
+        ensure!(
+            summary.assistant_message_count >= 0,
+            "raw session assistant count is negative"
+        );
+        ensure!(
+            summary.user_message_count + summary.assistant_message_count == summary.message_count,
+            "raw session role counts do not match message_count"
+        );
+        ensure!(
+            summary.user_message_samples.is_empty(),
+            "raw sessions returned samples for sample=0"
+        );
+        ensure!(
+            tuples.insert((&summary.source_root, &summary.project, &summary.session_id)),
+            "raw sessions returned a duplicate selector tuple"
+        );
+    }
+    Ok(envelope.sessions)
+}
+
+fn load_one_session<R: Runner>(runner: &R, summary: SessionSummary) -> Result<RememSession> {
+    let mut cursor: Option<String> = None;
+    let mut seen_cursors = HashSet::new();
+    let mut seen_ids = HashSet::new();
+    let mut previous_key: Option<(i64, i64)> = None;
+    let mut messages = Vec::new();
+    let mut user_messages = 0_i64;
+    let mut assistant_messages = 0_i64;
+    let mut first_message_epoch = None;
+    let mut last_message_epoch = None;
+    loop {
+        let args = message_args(&summary, cursor.as_deref());
+        let envelope: MessagesEnvelope = run_json(runner, &args, "raw messages")?;
+        validate_page(&summary, &envelope)?;
+        ensure!(
+            envelope.count == envelope.messages.len(),
+            "raw messages count mismatch: declared {}, received {}",
+            envelope.count,
+            envelope.messages.len()
+        );
+        let next_cursor = validated_next_cursor(&envelope, cursor.as_deref(), &mut seen_cursors)?;
+        for raw in envelope.messages {
+            validate_nullable_string(&raw.branch, "raw message branch")?;
+            validate_nullable_string(&raw.cwd, "raw message cwd")?;
+            ensure!(!raw.source.is_empty(), "raw message source is empty");
+            ensure!(
+                seen_ids.insert(raw.id),
+                "duplicate raw message id {}",
+                raw.id
+            );
+            let key = (raw.created_at_epoch, raw.id);
+            if let Some(previous) = previous_key {
+                ensure!(
+                    key > previous,
+                    "raw message order is not strictly monotonic"
+                );
+            }
+            previous_key = Some(key);
+            first_message_epoch.get_or_insert(raw.created_at_epoch);
+            last_message_epoch = Some(raw.created_at_epoch);
+            let role = match raw.role.as_str() {
+                "user" => {
+                    user_messages += 1;
+                    MessageRole::User
+                }
+                "assistant" => {
+                    assistant_messages += 1;
+                    MessageRole::Assistant
+                }
+                other => bail!("unsupported raw message role {other:?}"),
+            };
+            messages.push(SessionMessage {
+                role,
+                content: raw.content,
+            });
+        }
+        cursor = next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+    ensure!(
+        messages.len() as i64 == summary.message_count,
+        "raw session message count drift for ({:?}, {:?}, {:?}): expected {}, received {}",
+        summary.source_root,
+        summary.project,
+        summary.session_id,
+        summary.message_count,
+        messages.len()
+    );
+    ensure!(
+        user_messages == summary.user_message_count
+            && assistant_messages == summary.assistant_message_count,
+        "raw session role counts drifted from the session summary"
+    );
+    ensure!(
+        first_message_epoch == Some(summary.first_epoch),
+        "raw session first_epoch drifted from the session summary"
+    );
+    ensure!(
+        last_message_epoch == Some(summary.last_epoch),
+        "raw session last_epoch drifted from the session summary"
+    );
+    let started_at = DateTime::<Utc>::from_timestamp(summary.first_epoch, 0)
+        .context("raw session first_epoch is outside chrono range")?;
+    let mut result = RememSession {
+        source_root: summary.source_root,
+        project: summary.project,
+        session_id: summary.session_id,
+        first_epoch: summary.first_epoch,
+        session: Session {
+            source: SessionSource::RememRaw,
+            file_path: PathBuf::new(),
+            messages,
+            meta: SessionMeta {
+                project: None,
+                model: None,
+                started_at: Some(started_at),
+            },
+        },
+    };
+    result.session.meta.project = Some(result.project.clone());
+    result.session.file_path = PathBuf::from(result.stable_document_url());
+    Ok(result)
+}
+
+fn validate_page(summary: &SessionSummary, envelope: &MessagesEnvelope) -> Result<()> {
+    ensure!(
+        envelope.source_type == RAW_SOURCE_TYPE,
+        "raw messages source_type drift"
+    );
+    ensure!(
+        envelope.source_root == summary.source_root,
+        "raw messages source_root drift"
+    );
+    ensure!(
+        envelope.project == summary.project,
+        "raw messages project drift"
+    );
+    ensure!(
+        envelope.session_id == summary.session_id,
+        "raw messages session_id drift"
+    );
+    ensure!(
+        envelope.order == RAW_MESSAGE_ORDER,
+        "raw messages order drift"
+    );
+    ensure!(envelope.limit == 2000, "raw messages limit drift");
+    Ok(())
+}
+
+fn validated_next_cursor(
+    envelope: &MessagesEnvelope,
+    previous: Option<&str>,
+    seen: &mut HashSet<String>,
+) -> Result<Option<String>> {
+    let cursor = value_as_optional_string(&envelope.next_cursor, "raw messages next_cursor")?;
+    if envelope.has_more {
+        let cursor = cursor.context("raw messages has_more=true without next_cursor")?;
+        ensure!(!cursor.is_empty(), "raw messages next_cursor is empty");
+        ensure!(
+            !envelope.messages.is_empty(),
+            "raw messages cursor made no row progress"
+        );
+        ensure!(
+            previous != Some(cursor.as_str()),
+            "raw messages cursor did not progress"
+        );
+        ensure!(seen.insert(cursor.clone()), "raw messages cursor repeated");
+        Ok(Some(cursor))
+    } else {
+        ensure!(
+            cursor.is_none(),
+            "raw messages has_more=false with next_cursor"
+        );
+        Ok(None)
+    }
+}
+
+fn message_args(summary: &SessionSummary, cursor: Option<&str>) -> Vec<String> {
+    let mut args = strings(&[
+        "raw",
+        "messages",
+        "--source-root",
+        &summary.source_root,
+        "--project",
+        &summary.project,
+        "--session-id",
+        &summary.session_id,
+        "--limit",
+        RAW_MESSAGE_LIMIT,
+        "--json",
+    ]);
+    if let Some(cursor) = cursor {
+        args.push("--cursor".to_string());
+        args.push(cursor.to_string());
+    }
+    args
+}
+
+fn strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}
+
+fn run_json<T: for<'de> Deserialize<'de>, R: Runner>(
+    runner: &R,
+    args: &[String],
+    operation: &str,
+) -> Result<T> {
+    let output = runner.run(args)?;
+    if !output.success {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr_excerpt = stderr.trim().chars().take(500).collect::<String>();
+        bail!(
+            "{operation} failed with status {:?}: {}",
+            output.code,
+            stderr_excerpt
+        );
+    }
+    serde_json::from_slice(&output.stdout).with_context(|| format!("parse {operation} JSON"))
+}
+
+fn validate_nullable_i64(value: &Value, field: &str) -> Result<()> {
+    ensure!(
+        value.is_null() || value.as_i64().is_some(),
+        "{field} has invalid type"
+    );
+    Ok(())
+}
+
+fn validate_nullable_string(value: &Value, field: &str) -> Result<()> {
+    value_as_optional_string(value, field).map(|_| ())
+}
+
+fn value_as_optional_string(value: &Value, field: &str) -> Result<Option<String>> {
+    match value {
+        Value::Null => Ok(None),
+        Value::String(value) => Ok(Some(value.clone())),
+        _ => bail!("{field} has invalid type"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+
+    struct FakeRunner {
+        responses: RefCell<VecDeque<CommandResult>>,
+        calls: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl FakeRunner {
+        fn json(values: Vec<Value>) -> Self {
+            Self {
+                responses: RefCell::new(
+                    values
+                        .into_iter()
+                        .map(|value| CommandResult {
+                            success: true,
+                            code: Some(0),
+                            stdout: serde_json::to_vec(&value).unwrap(),
+                            stderr: Vec::new(),
+                        })
+                        .collect(),
+                ),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn one(result: CommandResult) -> Self {
+            Self {
+                responses: RefCell::new(VecDeque::from([result])),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl Runner for FakeRunner {
+        fn run(&self, args: &[String]) -> Result<CommandResult> {
+            self.calls.borrow_mut().push(args.to_vec());
+            self.responses
+                .borrow_mut()
+                .pop_front()
+                .context("unexpected fake remem invocation")
+        }
+    }
+
+    fn sessions(count: usize, summaries: Vec<Value>) -> Value {
+        serde_json::json!({
+            "since_epoch": null, "until_epoch": null, "project": null,
+            "sample": 0, "count": count, "sessions": summaries
+        })
+    }
+
+    fn summary(message_count: i64) -> Value {
+        serde_json::json!({
+            "source_root": "local", "project": "/repo", "session_id": "s1",
+            "first_epoch": 10, "last_epoch": 20, "message_count": message_count,
+            "user_message_count": (message_count + 1) / 2,
+            "assistant_message_count": message_count / 2,
+            "user_message_samples": []
+        })
+    }
+
+    fn message(id: i64, epoch: i64, role: &str) -> Value {
+        serde_json::json!({
+            "id": id, "role": role, "content": format!("m{id}"),
+            "source": "transcript", "branch": null, "cwd": "/repo",
+            "created_at_epoch": epoch
+        })
+    }
+
+    fn page(messages: Vec<Value>, has_more: bool, cursor: Value) -> Value {
+        serde_json::json!({
+            "source_type": "raw_archive", "source_root": "local",
+            "project": "/repo", "session_id": "s1",
+            "order": "created_at_epoch_asc_id_asc", "limit": 2000,
+            "count": messages.len(), "has_more": has_more,
+            "next_cursor": cursor, "messages": messages
+        })
+    }
+
+    #[test]
+    fn loads_multiple_pages_and_builds_stable_identity() {
+        let runner = FakeRunner::json(vec![
+            sessions(1, vec![summary(3)]),
+            page(
+                vec![message(1, 10, "user"), message(2, 10, "assistant")],
+                true,
+                Value::String("c1".into()),
+            ),
+            page(vec![message(3, 20, "user")], false, Value::Null),
+        ]);
+        let loaded = load_remem_sessions_with_runner(&runner, None, None).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].session.messages.len(), 3);
+        assert_eq!(loaded[0].session.source, SessionSource::RememRaw);
+        assert_eq!(loaded[0].first_epoch, 10);
+        assert_eq!(
+            loaded[0].stable_document_url(),
+            "remem-raw://v1/6c6f63616c/2f7265706f/7331"
+        );
+        assert!(runner.calls.borrow()[2].ends_with(&["--cursor".into(), "c1".into()]));
+    }
+
+    #[test]
+    fn reports_nonzero_and_invalid_json() {
+        let failed = FakeRunner::one(CommandResult {
+            success: false,
+            code: Some(7),
+            stdout: Vec::new(),
+            stderr: b"locked".to_vec(),
+        });
+        assert!(load_remem_sessions_with_runner(&failed, None, None)
+            .unwrap_err()
+            .to_string()
+            .contains("status Some(7)"));
+        let invalid = FakeRunner::one(CommandResult {
+            success: true,
+            code: Some(0),
+            stdout: b"not-json".to_vec(),
+            stderr: Vec::new(),
+        });
+        assert!(load_remem_sessions_with_runner(&invalid, None, None).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_fields_and_count_drift() {
+        let missing = FakeRunner::json(vec![serde_json::json!({"count": 0, "sessions": []})]);
+        assert!(load_remem_sessions_with_runner(&missing, None, None).is_err());
+        let drift = FakeRunner::json(vec![sessions(2, vec![summary(1)])]);
+        assert!(load_remem_sessions_with_runner(&drift, None, None)
+            .unwrap_err()
+            .to_string()
+            .contains("count mismatch"));
+    }
+
+    #[test]
+    fn rejects_selector_and_order_drift() {
+        let mut selector = page(vec![message(1, 10, "user")], false, Value::Null);
+        selector["project"] = Value::String("/other".into());
+        let runner = FakeRunner::json(vec![sessions(1, vec![summary(1)]), selector]);
+        assert!(load_remem_sessions_with_runner(&runner, None, None).is_err());
+
+        let mut order = page(vec![message(1, 10, "user")], false, Value::Null);
+        order["order"] = Value::String("id_asc".into());
+        let runner = FakeRunner::json(vec![sessions(1, vec![summary(1)]), order]);
+        assert!(load_remem_sessions_with_runner(&runner, None, None).is_err());
+    }
+
+    #[test]
+    fn rejects_cursor_stall_and_message_count_drift() {
+        let runner = FakeRunner::json(vec![
+            sessions(1, vec![summary(2)]),
+            page(
+                vec![message(1, 10, "user")],
+                true,
+                Value::String("same".into()),
+            ),
+            page(
+                vec![message(2, 20, "assistant")],
+                true,
+                Value::String("same".into()),
+            ),
+        ]);
+        assert!(load_remem_sessions_with_runner(&runner, None, None)
+            .unwrap_err()
+            .to_string()
+            .contains("did not progress"));
+
+        let runner = FakeRunner::json(vec![
+            sessions(1, vec![summary(2)]),
+            page(vec![message(1, 10, "user")], false, Value::Null),
+        ]);
+        assert!(load_remem_sessions_with_runner(&runner, None, None)
+            .unwrap_err()
+            .to_string()
+            .contains("message count drift"));
+    }
+
+    #[test]
+    fn rejects_summary_role_and_epoch_drift() {
+        let role_drift = FakeRunner::json(vec![
+            sessions(1, vec![summary(2)]),
+            page(
+                vec![message(1, 10, "user"), message(2, 20, "user")],
+                false,
+                Value::Null,
+            ),
+        ]);
+        assert!(load_remem_sessions_with_runner(&role_drift, None, None)
+            .unwrap_err()
+            .to_string()
+            .contains("role counts drifted"));
+
+        let epoch_drift = FakeRunner::json(vec![
+            sessions(1, vec![summary(2)]),
+            page(
+                vec![message(1, 11, "user"), message(2, 20, "assistant")],
+                false,
+                Value::Null,
+            ),
+        ]);
+        assert!(load_remem_sessions_with_runner(&epoch_drift, None, None)
+            .unwrap_err()
+            .to_string()
+            .contains("first_epoch drifted"));
+    }
+
+    #[test]
+    fn empty_selection_is_success_and_unknown_roles_fail() {
+        let empty = FakeRunner::json(vec![sessions(0, vec![])]);
+        assert!(load_remem_sessions_with_runner(&empty, None, None)
+            .unwrap()
+            .is_empty());
+        let runner = FakeRunner::json(vec![
+            sessions(1, vec![summary(1)]),
+            page(vec![message(1, 10, "system")], false, Value::Null),
+        ]);
+        assert!(load_remem_sessions_with_runner(&runner, None, None)
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported raw message role"));
+    }
+}

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -11,6 +11,12 @@ Use the installer from the repository root:
 scripts/install-local.sh
 ```
 
+Session ingestion also requires a compatible `remem` binary on `PATH` (or an
+explicit `REFINE_REMEM_BIN` path). Refine treats remem subprocess and JSON
+contract failures as ingest failures; it does not silently fall back to local
+transcript scanning. The temporary `--legacy-local-scan` option is the only
+rollback path during the one-release transition window.
+
 The installer is idempotent. It can be used for first install and for upgrades from a newer checkout.
 
 ## What The Installer Does

--- a/docs/SPEC-session-insights.md
+++ b/docs/SPEC-session-insights.md
@@ -8,12 +8,13 @@
 
 ### 数据源
 
-| 来源 | 位置 | 格式 |
+| 来源 | 入口 | 格式 |
 |------|------|------|
-| Claude Code 会话 | `~/.claude/projects/*/*.jsonl` | 完整对话（含 AI 回复、tool use） |
-| Codex 会话 | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` | 完整对话（session_meta + response_item） |
+| remem raw archive | `remem raw sessions/messages --json` | 完整 user/assistant 消息和精确 selector tuple |
+| 本地 Claude/Codex 文件 | `--legacy-local-scan` | 仅一个发布周期的显式回滚路径 |
 
-`~/.claude/history.jsonl` 只有用户输入摘要，不含 AI 回复，不适合深度分析。会话级 JSONL 包含完整交互，是主要数据源。
+默认路径不直接扫描文件系统。refine 逐页读取 remem 快照，并严格校验
+`source_type`、selector、排序、游标、计数和首尾时间；provider 失败或契约漂移时整次导入显式失败。
 
 ### 现有架构
 
@@ -27,7 +28,8 @@
 ### 两个 CLI 命令
 
 ```
-refine ingest-sessions [--source claude|codex|all] [--limit N] [--dry-run]
+refine ingest-sessions [--limit N | --latest N] [--dry-run]
+refine ingest-sessions --legacy-local-scan [--source claude|codex]
 refine insights [--period 30d] [--format terminal|json]
 ```
 
@@ -36,10 +38,10 @@ refine insights [--period 30d] [--format terminal|json]
 ```
 Phase 1: 发现与解析                    Phase 2: Facet 提取
 ───────────────────                   ──────────────────
-扫描 ~/.claude/ ~/.codex/              每个会话 → LLM 提取 10 维 facets
-过滤子 agent、太短的会话                存为 Document(source="claude-code-session")
-解析 JSONL → 统一 Session 结构          + Item(type=Observation) × N
-跳过已处理的（按 Document.url 去重）     缓存：已处理的 session 不再重复
+remem 枚举精确 tuple                    每个会话 → LLM 提取 10 维 facets
+读取并校验全部消息分页                   存为 Document(source="remem-raw-session")
+转换为统一 Session 结构                 + Item(type=Observation) × N
+按稳定 URL + raw_content 判断跳过或刷新  相同内容不重复，变化内容原位替换
 
 Phase 3: 聚合分析                      Phase 4: 处方生成
 ──────────────────                    ──────────────────
@@ -69,9 +71,9 @@ pub enum ItemType {
 // 统一的会话结构（跨 Claude Code / Codex）
 pub struct Session {
     pub id: String,                    // session UUID
-    pub source: SessionSource,         // ClaudeCode | Codex
+    pub source: SessionSource,         // RememRaw（默认）| ClaudeCode | Codex（回滚）
     pub project: Option<String>,       // 项目路径
-    pub file_path: String,             // 原始 JSONL 文件路径
+    pub file_path: String,             // remem 稳定 URL 或回滚路径文件名
     pub started_at: DateTime<Utc>,
     pub ended_at: Option<DateTime<Utc>>,
     pub messages: Vec<SessionMessage>,
@@ -79,6 +81,7 @@ pub struct Session {
 }
 
 pub enum SessionSource {
+    RememRaw,
     ClaudeCode,
     Codex,
 }
@@ -107,7 +110,10 @@ pub struct SessionMeta {
 }
 ```
 
-### JSONL 解析规则
+### Provider 与回滚解析规则
+
+默认路径只接收 remem 的 raw archive JSON 契约，不调用 JSONL parser。以下 JSONL
+规则仅适用于显式 `--legacy-local-scan` 回滚路径。
 
 #### Claude Code 会话 JSONL
 
@@ -190,9 +196,11 @@ pub struct SessionMeta {
 
 ### 去重与增量
 
-- 每个 Session 对应一个 Document，`url` 字段存 JSONL 文件路径
-- `ingest-sessions` 执行前查询已有 Document.url，跳过已处理的
-- 重新处理需要先删除对应 Document（级联删除关联 Items）
+- 每个 remem Session 对应一个 Document；`url` 为 exact tuple 的稳定十六进制编码
+- URL 已存在且 `raw_content` 相同则跳过；内容变化则保留 Document identity 并原子替换 Items
+- 对 `source_root=local`，按 session filename + 内容优先、首时间 + 内容次级匹配旧路径 Document；remem 替代项保存与旧 Document/items 删除在同一事务提交，匹配不唯一则 fail closed
+- 回滚扫描若命中已有 remem identity，则继续刷新该稳定 URL；不会恢复路径 URL 并生成第二套 facets
+- provider 失败、分页游标停滞或 selector/count/order 漂移时显式失败，不回退为本地扫描
 
 ## Files Changed
 
@@ -202,8 +210,8 @@ pub struct SessionMeta {
 |------|------|
 | `mod.rs` | 模块导出 |
 | `types.rs` | Session, SessionMessage, SessionMeta, SessionSource 类型 |
-| `discovery.rs` | 扫描 ~/.claude/ ~/.codex/ 发现会话文件 |
-| `parser.rs` | JSONL 解析器（Claude Code + Codex 两种格式） |
+| `discovery.rs` | 显式回滚路径扫描 ~/.claude/ ~/.codex/ |
+| `parser.rs` | 显式回滚路径的 JSONL 解析器（Claude Code + Codex） |
 | `filter.rs` | 过滤规则（太短、子 agent 等） |
 | `facets.rs` | Facet 提取 prompt 构建 + 响应解析 |
 | `aggregation.rs` | L1-L3 聚合计算 |
@@ -219,6 +227,7 @@ pub struct SessionMeta {
 | `packages/core/src/infra/sqlite/rows.rs` | row_to_item 支持 Observation |
 | `apps/cli/src/cli.rs` | Commands 添加 IngestSessions、Insights |
 | `apps/cli/src/handlers.rs` | 添加 handle_ingest_sessions、handle_insights |
+| `apps/cli/src/remem_sessions.rs` | remem 子进程适配、分页与契约校验、稳定 identity |
 
 ### 总计：8 个新文件 + 6 个修改文件 = 14 个文件
 
@@ -262,8 +271,9 @@ pub struct SessionMeta {
 
 ## Done-when
 
-1. `refine ingest-sessions` 能扫描、解析、提取 Claude Code + Codex 会话
+1. `refine ingest-sessions` 默认只从 remem raw archive 读取、校验并提取完整会话
 2. `refine insights` 能输出 L1-L4 四层分析报告
-3. 增量处理正常工作（第二次运行只处理新会话）
+3. 相同 raw 内容第二次运行会跳过，内容变化会原位刷新
 4. `cargo check` + `cargo test` 通过
 5. 至少 3 个真实会话的 facet 提取结果质量可接受
+6. remem 不可用或契约漂移时命令非零退出，只有显式回滚开关才扫描本地文件

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -119,13 +119,21 @@ bun run package
 
 ```bash
 refine ingest-sessions
-refine ingest-sessions --source claude
-refine ingest-sessions --source codex
+refine ingest-sessions --latest 20
 refine ingest-sessions --dry-run
+
+# Temporary one-release rollback only
+refine ingest-sessions --legacy-local-scan --source claude
+refine ingest-sessions --legacy-local-scan --source codex
 refine insights --prescription
 mirror dashboard
 mirror score
 ```
+
+On the first remem-backed run, refine supersedes a matching local path-keyed
+session Document/items and saves the replacement facets in one transaction.
+Ambiguous legacy identity stops the run instead of risking duplicate
+observations or deleting the wrong history.
 
 ### Knowledge and document operations
 

--- a/docs/cognitive-portraits/refine-data-pipelines.md
+++ b/docs/cognitive-portraits/refine-data-pipelines.md
@@ -10,7 +10,7 @@
 
 共识别 **9 条产出链路**，其中 **6 条调 LLM**、**5 条写 refine.db**、其余写本地文件或 stdout：
 
-- 1 条数据流入口（`refine ingest-sessions`，JSONL → refine.db）
+- 1 条数据流入口（`refine ingest-sessions`，remem raw archive → refine.db）
 - 1 条核心 LLM 聚合链路（`refine insights --prescription`，~10+1 次 LLM 并发）
 - 4 条 mirror 子命令（`score` / `motd` / `dashboard` / `weekly` / `profile`）
 - 2 条由 launchd 调度的 shell 脚本（daily/weekly）
@@ -23,8 +23,8 @@
 ## 链路全景图
 
 ```
-AI IDE JSONL 文件
- (Claude Code / Codex)
+remem raw archive
+ (完整 user/assistant 消息)
        │
        │ parse + LLM facet extract (3 并发 × 最多 5 次重试)
        ▼
@@ -94,15 +94,15 @@ AI IDE JSONL 文件
 
 | 字段 | 内容 |
 |---|---|
-| 命令入口 | `refine ingest-sessions [--source claude\|codex] [--limit N\|--latest N] [--dry-run]` |
+| 命令入口 | `refine ingest-sessions [--limit N\|--latest N] [--dry-run]`；一个发布周期内可显式使用 `--legacy-local-scan [--source claude\|codex]` |
 | 代码位置 | `apps/cli/src/cli.rs:74-88` → `apps/cli/src/handlers.rs:32-58` → `apps/cli/src/ingest_sessions.rs:41-199`（处理函数 `handle_ingest_sessions`，`process_single_session`，`llm_call_with_retry`，`extract_and_parse_facets_with_retry`）|
 | 触发方式 | 手动；由 `scripts/daily-refresh.sh` 每天 08:00 调用；由 `scripts/weekly-insights.sh` 每周一 09:00 调用 |
-| 数据来源 | `discover_sessions()` 扫描 Claude Code/Codex 的 JSONL 会话文件（路径来自 `refine_core::session::discover_sessions`）|
-| 处理步骤 | 1) 发现所有 JSONL 文件；2) 按 `--latest` (mtime 降序) 或 `--limit` (路径序) 裁剪；3) 串行去重（`doc_store.find_by_url` 查已存在 URL）+ 解析 + filter；4) `needs_chunking()` 为真时分块（每块单独 LLM 调用），否则单次调用；5) 3 路并发（`Semaphore::new(3)`）执行 LLM facet 抽取；6) `parse_facet_response` 解析 JSON；7) 保存 Document（title = session_summary），通过 `facets_to_items` 生成多条 Item 保存 |
-| LLM 调用 | **是**；每会话 1 次（或每分块 1 次，需要 chunking 时可能 N 次）+ 1 次最终合并；3 路并发；最多 5 次重试，base delay 10s，退避 `10 * 2^attempt` 秒；重试触发条件：`cooldown / service_busy / rate / 429 / Upstream / timeout / empty response` |
-| 输出目标 | **refine.db**：`documents` 表（每会话 1 行，source = `claude` 或 `codex`）+ `items` 表（每会话 N 行，`item_type='observation'`）|
-| 输出 schema | `Document { id, source, url=jsonl_path, title=session_summary, raw_content }`；`Item { id, item_type='observation', title, summary, content, tags, document_id, created_at, ... }`；字段含 `decision` / `bugfix` / `progress` / `question` / `code_artifact` / `cognitive_level` / `collaboration_mode` / `tool` / `friction` / `architecture` / `knowledge` / `pattern` 等 facet |
-| 依赖 | 无（这是唯一的数据流入口）；需要 LLM key |
+| 数据来源 | `remem raw sessions --json` 枚举 exact tuple，`remem raw messages --json` 读取完整快照分页；本地扫描只在显式回滚开关下运行 |
+| 处理步骤 | 1) 校验 session summary；2) 按 `--latest` 或 `--limit` 裁剪；3) 逐页校验 selector/order/cursor/count/epoch；4) 用稳定 URL + raw 内容跳过或刷新；5) 保守匹配本地旧路径 identity；6) filter/chunk；7) 默认串行（`REFINE_INGEST_CONCURRENCY` 可配置）执行 LLM facet 抽取；8) 在同一事务保存 remem Document/Items 并删除已取代旧 Document/items |
+| LLM 调用 | **是**；每会话 1 次（或每分块 1 次，需要 chunking 时可能 N 次）+ 1 次最终合并；默认并发度 1；最多 5 次重试，base delay 10s，退避 `10 * 2^attempt` 秒 |
+| 输出目标 | **refine.db**：`documents` 表（每会话 1 行，source = `remem-raw-session`）+ `items` 表（每会话 N 行，`item_type='observation'`）|
+| 输出 schema | `Document { id, source, url=remem-raw://v1/<hex tuple>, title, raw_content }`；`Item { id, item_type='observation', ..., document_id }`；内容变化时保留 Document identity 并替换关联 Items |
+| 依赖 | 兼容的 `remem` 二进制（`PATH` 或 `REFINE_REMEM_BIN`）和 LLM key；provider 错误会 fail closed |
 | 已知问题 | 网络波动 / API cooldown 时单会话可能耗尽 5 次重试失败；`daily-refresh.sh` 会根据 exit code 记录 `~/.refine/last-refresh-ok`，失败时不更新时间戳 |
 
 ---
@@ -247,10 +247,10 @@ AI IDE JSONL 文件
 
 ### 1. 数据流入点
 
-**只有链路 1 `refine ingest-sessions` 是数据流入口**（从 JSONL 文件 LLM 抽取）。所有其他链路（2~9）都是在 refine.db 里对已有 Observation 做聚合/加工/叙事。因此：
+**只有链路 1 `refine ingest-sessions` 是数据流入口**（默认从 remem raw archive 做 LLM 抽取）。所有其他链路（2~9）都是在 refine.db 里对已有 Observation 做聚合/加工/叙事。因此：
 
 - **链路 1 质量决定整条管道质量**。facet prompt 改动、chunking 策略、filter 策略的变化会扩散到下游所有报告。
-- 断掉链路 1（如 API key 失效、JSONL 格式变化）会让下游全部"显示空白"（`score` / `insights` / `dashboard` 都有 "暂无观测数据" 分支）。
+- 断掉链路 1（如 API key 失效、remem 不可用或契约漂移）会让导入显式失败；不会把 provider 错误降级成空输入。
 
 ### 2. LLM 成本分布
 
@@ -259,7 +259,7 @@ AI IDE JSONL 文件
 | 链路 | LLM 次数 | 并发度 | 场景 |
 |---|---|---|---|
 | 链路 2 `insights --prescription` | **≈11 次**（10 路 + 1 合并） | 10 | 最重 |
-| 链路 1 `ingest-sessions` | **每会话 1~N 次**（N = chunk 数量） | 3 | 批量时总量最大 |
+| 链路 1 `ingest-sessions` | **每会话 1~N 次**（N = chunk 数量） | 默认 1 | 批量时总量最大；可通过 env 配置 |
 | 链路 5 `weekly` | 1 次 | 1 | |
 | 链路 7 `profile` | 1 次 | 1 | |
 | 链路 3 `score` (advice) | 1 次（72h 缓存） | 1 | 命中缓存后 0 次 |
@@ -310,7 +310,7 @@ AI IDE JSONL 文件
 
 | 链路 | 使用 env |
 |---|---|
-| 链路 1 ingest-sessions | LLM key；可选 `REFINE_DB_PATH` |
+| 链路 1 ingest-sessions | `remem`（或 `REFINE_REMEM_BIN`）；LLM key；可选 `REFINE_DB_PATH`、`REFINE_INGEST_CONCURRENCY` |
 | 链路 2 insights | LLM key；可选 `REFINE_DB_PATH` |
 | 链路 3 score | 可选 LLM key（advice 可跳过）；可选 `REFINE_DB_PATH` |
 | 链路 4 dashboard | 可选 `REFINE_DB_PATH` |

--- a/packages/core/src/infra/sqlite/mod.rs
+++ b/packages/core/src/infra/sqlite/mod.rs
@@ -213,6 +213,38 @@ impl DocumentRepository for SqliteStore {
             .await
     }
 
+    async fn save_with_replaced_items_and_delete_documents(
+        &self,
+        doc: &Document,
+        items: &[Item],
+        obsolete_document_ids: &[DocumentId],
+    ) -> InfraResult<()> {
+        let doc = doc.clone();
+        let items = items.to_vec();
+        let obsolete_document_ids = obsolete_document_ids
+            .iter()
+            .map(|id| id.as_str().to_string())
+            .collect();
+        self.request(
+            |resp| SqliteCommand::DocSaveWithReplacedItemsAndDeleteDocuments {
+                doc,
+                items,
+                obsolete_document_ids,
+                resp,
+            },
+        )
+        .await
+    }
+
+    async fn delete_documents_with_items(&self, document_ids: &[DocumentId]) -> InfraResult<()> {
+        let ids = document_ids
+            .iter()
+            .map(|id| id.as_str().to_string())
+            .collect();
+        self.request(|resp| SqliteCommand::DocDeleteWithItems { ids, resp })
+            .await
+    }
+
     async fn delete(&self, id: &DocumentId) -> InfraResult<bool> {
         let id = id.as_str().to_string();
         self.request(|resp| SqliteCommand::DocDelete { id, resp })

--- a/packages/core/src/infra/sqlite/worker.rs
+++ b/packages/core/src/infra/sqlite/worker.rs
@@ -95,6 +95,12 @@ pub(super) enum SqliteCommand {
         items: Vec<Item>,
         resp: oneshot::Sender<InfraResult<()>>,
     },
+    DocSaveWithReplacedItemsAndDeleteDocuments {
+        doc: Document,
+        items: Vec<Item>,
+        obsolete_document_ids: Vec<String>,
+        resp: oneshot::Sender<InfraResult<()>>,
+    },
     DocFindById {
         id: String,
         resp: oneshot::Sender<InfraResult<Option<Document>>>,
@@ -110,6 +116,10 @@ pub(super) enum SqliteCommand {
     DocDelete {
         id: String,
         resp: oneshot::Sender<InfraResult<bool>>,
+    },
+    DocDeleteWithItems {
+        ids: Vec<String>,
+        resp: oneshot::Sender<InfraResult<()>>,
     },
     DocSearchText {
         query: String,
@@ -345,6 +355,23 @@ fn handle_command(conn: &Connection, command: SqliteCommand) {
                 save_document_with_replaced_items(conn, &doc, &items),
             );
         }
+        SqliteCommand::DocSaveWithReplacedItemsAndDeleteDocuments {
+            doc,
+            items,
+            obsolete_document_ids,
+            resp,
+        } => {
+            send_response(
+                "DocSaveWithReplacedItemsAndDeleteDocuments",
+                resp,
+                save_document_with_replaced_items_and_delete_documents(
+                    conn,
+                    &doc,
+                    &items,
+                    &obsolete_document_ids,
+                ),
+            );
+        }
         SqliteCommand::DocFindById { id, resp } => {
             send_response("DocFindById", resp, doc_ops::find_by_id(conn, &id));
         }
@@ -364,6 +391,13 @@ fn handle_command(conn: &Connection, command: SqliteCommand) {
         }
         SqliteCommand::DocDelete { id, resp } => {
             send_response("DocDelete", resp, doc_ops::delete(conn, &id));
+        }
+        SqliteCommand::DocDeleteWithItems { ids, resp } => {
+            send_response(
+                "DocDeleteWithItems",
+                resp,
+                delete_documents_with_items(conn, &ids),
+            );
         }
         SqliteCommand::DocSearchText {
             query,
@@ -466,5 +500,50 @@ fn save_document_with_replaced_items(
     }
     tx.commit()
         .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(())
+}
+
+fn save_document_with_replaced_items_and_delete_documents(
+    conn: &Connection,
+    doc: &Document,
+    items: &[Item],
+    obsolete_document_ids: &[String],
+) -> InfraResult<()> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    doc_ops::save(&tx, doc)?;
+    ops::delete_by_document_id(&tx, doc.id().as_str())?;
+    for item in items {
+        ops::save(&tx, item)?;
+    }
+    delete_documents_with_items_in_transaction(&tx, obsolete_document_ids)?;
+    tx.commit()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(())
+}
+
+fn delete_documents_with_items(conn: &Connection, document_ids: &[String]) -> InfraResult<()> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    delete_documents_with_items_in_transaction(&tx, document_ids)?;
+    tx.commit()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(())
+}
+
+fn delete_documents_with_items_in_transaction(
+    conn: &Connection,
+    document_ids: &[String],
+) -> InfraResult<()> {
+    for document_id in document_ids {
+        ops::delete_by_document_id(conn, document_id)?;
+        if !doc_ops::delete(conn, document_id)? {
+            return Err(InfraError::Database(format!(
+                "obsolete document {document_id} does not exist"
+            )));
+        }
+    }
     Ok(())
 }

--- a/packages/core/src/knowledge/doc_repository.rs
+++ b/packages/core/src/knowledge/doc_repository.rs
@@ -14,6 +14,13 @@ pub trait DocumentRepository: Send + Sync {
     async fn count(&self) -> InfraResult<usize>;
     async fn save(&self, doc: &Document) -> InfraResult<()>;
     async fn save_with_replaced_items(&self, doc: &Document, items: &[Item]) -> InfraResult<()>;
+    async fn save_with_replaced_items_and_delete_documents(
+        &self,
+        doc: &Document,
+        items: &[Item],
+        obsolete_document_ids: &[DocumentId],
+    ) -> InfraResult<()>;
+    async fn delete_documents_with_items(&self, document_ids: &[DocumentId]) -> InfraResult<()>;
     async fn delete(&self, id: &DocumentId) -> InfraResult<bool>;
     async fn search_text(
         &self,

--- a/packages/core/src/session/parser.rs
+++ b/packages/core/src/session/parser.rs
@@ -28,6 +28,9 @@ pub const MAX_SESSION_FILE_BYTES: u64 = 200 * 1024 * 1024;
 
 /// 解析 JSONL 文件为 Session
 pub fn parse_session_file(path: &Path, source: SessionSource) -> Result<Session, String> {
+    if source == SessionSource::RememRaw {
+        return Err("RememRaw sessions must be loaded through the remem CLI provider".to_string());
+    }
     let metadata = std::fs::metadata(path).map_err(|e| format!("读取文件失败: {}", e))?;
     let size = metadata.len();
     if size > MAX_SESSION_FILE_BYTES {
@@ -54,6 +57,9 @@ pub fn parse_session_content(
     path: &Path,
     source: SessionSource,
 ) -> Result<Session, String> {
+    if source == SessionSource::RememRaw {
+        return Err("RememRaw sessions cannot be parsed from transcript JSONL".to_string());
+    }
     let mut messages = Vec::new();
     let mut meta = SessionMeta::default();
     let mut malformed = 0usize;
@@ -87,6 +93,7 @@ pub fn parse_session_content(
             SessionSource::Codex => {
                 parse_codex_line(&value, &mut messages, &mut meta);
             }
+            SessionSource::RememRaw => unreachable!("RememRaw is rejected before JSONL parsing"),
         }
     }
 
@@ -354,6 +361,16 @@ fn parse_codex_response_item_message(value: &serde_json::Value) -> Option<Sessio
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn rejects_remem_raw_as_transcript_input() {
+        let path = Path::new("/does/not/need/to/exist.jsonl");
+        let file_error = parse_session_file(path, SessionSource::RememRaw).unwrap_err();
+        assert!(file_error.contains("remem CLI provider"));
+
+        let content_error = parse_session_content("{}", path, SessionSource::RememRaw).unwrap_err();
+        assert!(content_error.contains("cannot be parsed"));
+    }
 
     #[test]
     fn parse_claude_code_session() {

--- a/packages/core/src/session/types.rs
+++ b/packages/core/src/session/types.rs
@@ -1,6 +1,6 @@
 //! 会话类型定义
 //!
-//! 统一表示 Claude Code 和 Codex 的会话数据
+//! 统一表示 remem raw archive 和旧 Claude Code/Codex 文件扫描的会话数据
 
 use chrono::{DateTime, Utc};
 use std::path::PathBuf;
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 pub enum SessionSource {
     ClaudeCode,
     Codex,
+    RememRaw,
 }
 
 impl SessionSource {
@@ -17,6 +18,7 @@ impl SessionSource {
         match self {
             Self::ClaudeCode => "claude-code-session",
             Self::Codex => "codex-session",
+            Self::RememRaw => "remem-raw-session",
         }
     }
 }
@@ -138,5 +140,10 @@ mod tests {
             (MessageRole::User, "more"),
         ]);
         assert!(substantial.is_substantial());
+    }
+
+    #[test]
+    fn remem_raw_has_distinct_document_source() {
+        assert_eq!(SessionSource::RememRaw.as_str(), "remem-raw-session");
     }
 }


### PR DESCRIPTION
## Summary

- make `remem raw sessions/messages --json` the default and sole normal input for `refine ingest-sessions`
- validate exact selectors, ordering, counts, cursors, role counts, and first/last epochs fail closed across all snapshot pages
- derive stable Document identity from the exact tuple, refresh changed raw content, and skip unchanged sessions without an LLM call
- retain `--legacy-local-scan` as a documented one-release rollback; `--source` is rejected outside that mode
- migrate matching local path-keyed Documents safely: replacement facets and obsolete Items/Documents commit in one SQLite transaction; ambiguous or multiply claimed identity fails closed

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace` (297 passed; 1 doc-test ignored)
- extension: `bun run typecheck` and `bun run build`
- desktop UI: `bun run build`
- independent exact-head review at `87fd6798c87e37a17ba088ed20cde45dd704e477`: CLEAN

## Boundary

This completes the refine consumer implementation only. The aggregate-only before/after facet reconciliation remains on `majiayu000/remem#720`; that parent issue must stay open until reconciliation is posted and SP720-T5 is closed.

Closes #139
Refs majiayu000/remem#720