### PR TITLE
fix: recover local runtime and harden session ingestion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
             test -f "$f" || { echo "Missing: $f"; exit 1; }
           done
 
+  shell-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test unattended LLM credential scripts on GNU/Linux
+        run: bash scripts/test-llm-env.sh
+
   check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test unattended LLM credential scripts on GNU/Linux
-        run: bash scripts/test-llm-env.sh
+        run: |
+          bash scripts/test-llm-env.sh
+          bash scripts/test-runtime-wrappers.sh
 
   check:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ apps/desktop/src-tauri/target/
 
 # Runtime artifacts
 .backup/
+.omx/
 .run/*.log
 .run/*.err.log
 .run/*.out.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ reqwest = { version = "0.12", features = ["json"] }
 # Utils
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+sha2 = "0.10"
 
 # Internal
 refine-core = { path = "packages/core" }

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@
 # Install the local stack: CLI tools, server, launchd jobs, and optional UI dev service
 scripts/install-local.sh
 
-# Configure LLM (.env file)
-cat > .env << 'EOF'
-REFINE_OPENAI_API_KEY=your_key
-REFINE_OPENAI_BASE_URL=https://api.openai.com
-REFINE_OPENAI_MODEL=gpt-4o
-EOF
+# Configure unattended LLM credentials (review first; no values are printed)
+bash scripts/configure-llm-env.sh --check
+bash scripts/configure-llm-env.sh --migrate
+
+# If supported variables are already exported in this shell, use:
+# bash scripts/configure-llm-env.sh --from-env
 
 # Set up Claude Code skills (one-time symlink)
 ln -s "$(pwd)/skills/cognitive-portrait" ~/.claude/skills/cognitive-portrait
@@ -129,7 +129,28 @@ scripts/doctor-local.sh
 | Schedule | Task | What It Does |
 |----------|------|-------------|
 | Daily 8:00 AM | `scripts/daily-refresh.sh` | `refine ingest-sessions` → `mirror score` → writes `~/.refine/last-refresh-ok` |
-| Weekly Mon 9:00 AM | `scripts/weekly-insights.sh` | `refine insights --prescription` (10-way LLM) |
+| Weekly Sunday 09:00 | `scripts/weekly-insights.sh` | `refine insights --prescription` (10-way LLM) |
+
+### LLM credential loading
+
+Unattended jobs use `~/.refine/llm.env` (mode `0600`, owned by the current
+user) and never source `~/.zshrc`. Loading order is: non-empty credentials
+already in the process, the secure user file, then an explicit repository
+`.env` fallback used by the daily and weekly scripts for development. Lower
+priority sources never replace an already-set credential.
+
+The migration helper accepts only literal `export BASE_URL=...`,
+`export BASE_API_KEY=...`, and `export BASE_MODEL=...` definitions. It creates
+a private backup under `~/.refine/backups`, removes only those definitions,
+and adds one managed source block for interactive shells. `--check` is a
+read-only dry run; `--migrate` is the explicit write operation. The installer
+does not copy or migrate secrets. Run `scripts/doctor-local.sh` after
+configuration to verify the same clean-environment preflight used by launchd.
+
+For a manual development-only fallback, a repository `.env` may contain
+supported variables such as `REFINE_OPENAI_API_KEY`,
+`REFINE_OPENAI_BASE_URL`, and `REFINE_OPENAI_MODEL`; scheduled scripts pass
+that path explicitly to the loader rather than sourcing it automatically.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ln -s "$(pwd)/skills/cognitive-portrait" ~/.claude/skills/cognitive-portrait
 # If ~/.claude/skills/cognitive-portrait already exists as a directory (old copy),
 # delete it first: rm -rf ~/.claude/skills/cognitive-portrait
 
-# Import sessions from remem's raw archive
+# Import sessions (auto prefers remem and falls back to local when remem is absent)
 refine ingest-sessions
 
 # See your cognitive snapshot
@@ -145,9 +145,9 @@ friction_green = 1.0         # friction < 1.0/session = green
 ### Data Flow
 
 ```
-remem raw sessions/messages         ← Claude Code + Codex raw archive
+remem raw sessions/messages         ← preferred Claude Code + Codex raw archive
     │
-    ▼ refine ingest-sessions        (12-dimension facet extraction via LLM)
+    ▼ refine ingest-sessions        (auto: remem, or local discovery if remem is absent)
     │
 SQLite (observations, documents)    ← Shared data store
     │
@@ -160,24 +160,29 @@ SQLite (observations, documents)    ← Shared data store
 
 ## Refine CLI Commands
 
-`refine ingest-sessions` requires a compatible `remem` binary on `PATH`. Set
-`REFINE_REMEM_BIN` to an explicit binary path when needed. The normal path
-enumerates exact tuples with `remem raw sessions --json`, reads every snapshot-
-paginated `remem raw messages --json` page, and fails visibly on provider or
-contract errors. During the switch, a matching local path-keyed Document/items
-and its remem replacement facets are changed in one transaction;
-ambiguous legacy identity fails closed. Direct transcript scanning is disabled by default;
-`--legacy-local-scan` is a temporary one-release rollback switch and reuses a
-matching remem identity instead of creating a second active facet set.
+`refine ingest-sessions` defaults to `--provider auto`: it prefers a compatible
+`remem` binary on `PATH` (or the path in `REFINE_REMEM_BIN`) and falls back to
+the local Claude/Codex session scanner only when that executable is absent.
+`--provider remem` is strict and fails visibly on subprocess, JSON, contract,
+or pagination errors; those errors never trigger a local fallback.
+`--provider local` is a supported provider and accepts `--source claude|codex`.
+The deprecated `--legacy-local-scan` flag remains an alias for
+`--provider local`. A matching local path-keyed Document/items and its remem
+replacement facets are changed in one transaction; ambiguous legacy identity
+fails closed and the remem identity is reused instead of creating a second
+active facet set.
 
 ### Session Analysis
 
 ```bash
-refine ingest-sessions                  # Import complete sessions from remem
-refine ingest-sessions --latest 20      # Most recent 20 remem sessions
+refine ingest-sessions                  # auto: remem, then local only if remem is absent
+refine ingest-sessions --provider remem # Strict remem raw archive provider
+refine ingest-sessions --provider local # Supported local Claude/Codex scanner
+refine ingest-sessions --provider local --source claude
+refine ingest-sessions --latest 20      # Most recent sessions from the selected provider
 refine ingest-sessions --dry-run        # Preview without LLM calls
 refine ingest-sessions --legacy-local-scan --source claude
-                                        # One-release rollback to filesystem discovery
+                                        # Deprecated alias for --provider local
 refine insights --prescription          # L1-L4 cognitive report
 mirror dashboard                        # Cognitive growth dashboard
 ```

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -19,6 +19,7 @@ dirs = "5"
 dotenvy = "0.15"
 serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -20,6 +20,7 @@ dotenvy = "0.15"
 serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true
+fs2 = "0.4"
 
 [dev-dependencies]
 async-trait.workspace = true

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -164,6 +164,12 @@ pub enum Commands {
     DeepInquiry,
 }
 
+impl Commands {
+    pub(crate) fn is_read_only_preview(&self) -> bool {
+        matches!(self, Self::IngestSessions { dry_run: true, .. })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -1,4 +1,45 @@
-use clap::{Parser, Subcommand};
+use anyhow::{bail, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum IngestProvider {
+    Auto,
+    Remem,
+    Local,
+}
+
+impl IngestProvider {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Remem => "remem",
+            Self::Local => "local",
+        }
+    }
+
+    pub(crate) fn resolve(explicit: Option<Self>, legacy_local_scan: bool) -> Result<Self> {
+        if legacy_local_scan {
+            if let Some(provider) = explicit {
+                if provider != Self::Local {
+                    bail!(
+                        "--legacy-local-scan is a deprecated alias for --provider local and cannot be combined with --provider {}; use --provider local or remove the alias",
+                        provider.as_str()
+                    );
+                }
+            }
+            return Ok(Self::Local);
+        }
+
+        Ok(explicit.unwrap_or(Self::Auto))
+    }
+}
+
+impl fmt::Display for IngestProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 #[derive(Parser)]
 #[command(name = "refine")]
@@ -73,9 +114,12 @@ pub enum Commands {
     },
     /// 从 AI 编程会话中提取认知观测
     IngestSessions {
-        /// Legacy local-scan source filter (claude, codex); requires --legacy-local-scan.
-        #[arg(long, requires = "legacy_local_scan")]
+        /// Local scanner source filter (claude, codex); requires --provider local.
+        #[arg(long)]
         source: Option<String>,
+        /// Session provider: auto (default), remem, or local.
+        #[arg(long, value_enum, value_name = "PROVIDER")]
+        provider: Option<IngestProvider>,
         /// 限制处理数量（按路径顺序取前 N 个），与 --latest 互斥
         #[arg(short, long, conflicts_with = "latest")]
         limit: Option<usize>,
@@ -85,7 +129,7 @@ pub enum Commands {
         /// 仅预览，不实际处理
         #[arg(long)]
         dry_run: bool,
-        /// Temporarily use the legacy filesystem scanner instead of remem (one-release rollback).
+        /// Deprecated alias for --provider local.
         #[arg(long)]
         legacy_local_scan: bool,
         /// Explicitly retry sessions previously quarantined for deterministic provider rejection.
@@ -118,4 +162,73 @@ pub enum Commands {
     /// Removed — use 'mirror score' instead
     #[command(hide = true)]
     DeepInquiry,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ingest_command(args: &[&str]) -> (Option<IngestProvider>, bool) {
+        let cli = Cli::try_parse_from(args).expect("CLI arguments should parse");
+        let Commands::IngestSessions {
+            provider,
+            legacy_local_scan,
+            ..
+        } = cli.command
+        else {
+            panic!("expected ingest-sessions command");
+        };
+        (provider, legacy_local_scan)
+    }
+
+    #[test]
+    fn ingest_provider_defaults_to_auto() {
+        let (provider, legacy_local_scan) = ingest_command(&["refine", "ingest-sessions"]);
+        assert_eq!(
+            IngestProvider::resolve(provider, legacy_local_scan).unwrap(),
+            IngestProvider::Auto
+        );
+    }
+
+    #[test]
+    fn ingest_provider_accepts_all_first_class_values() {
+        for (value, expected) in [
+            ("auto", IngestProvider::Auto),
+            ("remem", IngestProvider::Remem),
+            ("local", IngestProvider::Local),
+        ] {
+            let (provider, legacy_local_scan) =
+                ingest_command(&["refine", "ingest-sessions", "--provider", value]);
+            assert_eq!(
+                IngestProvider::resolve(provider, legacy_local_scan).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_local_scan_remains_a_local_alias_and_rejects_contradictions() {
+        let (provider, legacy_local_scan) = ingest_command(&[
+            "refine",
+            "ingest-sessions",
+            "--legacy-local-scan",
+            "--source",
+            "codex",
+        ]);
+        assert_eq!(
+            IngestProvider::resolve(provider, legacy_local_scan).unwrap(),
+            IngestProvider::Local
+        );
+
+        let (provider, legacy_local_scan) = ingest_command(&[
+            "refine",
+            "ingest-sessions",
+            "--provider",
+            "remem",
+            "--legacy-local-scan",
+        ]);
+        let error = IngestProvider::resolve(provider, legacy_local_scan)
+            .expect_err("remem and the local alias contradict each other");
+        assert!(error.to_string().contains("--provider local"));
+    }
 }

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -88,6 +88,9 @@ pub enum Commands {
         /// Temporarily use the legacy filesystem scanner instead of remem (one-release rollback).
         #[arg(long)]
         legacy_local_scan: bool,
+        /// Explicitly retry sessions previously quarantined for deterministic provider rejection.
+        #[arg(long)]
+        retry_quarantined: bool,
     },
     /// 生成认知洞察报告
     Insights {

--- a/apps/cli/src/handlers.rs
+++ b/apps/cli/src/handlers.rs
@@ -1,4 +1,4 @@
-use crate::cli::Commands;
+use crate::cli::{Commands, IngestProvider};
 use crate::ingest_sessions::{handle_ingest_sessions, IngestOptions};
 use crate::insights::{handle_insights, InsightsOptions};
 use crate::support::{build_llm_client_from_env, format_item, parse_item_type};
@@ -33,12 +33,14 @@ pub async fn run(
         } => handle_add(&title, &summary, &r#type, store).await,
         Commands::IngestSessions {
             source,
+            provider,
             limit,
             latest,
             dry_run,
             legacy_local_scan,
             retry_quarantined,
         } => {
+            let provider = IngestProvider::resolve(provider, legacy_local_scan)?;
             let source_filter = source
                 .as_deref()
                 .map(|raw| {
@@ -46,6 +48,14 @@ pub async fn run(
                         .with_context(|| format!("invalid session source {raw:?}"))
                 })
                 .transpose()?;
+            if source_filter.is_some() && provider != IngestProvider::Local {
+                anyhow::bail!(
+                    "--source requires --provider local because remem does not expose a trustworthy Claude/Codex source"
+                );
+            }
+            if legacy_local_scan {
+                eprintln!("warning: --legacy-local-scan is deprecated; use --provider local");
+            }
             let llm_client = if dry_run {
                 None
             } else {
@@ -55,10 +65,10 @@ pub async fn run(
             handle_ingest_sessions(
                 IngestOptions {
                     source: source_filter,
+                    provider,
                     limit,
                     latest,
                     dry_run,
-                    legacy_local_scan,
                     retry_quarantined,
                 },
                 db_path,

--- a/apps/cli/src/handlers.rs
+++ b/apps/cli/src/handlers.rs
@@ -37,6 +37,7 @@ pub async fn run(
             latest,
             dry_run,
             legacy_local_scan,
+            retry_quarantined,
         } => {
             let source_filter = source
                 .as_deref()
@@ -58,6 +59,7 @@ pub async fn run(
                     latest,
                     dry_run,
                     legacy_local_scan,
+                    retry_quarantined,
                 },
                 db_path,
                 doc_store,

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -18,11 +18,14 @@ use refine_core::session::{
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 use tokio::sync::Semaphore;
 
 mod legacy_migration;
+mod quarantine;
+
+use quarantine::QuarantineStore;
 
 const DEFAULT_CONCURRENCY: usize = 1;
 
@@ -41,6 +44,7 @@ pub struct IngestOptions {
     pub latest: Option<usize>,
     pub dry_run: bool,
     pub legacy_local_scan: bool,
+    pub retry_quarantined: bool,
 }
 
 /// 待处理的会话（已通过去重和过滤）
@@ -254,6 +258,7 @@ async fn handle_remem_ingest_sessions(
         skipped_filter,
         stale_refresh,
         options.dry_run,
+        options.retry_quarantined,
         doc_store,
         llm_client,
     )
@@ -421,6 +426,7 @@ async fn handle_legacy_ingest_sessions(
         skipped_filter,
         stale_refresh,
         options.dry_run,
+        options.retry_quarantined,
         doc_store,
         llm_client,
     )
@@ -436,12 +442,13 @@ async fn handle_legacy_ingest_sessions(
 
 #[allow(clippy::too_many_arguments)]
 async fn process_pending_sessions(
-    pending: Vec<PendingSession>,
+    mut pending: Vec<PendingSession>,
     total: usize,
     skipped_dup: usize,
     skipped_filter: usize,
     stale_refresh: usize,
     dry_run: bool,
+    retry_quarantined: bool,
     doc_store: Arc<dyn DocumentRepository>,
     llm_client: Option<Arc<dyn LlmClient>>,
 ) -> Result<()> {
@@ -454,17 +461,38 @@ async fn process_pending_sessions(
         return Ok(());
     }
 
+    let mut quarantine = QuarantineStore::load()?;
+    let mut skipped_quarantined = 0usize;
+    if !retry_quarantined {
+        pending.retain(|session| {
+            if quarantine.contains(&session.url) {
+                skipped_quarantined += 1;
+                false
+            } else {
+                true
+            }
+        });
+    }
+
     let concurrency = concurrency();
     println!(
-        "待处理 {} 个会话（跳过重复 {}, 过滤 {}, 刷新过期 {}），{} 路并发...\n",
+        "待处理 {} 个会话（跳过重复 {}, 过滤 {}, 刷新过期 {}, 隔离跳过 {}），{} 路并发...\n",
         pending.len(),
         skipped_dup,
         skipped_filter,
         stale_refresh,
+        skipped_quarantined,
         concurrency,
     );
     if pending.is_empty() {
-        println!("全部已处理完毕。");
+        if quarantine.len() > 0 {
+            anyhow::bail!(
+                "仍有 {} 个会话处于隔离状态；队列: {}；确认上游策略已修复后使用 --retry-quarantined",
+                quarantine.len(),
+                quarantine.path().display()
+            );
+        }
+        println!("全部已处理完毕，隔离队列为空。");
         return Ok(());
     }
 
@@ -474,6 +502,8 @@ async fn process_pending_sessions(
     let failed = Arc::new(AtomicUsize::new(0));
     let total_items = Arc::new(AtomicUsize::new(0));
     let quota_hit = Arc::new(AtomicBool::new(false));
+    let succeeded_urls = Arc::new(Mutex::new(HashSet::<String>::new()));
+    let rejected_sessions = Arc::new(Mutex::new(Vec::<(String, String, String)>::new()));
     let mut handles = Vec::new();
 
     for ps in pending {
@@ -484,16 +514,36 @@ async fn process_pending_sessions(
         let failed = failed.clone();
         let total_items = total_items.clone();
         let quota_hit = quota_hit.clone();
+        let succeeded_urls = succeeded_urls.clone();
+        let rejected_sessions = rejected_sessions.clone();
         handles.push(tokio::spawn(async move {
             let _permit = sem.acquire().await.expect("semaphore closed");
             match process_single_session(&ps, &client, &doc_store, &quota_hit).await {
                 Ok(item_count) => {
                     processed.fetch_add(1, Ordering::Relaxed);
                     total_items.fetch_add(item_count, Ordering::Relaxed);
+                    succeeded_urls
+                        .lock()
+                        .expect("succeeded URL lock poisoned")
+                        .insert(ps.url.clone());
                 }
                 Err(error) => {
-                    eprintln!("  ✗ [{}/{}] 失败: {}", ps.idx + 1, ps.total, error);
-                    failed.fetch_add(1, Ordering::Relaxed);
+                    if let Some((code, message)) = content_rejection(&error) {
+                        eprintln!(
+                            "  ⛔ [{}/{}] 隔离: {} ({})",
+                            ps.idx + 1,
+                            ps.total,
+                            code,
+                            ps.url
+                        );
+                        rejected_sessions
+                            .lock()
+                            .expect("rejected session lock poisoned")
+                            .push((ps.url.clone(), code, message));
+                    } else {
+                        eprintln!("  ✗ [{}/{}] 失败: {}", ps.idx + 1, ps.total, error);
+                        failed.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
             }
         }));
@@ -506,13 +556,46 @@ async fn process_pending_sessions(
     let processed = processed.load(Ordering::Relaxed);
     let failed = failed.load(Ordering::Relaxed);
     let total_items = total_items.load(Ordering::Relaxed);
+    for url in succeeded_urls
+        .lock()
+        .expect("succeeded URL lock poisoned")
+        .iter()
+    {
+        quarantine.resolve(url);
+    }
+    let rejected = rejected_sessions
+        .lock()
+        .expect("rejected session lock poisoned");
+    for (url, code, message) in rejected.iter() {
+        quarantine.record(url, code, message);
+    }
+    let rejected_count = rejected.len();
+    drop(rejected);
+    quarantine.save_if_dirty()?;
+    let quarantine_count = quarantine.len();
     println!(
-        "\n完成: 处理 {}, 跳过重复 {}, 过滤 {}, 刷新过期 {}, 失败 {}, 生成 {} 条观测",
-        processed, skipped_dup, skipped_filter, stale_refresh, failed, total_items
+        "\n完成: 处理 {}, 跳过重复 {}, 过滤 {}, 刷新过期 {}, 失败 {}, 新增隔离 {}, 隔离总数 {}, 生成 {} 条观测",
+        processed,
+        skipped_dup,
+        skipped_filter,
+        stale_refresh,
+        failed,
+        rejected_count,
+        quarantine_count,
+        total_items
     );
-    if failed > 0 {
-        eprintln!("提示: 重新运行即可续传失败的会话");
-        anyhow::bail!("{} 个会话提取失败", failed);
+    if failed > 0 || quarantine_count > 0 {
+        if failed > 0 {
+            eprintln!("提示: 瞬态失败会在下次运行续传");
+        }
+        if quarantine_count > 0 {
+            eprintln!(
+                "提示: {} 个确定性拒绝已隔离，不会自动重试；队列: {}",
+                quarantine_count,
+                quarantine.path().display()
+            );
+        }
+        anyhow::bail!("摄入不完整: 瞬态失败 {}, 隔离 {}", failed, quarantine_count);
     }
     Ok(())
 }
@@ -527,17 +610,16 @@ async fn process_single_session(
         let total_chunks = ps.chunks.len();
         let mut summaries = Vec::with_capacity(total_chunks);
         for (idx, chunk) in ps.chunks.iter().enumerate() {
-            match llm_call_with_retry(client, chunk, quota_hit).await {
-                Ok(text) => summaries.push(text),
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "分块 {}/{} 提取失败，整个 session 视为失败以避免数据缺失: {}",
+            let text = llm_call_with_retry(client, chunk, quota_hit)
+                .await
+                .with_context(|| {
+                    format!(
+                        "分块 {}/{} 提取失败，整个 session 视为失败以避免数据缺失",
                         idx + 1,
-                        total_chunks,
-                        e
-                    ));
-                }
-            }
+                        total_chunks
+                    )
+                })?;
+            summaries.push(text);
         }
         summaries.join("\n\n---\n\n")
     } else {
@@ -563,6 +645,17 @@ async fn process_single_session(
     );
 
     Ok(item_count)
+}
+
+fn content_rejection(error: &anyhow::Error) -> Option<(String, String)> {
+    error.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<InfraError>()
+            .and_then(|infra_error| match infra_error {
+                InfraError::LlmRejected { code, message } => Some((code.clone(), message.clone())),
+                _ => None,
+            })
+    })
 }
 
 fn build_session_document(ps: &PendingSession, title: &str) -> Document {

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -1,8 +1,13 @@
 //! ingest-sessions 命令实现
 //!
-//! 默认从 remem raw archive 读取；支持可配置并发、断点续传和 API 限流重试
+//! 默认优先从 remem raw archive 读取；remem 不存在时自动扫描本地会话
+//! 文件；支持可配置并发、断点续传和 API 限流重试
 
-use crate::remem_sessions::{load_remem_session, load_remem_session_summaries};
+use crate::cli::IngestProvider;
+use crate::remem_sessions::{
+    is_missing_remem_executable, load_remem_session, load_remem_session_summaries,
+    RememSessionSummary,
+};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use refine_core::error::InfraError;
@@ -39,12 +44,31 @@ fn concurrency() -> usize {
 
 pub struct IngestOptions {
     pub source: Option<SessionSource>,
+    pub provider: IngestProvider,
     pub limit: Option<usize>,
     /// 按 mtime 降序取最近 N 个会话，与 limit 互斥
     pub latest: Option<usize>,
     pub dry_run: bool,
-    pub legacy_local_scan: bool,
     pub retry_quarantined: bool,
+}
+
+#[derive(Debug)]
+enum AutoProviderSelection<T> {
+    Remem(T),
+    LocalFallback,
+}
+
+fn select_auto_provider<T, F>(load_remem: F) -> Result<AutoProviderSelection<T>>
+where
+    F: FnOnce() -> Result<T>,
+{
+    match load_remem() {
+        Ok(value) => Ok(AutoProviderSelection::Remem(value)),
+        Err(error) if is_missing_remem_executable(&error) => {
+            Ok(AutoProviderSelection::LocalFallback)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 /// 待处理的会话（已通过去重和过滤）
@@ -141,10 +165,41 @@ pub async fn handle_ingest_sessions(
     doc_store: Arc<dyn DocumentRepository>,
     llm_client: Option<Arc<dyn LlmClient>>,
 ) -> Result<()> {
-    if options.legacy_local_scan {
-        return handle_legacy_ingest_sessions(options, db_path, doc_store, llm_client).await;
+    if options.source.is_some() && options.provider != IngestProvider::Local {
+        anyhow::bail!(
+            "--source requires --provider local because remem does not expose a trustworthy Claude/Codex source"
+        );
     }
-    handle_remem_ingest_sessions(options, doc_store, llm_client).await
+
+    match options.provider {
+        IngestProvider::Local => {
+            println!("provider=local");
+            handle_legacy_ingest_sessions(options, db_path, doc_store, llm_client).await
+        }
+        IngestProvider::Remem => {
+            println!("provider=remem");
+            handle_remem_ingest_sessions(options, doc_store, llm_client).await
+        }
+        IngestProvider::Auto => {
+            println!("provider=requested:auto");
+            match select_auto_provider(|| {
+                load_remem_session_summaries(options.limit, options.latest)
+            }) {
+                Ok(AutoProviderSelection::Remem(summaries)) => {
+                    println!("provider=selected:remem");
+                    handle_remem_ingest_sessions_with_summaries(
+                        options, summaries, doc_store, llm_client,
+                    )
+                    .await
+                }
+                Ok(AutoProviderSelection::LocalFallback) => {
+                    println!("provider=selected:local (auto fallback: remem executable not found)");
+                    handle_legacy_ingest_sessions(options, db_path, doc_store, llm_client).await
+                }
+                Err(error) => Err(error.context("failed to load session summaries from remem")),
+            }
+        }
+    }
 }
 
 async fn handle_remem_ingest_sessions(
@@ -152,14 +207,23 @@ async fn handle_remem_ingest_sessions(
     doc_store: Arc<dyn DocumentRepository>,
     llm_client: Option<Arc<dyn LlmClient>>,
 ) -> Result<()> {
+    let summaries = load_remem_session_summaries(options.limit, options.latest)
+        .context("failed to load session summaries from remem")?;
+    handle_remem_ingest_sessions_with_summaries(options, summaries, doc_store, llm_client).await
+}
+
+async fn handle_remem_ingest_sessions_with_summaries(
+    options: IngestOptions,
+    summaries: Vec<RememSessionSummary>,
+    doc_store: Arc<dyn DocumentRepository>,
+    llm_client: Option<Arc<dyn LlmClient>>,
+) -> Result<()> {
     if options.source.is_some() {
         anyhow::bail!(
-            "--source cannot be used with the remem provider because its contract does not expose a trustworthy Claude/Codex source; use --legacy-local-scan --source <claude|codex> only for rollback"
+            "--source requires --provider local because remem does not expose a trustworthy Claude/Codex source"
         );
     }
 
-    let summaries = load_remem_session_summaries(options.limit, options.latest)
-        .context("failed to load session summaries from remem")?;
     println!("remem 返回 {} 个会话摘要", summaries.len());
 
     let total = summaries.len();

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -273,12 +273,20 @@ async fn handle_remem_ingest_sessions_with_summaries(
         fully_loaded += 1;
         let raw_content = remem_session.session.to_document_content();
         let source_version = content_source_version("remem", &raw_content);
-        let mut legacy_documents_to_delete = if legacy_identity_is_unique {
-            legacy_migration::matching_legacy_document_ids(
+        let legacy_documents_to_delete = if legacy_identity_is_unique {
+            let document_ids = legacy_migration::matching_legacy_document_ids(
                 &existing_documents,
                 &remem_session,
                 &raw_content,
-            )?
+            )?;
+            for document_id in &document_ids {
+                if !claimed_legacy_documents.insert(document_id.clone()) {
+                    anyhow::bail!(
+                        "legacy document {document_id} ambiguously matches multiple remem sessions"
+                    );
+                }
+            }
+            document_ids
         } else if let Some(document_id) =
             legacy_migration::legacy_document_covering_nonunique_summary(
                 &existing_documents,
@@ -297,8 +305,6 @@ async fn handle_remem_ingest_sessions_with_summaries(
         } else {
             Vec::new()
         };
-        legacy_documents_to_delete
-            .retain(|document_id| claimed_legacy_documents.insert(document_id.clone()));
         if let Some(existing_doc) = existing_document.as_ref() {
             if existing_doc.raw_content() == raw_content {
                 if options.dry_run {

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -20,6 +20,7 @@ use refine_core::session::{
     build_facet_prompt, chunk_session, discover_sessions, facets_to_items, needs_chunking,
     parse_facet_response, parse_session_file, FilterConfig, SessionSource, FACET_SYSTEM_PROMPT,
 };
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -30,7 +31,7 @@ use tokio::sync::Semaphore;
 mod legacy_migration;
 mod quarantine;
 
-use quarantine::QuarantineStore;
+use quarantine::{record_key as quarantine_key, QuarantineStore};
 
 const DEFAULT_CONCURRENCY: usize = 1;
 
@@ -109,31 +110,9 @@ fn session_needs_refresh(existing_doc: &Document, file_modified_at: SystemTime) 
     file_modified_at > existing_doc.updated_at()
 }
 
-fn remem_source_version(summary: &RememSessionSummary) -> String {
-    format!(
-        "remem:v1:{}:{}:{}:{}:{}",
-        summary.first_epoch,
-        summary.last_epoch,
-        summary.message_count,
-        summary.user_message_count,
-        summary.assistant_message_count
-    )
-}
-
-fn document_covers_remem_summary(document: &Document, summary: &RememSessionSummary) -> bool {
-    let expected = remem_source_version(summary);
-    document.source_version() == Some(expected.as_str())
-}
-
-fn legacy_document_covers_remem_summary(
-    document: &Document,
-    summary: &RememSessionSummary,
-) -> bool {
-    // Legacy documents predate source_version. Keep their historical
-    // timestamp-based prefilter so a metadata migration cannot turn every
-    // legacy session into an LLM refresh. Canonical remem documents must use
-    // the exact source snapshot above instead.
-    document.updated_at().timestamp() >= summary.last_epoch
+fn content_source_version(provider: &str, raw_content: &str) -> String {
+    let digest = Sha256::digest(raw_content.as_bytes());
+    format!("{provider}:v2:sha256:{digest:x}")
 }
 
 fn document_with_source_version(document: &Document, source_version: &str) -> Document {
@@ -273,7 +252,6 @@ async fn handle_remem_ingest_sessions_with_summaries(
         .filter(|document| document.source() == "remem-raw-session")
         .map(|document| (document.url(), document))
         .collect();
-    let legacy_document_index = legacy_migration::legacy_document_index(&existing_documents);
     let mut claimed_legacy_documents = HashSet::new();
     let mut pending = Vec::new();
     let mut skipped_dup = 0usize;
@@ -283,27 +261,7 @@ async fn handle_remem_ingest_sessions_with_summaries(
 
     for (idx, summary) in summaries.into_iter().enumerate() {
         let url = summary.stable_document_url();
-        let source_version = remem_source_version(&summary);
         let existing_document = existing_remem_documents.get(url.as_str()).copied().cloned();
-        if existing_document
-            .as_ref()
-            .is_some_and(|document| document_covers_remem_summary(document, &summary))
-        {
-            skipped_dup += 1;
-            continue;
-        }
-        if existing_document.is_none() && summary.legacy_identity_is_unique {
-            let legacy_document = legacy_migration::matching_legacy_document_for_summary(
-                &legacy_document_index,
-                &summary,
-            )?;
-            if legacy_document
-                .is_some_and(|document| legacy_document_covers_remem_summary(document, &summary))
-            {
-                skipped_dup += 1;
-                continue;
-            }
-        }
         if summary.user_message_count < filter_config.min_user_messages as i64 {
             skipped_filter += 1;
             continue;
@@ -314,6 +272,7 @@ async fn handle_remem_ingest_sessions_with_summaries(
             .with_context(|| format!("failed to load full remem session for {url}"))?;
         fully_loaded += 1;
         let raw_content = remem_session.session.to_document_content();
+        let source_version = content_source_version("remem", &raw_content);
         let legacy_documents_to_delete = if legacy_identity_is_unique {
             legacy_migration::matching_legacy_document_ids(
                 &existing_documents,
@@ -500,6 +459,7 @@ async fn handle_legacy_ingest_sessions(
         let has_embedded_timestamp = session.meta.started_at.is_some();
         let captured_at = session_captured_at(session.meta.started_at, ds.modified_at);
         let raw_content = session.to_document_content();
+        let source_version = content_source_version("local", &raw_content);
         let remem_document = legacy_migration::matching_remem_document(
             &existing_documents,
             &ds.path,
@@ -517,12 +477,16 @@ async fn handle_legacy_ingest_sessions(
             if let Some(legacy_doc) = legacy_document.as_ref() {
                 legacy_documents_to_delete.push(legacy_doc.id().clone());
             }
-            if remem_doc.raw_content() == raw_content {
-                if options.dry_run && !legacy_documents_to_delete.is_empty() {
-                    println!(
-                        "  [dry-run] {} | would remove superseded legacy document",
-                        legacy_url
-                    );
+            if remem_doc.raw_content() == raw_content
+                || remem_doc.raw_content().starts_with(&raw_content)
+            {
+                if options.dry_run {
+                    if !legacy_documents_to_delete.is_empty() {
+                        println!(
+                            "  [dry-run] {} | would remove superseded legacy document",
+                            legacy_url
+                        );
+                    }
                 } else {
                     doc_store
                         .delete_documents_with_items(&legacy_documents_to_delete)
@@ -532,12 +496,18 @@ async fn handle_legacy_ingest_sessions(
                 skipped_dup += 1;
                 continue;
             }
-            stale_refresh += 1;
-            (
-                remem_doc.url().to_string(),
-                SessionSource::RememRaw,
-                Some(remem_doc),
-            )
+            // A local archive is never authoritative over a canonical remem
+            // document. If it is not a prefix/equal snapshot, keep it under
+            // its local identity instead of replacing remem data.
+            if let Some(existing_doc) = legacy_document.as_ref() {
+                if session_needs_refresh(existing_doc, ds.modified_at) {
+                    stale_refresh += 1;
+                } else {
+                    skipped_dup += 1;
+                    continue;
+                }
+            }
+            (legacy_url, ds.source.clone(), legacy_document)
         } else {
             if let Some(existing_doc) = legacy_document.as_ref() {
                 if session_needs_refresh(existing_doc, ds.modified_at) {
@@ -581,7 +551,7 @@ async fn handle_legacy_ingest_sessions(
             captured_at,
             has_embedded_timestamp,
             raw_content,
-            source_version: None,
+            source_version: Some(source_version),
             needs_chunk: !chunks.is_empty(),
             chunks,
             existing_document,
@@ -603,7 +573,7 @@ async fn handle_legacy_ingest_sessions(
     .await?;
 
     // Advance the incremental scan cursor so the next run only sees newer files.
-    if incremental {
+    if incremental && !options.dry_run {
         write_last_ingest_mtime(source.as_ref(), db_path, scan_start);
     }
 
@@ -632,12 +602,14 @@ async fn process_pending_sessions(
     }
 
     let mut quarantine = QuarantineStore::load()?;
-    let selected_urls: HashSet<String> =
-        pending.iter().map(|session| session.url.clone()).collect();
+    let selected_identities: HashSet<String> = pending
+        .iter()
+        .map(|session| quarantine_key(&session.url, session.source_version.as_deref()))
+        .collect();
     let mut skipped_quarantined = 0usize;
     if !retry_quarantined {
         pending.retain(|session| {
-            if quarantine.contains(&session.url) {
+            if quarantine.contains(&session.url, session.source_version.as_deref()) {
                 skipped_quarantined += 1;
                 false
             } else {
@@ -657,7 +629,7 @@ async fn process_pending_sessions(
         concurrency,
     );
     if pending.is_empty() {
-        let selected_quarantine_count = quarantine.count_matching(&selected_urls);
+        let selected_quarantine_count = quarantine.count_matching(&selected_identities);
         if selected_quarantine_count > 0 {
             anyhow::bail!(
                 "本次选择中仍有 {} 个会话处于隔离状态；队列: {}；确认上游策略已修复后使用 --retry-quarantined",
@@ -682,8 +654,10 @@ async fn process_pending_sessions(
     let failed = Arc::new(AtomicUsize::new(0));
     let total_items = Arc::new(AtomicUsize::new(0));
     let quota_hit = Arc::new(AtomicBool::new(false));
-    let succeeded_urls = Arc::new(Mutex::new(HashSet::<String>::new()));
-    let rejected_sessions = Arc::new(Mutex::new(Vec::<(String, String, String)>::new()));
+    let succeeded_sessions = Arc::new(Mutex::new(HashSet::<(String, Option<String>)>::new()));
+    let rejected_sessions = Arc::new(Mutex::new(
+        Vec::<(String, Option<String>, String, String)>::new(),
+    ));
     let mut handles = Vec::new();
 
     for ps in pending {
@@ -694,7 +668,7 @@ async fn process_pending_sessions(
         let failed = failed.clone();
         let total_items = total_items.clone();
         let quota_hit = quota_hit.clone();
-        let succeeded_urls = succeeded_urls.clone();
+        let succeeded_sessions = succeeded_sessions.clone();
         let rejected_sessions = rejected_sessions.clone();
         handles.push(tokio::spawn(async move {
             let _permit = sem.acquire().await.expect("semaphore closed");
@@ -702,10 +676,10 @@ async fn process_pending_sessions(
                 Ok(item_count) => {
                     processed.fetch_add(1, Ordering::Relaxed);
                     total_items.fetch_add(item_count, Ordering::Relaxed);
-                    succeeded_urls
+                    succeeded_sessions
                         .lock()
                         .expect("succeeded URL lock poisoned")
-                        .insert(ps.url.clone());
+                        .insert((ps.url.clone(), ps.source_version.clone()));
                 }
                 Err(error) => {
                     if let Some((code, message)) = content_rejection(&error) {
@@ -719,7 +693,7 @@ async fn process_pending_sessions(
                         rejected_sessions
                             .lock()
                             .expect("rejected session lock poisoned")
-                            .push((ps.url.clone(), code, message));
+                            .push((ps.url.clone(), ps.source_version.clone(), code, message));
                     } else {
                         eprintln!("  ✗ [{}/{}] 失败: {}", ps.idx + 1, ps.total, error);
                         failed.fetch_add(1, Ordering::Relaxed);
@@ -736,7 +710,7 @@ async fn process_pending_sessions(
     let processed = processed.load(Ordering::Relaxed);
     let failed = failed.load(Ordering::Relaxed);
     let total_items = total_items.load(Ordering::Relaxed);
-    for url in succeeded_urls
+    for (url, _) in succeeded_sessions
         .lock()
         .expect("succeeded URL lock poisoned")
         .iter()
@@ -746,14 +720,14 @@ async fn process_pending_sessions(
     let rejected = rejected_sessions
         .lock()
         .expect("rejected session lock poisoned");
-    for (url, code, message) in rejected.iter() {
-        quarantine.record(url, code, message);
+    for (url, source_version, code, message) in rejected.iter() {
+        quarantine.record(url, source_version.as_deref(), code, message);
     }
     let rejected_count = rejected.len();
     drop(rejected);
     quarantine.save_if_dirty()?;
     let quarantine_count = quarantine.len();
-    let selected_quarantine_count = quarantine.count_matching(&selected_urls);
+    let selected_quarantine_count = quarantine.count_matching(&selected_identities);
     println!(
         "\n完成: 处理 {}, 跳过重复 {}, 过滤 {}, 刷新过期 {}, 失败 {}, 新增隔离 {}, 本次相关隔离 {}, 隔离总数 {}, 生成 {} 条观测",
         processed,

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -81,6 +81,7 @@ struct PendingSession {
     captured_at: DateTime<Utc>,
     has_embedded_timestamp: bool,
     raw_content: String,
+    source_version: Option<String>,
     needs_chunk: bool,
     chunks: Vec<String>,
     existing_document: Option<Document>,
@@ -108,8 +109,20 @@ fn session_needs_refresh(existing_doc: &Document, file_modified_at: SystemTime) 
     file_modified_at > existing_doc.updated_at()
 }
 
-fn document_covers_remem_summary(document: &Document, last_epoch: i64) -> bool {
-    document.updated_at().timestamp() >= last_epoch
+fn remem_source_version(summary: &RememSessionSummary) -> String {
+    format!(
+        "remem:v1:{}:{}:{}:{}:{}",
+        summary.first_epoch,
+        summary.last_epoch,
+        summary.message_count,
+        summary.user_message_count,
+        summary.assistant_message_count
+    )
+}
+
+fn document_covers_remem_summary(document: &Document, summary: &RememSessionSummary) -> bool {
+    let expected = remem_source_version(summary);
+    document.source_version() == Some(expected.as_str())
 }
 
 fn incremental_cursor_path(home: &Path, source: Option<&SessionSource>, db_path: &Path) -> PathBuf {
@@ -245,10 +258,11 @@ async fn handle_remem_ingest_sessions_with_summaries(
 
     for (idx, summary) in summaries.into_iter().enumerate() {
         let url = summary.stable_document_url();
+        let source_version = remem_source_version(&summary);
         let existing_document = existing_remem_documents.get(url.as_str()).copied().cloned();
         if existing_document
             .as_ref()
-            .is_some_and(|document| document_covers_remem_summary(document, summary.last_epoch))
+            .is_some_and(|document| document_covers_remem_summary(document, &summary))
         {
             skipped_dup += 1;
             continue;
@@ -259,7 +273,7 @@ async fn handle_remem_ingest_sessions_with_summaries(
                 &summary,
             )?;
             if legacy_document
-                .is_some_and(|document| document_covers_remem_summary(document, summary.last_epoch))
+                .is_some_and(|document| document_covers_remem_summary(document, &summary))
             {
                 skipped_dup += 1;
                 continue;
@@ -271,7 +285,6 @@ async fn handle_remem_ingest_sessions_with_summaries(
         }
 
         let legacy_identity_is_unique = summary.legacy_identity_is_unique;
-        let last_epoch = summary.last_epoch;
         let remem_session = load_remem_session(summary)
             .with_context(|| format!("failed to load full remem session for {url}"))?;
         fully_loaded += 1;
@@ -286,7 +299,6 @@ async fn handle_remem_ingest_sessions_with_summaries(
             &existing_documents,
             &remem_session,
             &raw_content,
-            last_epoch,
         ) {
             skipped_dup += 1;
             continue;
@@ -309,6 +321,14 @@ async fn handle_remem_ingest_sessions_with_summaries(
                         legacy_documents_to_delete.len()
                     );
                 } else {
+                    if existing_doc.source_version() != Some(source_version.as_str()) {
+                        let mut versioned_document = existing_doc.clone();
+                        versioned_document.set_source_version(Some(&source_version));
+                        doc_store
+                            .save(&versioned_document)
+                            .await
+                            .context("save remem source snapshot metadata")?;
+                    }
                     doc_store
                         .delete_documents_with_items(&legacy_documents_to_delete)
                         .await
@@ -360,6 +380,7 @@ async fn handle_remem_ingest_sessions_with_summaries(
             captured_at,
             has_embedded_timestamp: true,
             raw_content,
+            source_version: Some(source_version),
             needs_chunk: !chunks.is_empty(),
             chunks,
             existing_document,
@@ -530,6 +551,7 @@ async fn handle_legacy_ingest_sessions(
             captured_at,
             has_embedded_timestamp,
             raw_content,
+            source_version: None,
             needs_chunk: !chunks.is_empty(),
             chunks,
             existing_document,
@@ -580,6 +602,8 @@ async fn process_pending_sessions(
     }
 
     let mut quarantine = QuarantineStore::load()?;
+    let selected_urls: HashSet<String> =
+        pending.iter().map(|session| session.url.clone()).collect();
     let mut skipped_quarantined = 0usize;
     if !retry_quarantined {
         pending.retain(|session| {
@@ -603,14 +627,22 @@ async fn process_pending_sessions(
         concurrency,
     );
     if pending.is_empty() {
-        if quarantine.len() > 0 {
+        let selected_quarantine_count = quarantine.count_matching(&selected_urls);
+        if selected_quarantine_count > 0 {
             anyhow::bail!(
-                "仍有 {} 个会话处于隔离状态；队列: {}；确认上游策略已修复后使用 --retry-quarantined",
-                quarantine.len(),
+                "本次选择中仍有 {} 个会话处于隔离状态；队列: {}；确认上游策略已修复后使用 --retry-quarantined",
+                selected_quarantine_count,
                 quarantine.path().display()
             );
         }
-        println!("全部已处理完毕，隔离队列为空。");
+        if quarantine.len() > 0 {
+            println!(
+                "全部已处理完毕；隔离队列另有 {} 个不在本次选择范围内的记录。",
+                quarantine.len()
+            );
+        } else {
+            println!("全部已处理完毕，隔离队列为空。");
+        }
         return Ok(());
     }
 
@@ -691,29 +723,35 @@ async fn process_pending_sessions(
     drop(rejected);
     quarantine.save_if_dirty()?;
     let quarantine_count = quarantine.len();
+    let selected_quarantine_count = quarantine.count_matching(&selected_urls);
     println!(
-        "\n完成: 处理 {}, 跳过重复 {}, 过滤 {}, 刷新过期 {}, 失败 {}, 新增隔离 {}, 隔离总数 {}, 生成 {} 条观测",
+        "\n完成: 处理 {}, 跳过重复 {}, 过滤 {}, 刷新过期 {}, 失败 {}, 新增隔离 {}, 本次相关隔离 {}, 隔离总数 {}, 生成 {} 条观测",
         processed,
         skipped_dup,
         skipped_filter,
         stale_refresh,
         failed,
         rejected_count,
+        selected_quarantine_count,
         quarantine_count,
         total_items
     );
-    if failed > 0 || quarantine_count > 0 {
+    if failed > 0 || selected_quarantine_count > 0 {
         if failed > 0 {
             eprintln!("提示: 瞬态失败会在下次运行续传");
         }
-        if quarantine_count > 0 {
+        if selected_quarantine_count > 0 {
             eprintln!(
-                "提示: {} 个确定性拒绝已隔离，不会自动重试；队列: {}",
-                quarantine_count,
+                "提示: 本次选择中的 {} 个确定性拒绝已隔离，不会自动重试；队列: {}",
+                selected_quarantine_count,
                 quarantine.path().display()
             );
         }
-        anyhow::bail!("摄入不完整: 瞬态失败 {}, 隔离 {}", failed, quarantine_count);
+        anyhow::bail!(
+            "摄入不完整: 瞬态失败 {}, 本次相关隔离 {}",
+            failed,
+            selected_quarantine_count
+        );
     }
     Ok(())
 }
@@ -790,6 +828,7 @@ fn build_session_document(ps: &PendingSession, title: &str) -> Document {
             raw_content: ps.raw_content.clone(),
             source: ps.source.as_str().to_string(),
             url: ps.url.clone(),
+            source_version: ps.source_version.clone(),
             captured_at,
             created_at: existing_doc.created_at(),
             updated_at: Utc::now(),
@@ -799,6 +838,7 @@ fn build_session_document(ps: &PendingSession, title: &str) -> Document {
     let mut doc = Document::new(ps.source.as_str(), &ps.raw_content);
     doc.set_title(title);
     doc.set_url(&ps.url);
+    doc.set_source_version(ps.source_version.as_deref());
     doc.set_captured_at(ps.captured_at);
     doc
 }

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -273,29 +273,32 @@ async fn handle_remem_ingest_sessions_with_summaries(
         fully_loaded += 1;
         let raw_content = remem_session.session.to_document_content();
         let source_version = content_source_version("remem", &raw_content);
-        let legacy_documents_to_delete = if legacy_identity_is_unique {
+        let mut legacy_documents_to_delete = if legacy_identity_is_unique {
             legacy_migration::matching_legacy_document_ids(
                 &existing_documents,
                 &remem_session,
                 &raw_content,
             )?
-        } else if legacy_migration::legacy_document_covers_nonunique_summary(
-            &existing_documents,
-            &remem_session,
-            &raw_content,
-        ) {
-            skipped_dup += 1;
-            continue;
+        } else if let Some(document_id) =
+            legacy_migration::legacy_document_covering_nonunique_summary(
+                &existing_documents,
+                &remem_session,
+                &raw_content,
+            )
+        {
+            if legacy_migration::claim_legacy_coverage_once(
+                &mut claimed_legacy_documents,
+                Some(document_id),
+            ) {
+                skipped_dup += 1;
+                continue;
+            }
+            Vec::new()
         } else {
             Vec::new()
         };
-        for document_id in &legacy_documents_to_delete {
-            if !claimed_legacy_documents.insert(document_id.clone()) {
-                anyhow::bail!(
-                    "legacy document {document_id} matched more than one remem tuple; refusing destructive cleanup"
-                );
-            }
-        }
+        legacy_documents_to_delete
+            .retain(|document_id| claimed_legacy_documents.insert(document_id.clone()));
         if let Some(existing_doc) = existing_document.as_ref() {
             if existing_doc.raw_content() == raw_content {
                 if options.dry_run {

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -125,6 +125,20 @@ fn document_covers_remem_summary(document: &Document, summary: &RememSessionSumm
     document.source_version() == Some(expected.as_str())
 }
 
+fn document_with_source_version(document: &Document, source_version: &str) -> Document {
+    Document::restore(RestoreDocumentParams {
+        id: document.id().clone(),
+        title: document.title().map(ToOwned::to_owned),
+        raw_content: document.raw_content().to_string(),
+        source: document.source().to_string(),
+        url: document.url().to_string(),
+        source_version: Some(source_version.to_string()),
+        captured_at: document.captured_at(),
+        created_at: document.created_at(),
+        updated_at: document.updated_at(),
+    })
+}
+
 fn incremental_cursor_path(home: &Path, source: Option<&SessionSource>, db_path: &Path) -> PathBuf {
     let source_key = match source {
         Some(SessionSource::ClaudeCode) => "claude-code",
@@ -322,8 +336,8 @@ async fn handle_remem_ingest_sessions_with_summaries(
                     );
                 } else {
                     if existing_doc.source_version() != Some(source_version.as_str()) {
-                        let mut versioned_document = existing_doc.clone();
-                        versioned_document.set_source_version(Some(&source_version));
+                        let versioned_document =
+                            document_with_source_version(existing_doc, &source_version);
                         doc_store
                             .save(&versioned_document)
                             .await

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -6,7 +6,10 @@ use crate::remem_sessions::load_remem_sessions;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use refine_core::error::InfraError;
-use refine_core::infra::{llm_with_retry_policy, LlmClient, LlmRetryPolicy};
+use refine_core::infra::{
+    llm_with_retry_policy, LlmClient, LlmRetryPolicy, DEFAULT_MAX_RETRIES,
+    DEFAULT_RETRY_BASE_DELAY_SECS,
+};
 use refine_core::knowledge::{Document, DocumentRepository, RestoreDocumentParams};
 use refine_core::session::{
     build_facet_prompt, chunk_session, discover_sessions, facets_to_items, needs_chunking,
@@ -606,12 +609,10 @@ async fn llm_call_with_retry(
         LlmRetryPolicy::default(),
         |attempt, max_retries, delay_secs, err| {
             let message = err.to_string();
+            let preview = log_preview(&message, 80);
             eprintln!(
                 "    ⏳ 重试 ({}/{}) 等待 {}s: {}",
-                attempt,
-                max_retries,
-                delay_secs,
-                &message[..message.len().min(80)],
+                attempt, max_retries, delay_secs, preview,
             );
         },
     )
@@ -634,8 +635,61 @@ async fn extract_and_parse_facets_with_retry(
     client: &Arc<dyn LlmClient>,
     quota_hit: &Arc<AtomicBool>,
 ) -> Result<refine_core::session::FacetResponse> {
-    let response = llm_call_with_retry(client, content, quota_hit).await?;
-    parse_facet_response(&response).map_err(|e| anyhow::anyhow!(e))
+    extract_and_parse_facets_with_retry_policy(
+        content,
+        client,
+        quota_hit,
+        DEFAULT_MAX_RETRIES,
+        DEFAULT_RETRY_BASE_DELAY_SECS,
+    )
+    .await
+}
+
+async fn extract_and_parse_facets_with_retry_policy(
+    content: &str,
+    client: &Arc<dyn LlmClient>,
+    quota_hit: &Arc<AtomicBool>,
+    max_retries: usize,
+    base_delay_secs: u64,
+) -> Result<refine_core::session::FacetResponse> {
+    let max_retries = max_retries.max(1);
+
+    for attempt in 0..max_retries {
+        let response = llm_call_with_retry(client, content, quota_hit).await?;
+        match parse_facet_response(&response) {
+            Ok(facets) => return Ok(facets),
+            Err(err) if attempt == max_retries - 1 => return Err(anyhow::anyhow!(err)),
+            Err(err) => {
+                let delay_secs = ingest_retry_delay_secs(base_delay_secs, attempt);
+                eprintln!(
+                    "    ⏳ 解析重试 ({}/{}) 等待 {}s: {}",
+                    attempt + 1,
+                    max_retries,
+                    delay_secs,
+                    log_preview(&err, 80),
+                );
+                if delay_secs > 0 {
+                    tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+                }
+            }
+        }
+    }
+
+    unreachable!("parse retry loop always returns on success or failure")
+}
+
+fn ingest_retry_delay_secs(base_delay_secs: u64, attempt: usize) -> u64 {
+    let backoff_factor = 1u64.checked_shl(attempt as u32).unwrap_or(u64::MAX);
+    base_delay_secs.saturating_mul(backoff_factor)
+}
+
+fn log_preview(message: &str, max_chars: usize) -> String {
+    let mut chars = message.chars();
+    let mut preview: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        preview.push_str("...");
+    }
+    preview
 }
 
 #[cfg(test)]

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -2,7 +2,7 @@
 //!
 //! 默认从 remem raw archive 读取；支持可配置并发、断点续传和 API 限流重试
 
-use crate::remem_sessions::load_remem_sessions;
+use crate::remem_sessions::{load_remem_session, load_remem_session_summaries};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use refine_core::error::InfraError;
@@ -15,7 +15,7 @@ use refine_core::session::{
     build_facet_prompt, chunk_session, discover_sessions, facets_to_items, needs_chunking,
     parse_facet_response, parse_session_file, FilterConfig, SessionSource, FACET_SYSTEM_PROMPT,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -82,6 +82,10 @@ fn session_captured_at(
 fn session_needs_refresh(existing_doc: &Document, file_modified_at: SystemTime) -> bool {
     let file_modified_at = DateTime::<Utc>::from(file_modified_at);
     file_modified_at > existing_doc.updated_at()
+}
+
+fn document_covers_remem_summary(document: &Document, last_epoch: i64) -> bool {
+    document.updated_at().timestamp() >= last_epoch
 }
 
 fn incremental_cursor_path(home: &Path, source: Option<&SessionSource>, db_path: &Path) -> PathBuf {
@@ -154,28 +158,68 @@ async fn handle_remem_ingest_sessions(
         );
     }
 
-    let sessions = load_remem_sessions(options.limit, options.latest)
-        .context("failed to load sessions from remem")?;
-    println!("remem 返回 {} 个会话", sessions.len());
+    let summaries = load_remem_session_summaries(options.limit, options.latest)
+        .context("failed to load session summaries from remem")?;
+    println!("remem 返回 {} 个会话摘要", summaries.len());
 
-    let total = sessions.len();
+    let total = summaries.len();
     let filter_config = FilterConfig::default();
     let document_count = doc_store.count().await?;
     let existing_documents = doc_store.find_recent(0, document_count).await?;
+    let existing_remem_documents: HashMap<&str, &Document> = existing_documents
+        .iter()
+        .filter(|document| document.source() == "remem-raw-session")
+        .map(|document| (document.url(), document))
+        .collect();
+    let legacy_document_index = legacy_migration::legacy_document_index(&existing_documents);
     let mut claimed_legacy_documents = HashSet::new();
     let mut pending = Vec::new();
     let mut skipped_dup = 0usize;
     let mut skipped_filter = 0usize;
     let mut stale_refresh = 0usize;
+    let mut fully_loaded = 0usize;
 
-    for (idx, remem_session) in sessions.into_iter().enumerate() {
-        let url = remem_session.stable_document_url();
+    for (idx, summary) in summaries.into_iter().enumerate() {
+        let url = summary.stable_document_url();
+        let existing_document = existing_remem_documents.get(url.as_str()).copied().cloned();
+        if existing_document
+            .as_ref()
+            .is_some_and(|document| document_covers_remem_summary(document, summary.last_epoch))
+        {
+            skipped_dup += 1;
+            continue;
+        }
+        if existing_document.is_none() && summary.legacy_identity_is_unique {
+            let legacy_document = legacy_migration::matching_legacy_document_for_summary(
+                &legacy_document_index,
+                &summary,
+            )?;
+            if legacy_document
+                .is_some_and(|document| document_covers_remem_summary(document, summary.last_epoch))
+            {
+                skipped_dup += 1;
+                continue;
+            }
+        }
+        if summary.user_message_count < filter_config.min_user_messages as i64 {
+            skipped_filter += 1;
+            continue;
+        }
+
+        let legacy_identity_is_unique = summary.legacy_identity_is_unique;
+        let remem_session = load_remem_session(summary)
+            .with_context(|| format!("failed to load full remem session for {url}"))?;
+        fully_loaded += 1;
         let raw_content = remem_session.session.to_document_content();
-        let legacy_documents_to_delete = legacy_migration::matching_legacy_document_ids(
-            &existing_documents,
-            &remem_session,
-            &raw_content,
-        )?;
+        let legacy_documents_to_delete = if legacy_identity_is_unique {
+            legacy_migration::matching_legacy_document_ids(
+                &existing_documents,
+                &remem_session,
+                &raw_content,
+            )?
+        } else {
+            Vec::new()
+        };
         for document_id in &legacy_documents_to_delete {
             if !claimed_legacy_documents.insert(document_id.clone()) {
                 anyhow::bail!(
@@ -183,7 +227,6 @@ async fn handle_remem_ingest_sessions(
                 );
             }
         }
-        let existing_document = doc_store.find_by_url(&url).await?;
         if let Some(existing_doc) = existing_document.as_ref() {
             if existing_doc.raw_content() == raw_content {
                 if options.dry_run && !legacy_documents_to_delete.is_empty() {
@@ -250,6 +293,8 @@ async fn handle_remem_ingest_sessions(
             legacy_documents_to_delete,
         });
     }
+
+    println!("摘要预筛选后拉取了 {fully_loaded}/{total} 个完整会话");
 
     process_pending_sessions(
         pending,

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -207,6 +207,7 @@ async fn handle_remem_ingest_sessions(
         }
 
         let legacy_identity_is_unique = summary.legacy_identity_is_unique;
+        let last_epoch = summary.last_epoch;
         let remem_session = load_remem_session(summary)
             .with_context(|| format!("failed to load full remem session for {url}"))?;
         fully_loaded += 1;
@@ -217,6 +218,14 @@ async fn handle_remem_ingest_sessions(
                 &remem_session,
                 &raw_content,
             )?
+        } else if legacy_migration::legacy_document_covers_nonunique_summary(
+            &existing_documents,
+            &remem_session,
+            &raw_content,
+            last_epoch,
+        ) {
+            skipped_dup += 1;
+            continue;
         } else {
             Vec::new()
         };

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -125,6 +125,17 @@ fn document_covers_remem_summary(document: &Document, summary: &RememSessionSumm
     document.source_version() == Some(expected.as_str())
 }
 
+fn legacy_document_covers_remem_summary(
+    document: &Document,
+    summary: &RememSessionSummary,
+) -> bool {
+    // Legacy documents predate source_version. Keep their historical
+    // timestamp-based prefilter so a metadata migration cannot turn every
+    // legacy session into an LLM refresh. Canonical remem documents must use
+    // the exact source snapshot above instead.
+    document.updated_at().timestamp() >= summary.last_epoch
+}
+
 fn document_with_source_version(document: &Document, source_version: &str) -> Document {
     Document::restore(RestoreDocumentParams {
         id: document.id().clone(),
@@ -287,7 +298,7 @@ async fn handle_remem_ingest_sessions_with_summaries(
                 &summary,
             )?;
             if legacy_document
-                .is_some_and(|document| document_covers_remem_summary(document, &summary))
+                .is_some_and(|document| legacy_document_covers_remem_summary(document, &summary))
             {
                 skipped_dup += 1;
                 continue;
@@ -328,12 +339,17 @@ async fn handle_remem_ingest_sessions_with_summaries(
         }
         if let Some(existing_doc) = existing_document.as_ref() {
             if existing_doc.raw_content() == raw_content {
-                if options.dry_run && !legacy_documents_to_delete.is_empty() {
-                    println!(
-                        "  [dry-run] {} | would remove {} superseded legacy document(s)",
-                        url,
-                        legacy_documents_to_delete.len()
-                    );
+                if options.dry_run {
+                    if existing_doc.source_version() != Some(source_version.as_str()) {
+                        println!("  [dry-run] {url} | would backfill source snapshot metadata");
+                    }
+                    if !legacy_documents_to_delete.is_empty() {
+                        println!(
+                            "  [dry-run] {} | would remove {} superseded legacy document(s)",
+                            url,
+                            legacy_documents_to_delete.len()
+                        );
+                    }
                 } else {
                     if existing_doc.source_version() != Some(source_version.as_str()) {
                         let versioned_document =

--- a/apps/cli/src/ingest_sessions/legacy_migration.rs
+++ b/apps/cli/src/ingest_sessions/legacy_migration.rs
@@ -90,15 +90,12 @@ pub(super) fn legacy_document_covers_nonunique_summary(
     documents: &[Document],
     remem_session: &RememSession,
     raw_content: &str,
-    last_epoch: i64,
 ) -> bool {
     remem_session.source_root == LOCAL_SOURCE_ROOT
         && documents.iter().any(|document| {
             LEGACY_SOURCES.contains(&document.source())
                 && url_matches_session_id(document.url(), &remem_session.session_id)
-                && (document.raw_content() == raw_content
-                    || (content_matches(document.raw_content(), raw_content)
-                        && document.updated_at().timestamp() >= last_epoch))
+                && document.raw_content() == raw_content
         })
 }
 
@@ -247,6 +244,7 @@ mod tests {
             raw_content: content.to_string(),
             source: source.to_string(),
             url: url.to_string(),
+            source_version: None,
             captured_at,
             created_at: original.created_at(),
             updated_at: original.updated_at(),
@@ -326,19 +324,16 @@ mod tests {
             &documents,
             &remem("local", "session-1"),
             "same",
-            i64::MAX,
         ));
         assert!(!legacy_document_covers_nonunique_summary(
             &documents,
             &remem("local", "session-1"),
             "same plus append",
-            i64::MAX,
         ));
         assert!(!legacy_document_covers_nonunique_summary(
             &documents,
             &remem("remote", "session-1"),
             "same",
-            10,
         ));
     }
 

--- a/apps/cli/src/ingest_sessions/legacy_migration.rs
+++ b/apps/cli/src/ingest_sessions/legacy_migration.rs
@@ -1,13 +1,49 @@
-use crate::remem_sessions::RememSession;
+use crate::remem_sessions::{RememSession, RememSessionSummary};
 use anyhow::{bail, Result};
 use chrono::{DateTime, Utc};
 use refine_core::knowledge::{Document, DocumentId};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 const LOCAL_SOURCE_ROOT: &str = "local";
 const LOCAL_SOURCE_ROOT_HEX: &str = "6c6f63616c";
 const LEGACY_SOURCES: [&str; 2] = ["claude-code-session", "codex-session"];
+
+pub(super) fn legacy_document_index(documents: &[Document]) -> HashMap<String, Vec<&Document>> {
+    let mut index = HashMap::new();
+    for document in documents
+        .iter()
+        .filter(|document| LEGACY_SOURCES.contains(&document.source()))
+    {
+        for session_id in session_id_candidates(Path::new(document.url())) {
+            index
+                .entry(session_id)
+                .or_insert_with(Vec::new)
+                .push(document);
+        }
+    }
+    index
+}
+
+pub(super) fn matching_legacy_document_for_summary<'doc>(
+    index: &HashMap<String, Vec<&'doc Document>>,
+    summary: &RememSessionSummary,
+) -> Result<Option<&'doc Document>> {
+    if summary.source_root != LOCAL_SOURCE_ROOT {
+        return Ok(None);
+    }
+    match index.get(&summary.session_id).map(Vec::as_slice) {
+        None | Some([]) => Ok(None),
+        Some([document]) => Ok(Some(*document)),
+        Some(matches) => bail!(
+            "ambiguous legacy filename identity for remem tuple ({:?}, {:?}, {:?}): {} candidates",
+            summary.source_root,
+            summary.project,
+            summary.session_id,
+            matches.len()
+        ),
+    }
+}
 
 pub(super) fn matching_legacy_document_ids(
     documents: &[Document],
@@ -148,7 +184,8 @@ fn session_id_candidates(path: &Path) -> Vec<String> {
     let mut candidates = vec![stem.to_string()];
     if stem.len() >= 36 {
         let suffix = &stem[stem.len() - 36..];
-        if suffix.as_bytes().get(8) == Some(&b'-')
+        if suffix != stem
+            && suffix.as_bytes().get(8) == Some(&b'-')
             && suffix.as_bytes().get(13) == Some(&b'-')
             && suffix.as_bytes().get(18) == Some(&b'-')
             && suffix.as_bytes().get(23) == Some(&b'-')
@@ -215,6 +252,55 @@ mod tests {
         }
     }
 
+    fn summary(source_root: &str, session_id: &str) -> RememSessionSummary {
+        RememSessionSummary {
+            source_root: source_root.to_string(),
+            project: "/repo".to_string(),
+            session_id: session_id.to_string(),
+            first_epoch: 10,
+            last_epoch: 20,
+            message_count: 2,
+            user_message_count: 1,
+            assistant_message_count: 1,
+            user_message_samples: Vec::new(),
+            legacy_identity_is_unique: true,
+        }
+    }
+
+    #[test]
+    fn summary_lookup_uses_unique_legacy_filename_without_content_loading() {
+        let session_id = "12345678-1234-1234-1234-123456789abc";
+        let legacy = document(
+            "codex-session",
+            &format!("/tmp/rollout-prefix-{session_id}.jsonl"),
+            "old",
+            10,
+        );
+        let documents = vec![legacy.clone()];
+        let index = legacy_document_index(&documents);
+
+        let matched =
+            matching_legacy_document_for_summary(&index, &summary(LOCAL_SOURCE_ROOT, session_id))
+                .unwrap()
+                .unwrap();
+        assert_eq!(matched.id(), legacy.id());
+        assert!(
+            matching_legacy_document_for_summary(&index, &summary("remote", session_id))
+                .unwrap()
+                .is_none()
+        );
+
+        let exact = document(
+            "claude-code-session",
+            &format!("/tmp/{session_id}.jsonl"),
+            "old",
+            10,
+        );
+        let exact_documents = vec![exact];
+        let exact_index = legacy_document_index(&exact_documents);
+        assert_eq!(exact_index.get(session_id).unwrap().len(), 1);
+    }
+
     #[test]
     fn matches_local_filename_or_epoch_content_but_not_remote() {
         let filename = document("claude-code-session", "/tmp/session-1.jsonl", "old", 5);
@@ -227,7 +313,7 @@ mod tests {
         assert_eq!(matched, vec![filename.id().clone()]);
 
         let matched = matching_legacy_document_ids(
-            &[epoch.clone()],
+            std::slice::from_ref(&epoch),
             &remem("local", "canonical-id"),
             "prefix plus append",
         )
@@ -274,7 +360,7 @@ mod tests {
             "/tmp/rollout-2026-07-20T00-00-00-12345678-1234-1234-1234-123456789abc.jsonl",
         );
         let matched = matching_remem_document(
-            &[remem_doc.clone()],
+            std::slice::from_ref(&remem_doc),
             path,
             Utc.timestamp_opt(10, 0).unwrap(),
             raw,

--- a/apps/cli/src/ingest_sessions/legacy_migration.rs
+++ b/apps/cli/src/ingest_sessions/legacy_migration.rs
@@ -92,17 +92,28 @@ pub(super) fn matching_legacy_document_ids(
     Ok(Vec::new())
 }
 
-pub(super) fn legacy_document_covers_nonunique_summary(
+pub(super) fn legacy_document_covering_nonunique_summary(
     documents: &[Document],
     remem_session: &RememSession,
     raw_content: &str,
-) -> bool {
-    remem_session.source_root == LOCAL_SOURCE_ROOT
-        && documents.iter().any(|document| {
-            LEGACY_SOURCES.contains(&document.source())
-                && url_matches_session_id(document.url(), &remem_session.session_id)
-                && document.raw_content() == raw_content
+) -> Option<DocumentId> {
+    (remem_session.source_root == LOCAL_SOURCE_ROOT)
+        .then(|| {
+            documents.iter().find(|document| {
+                LEGACY_SOURCES.contains(&document.source())
+                    && url_matches_session_id(document.url(), &remem_session.session_id)
+                    && document.raw_content() == raw_content
+            })
         })
+        .flatten()
+        .map(|document| document.id().clone())
+}
+
+pub(super) fn claim_legacy_coverage_once(
+    claimed: &mut HashSet<DocumentId>,
+    document_id: Option<DocumentId>,
+) -> bool {
+    document_id.is_some_and(|document_id| claimed.insert(document_id))
 }
 
 fn unique_match(matches: Vec<&Document>, remem_session: &RememSession) -> Result<Vec<DocumentId>> {
@@ -326,21 +337,40 @@ mod tests {
         let legacy = document("codex-session", "/tmp/session-1.jsonl", "same", 10);
         let documents = vec![legacy];
 
-        assert!(legacy_document_covers_nonunique_summary(
+        assert!(legacy_document_covering_nonunique_summary(
             &documents,
             &remem("local", "session-1"),
             "same",
-        ));
-        assert!(!legacy_document_covers_nonunique_summary(
+        )
+        .is_some());
+        assert!(legacy_document_covering_nonunique_summary(
             &documents,
             &remem("local", "session-1"),
             "same plus append",
-        ));
-        assert!(!legacy_document_covers_nonunique_summary(
+        )
+        .is_none());
+        assert!(legacy_document_covering_nonunique_summary(
             &documents,
             &remem("remote", "session-1"),
             "same",
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn nonunique_legacy_coverage_can_only_be_claimed_once() {
+        let legacy = document("codex-session", "/tmp/session-1.jsonl", "same", 10);
+        let mut claimed = HashSet::new();
+
+        assert!(claim_legacy_coverage_once(
+            &mut claimed,
+            Some(legacy.id().clone())
         ));
+        assert!(!claim_legacy_coverage_once(
+            &mut claimed,
+            Some(legacy.id().clone())
+        ));
+        assert!(!claim_legacy_coverage_once(&mut claimed, None));
     }
 
     #[test]

--- a/apps/cli/src/ingest_sessions/legacy_migration.rs
+++ b/apps/cli/src/ingest_sessions/legacy_migration.rs
@@ -1,14 +1,19 @@
-use crate::remem_sessions::{RememSession, RememSessionSummary};
+use crate::remem_sessions::RememSession;
+#[cfg(test)]
+use crate::remem_sessions::RememSessionSummary;
 use anyhow::{bail, Result};
 use chrono::{DateTime, Utc};
 use refine_core::knowledge::{Document, DocumentId};
-use std::collections::{HashMap, HashSet};
+#[cfg(test)]
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::Path;
 
 const LOCAL_SOURCE_ROOT: &str = "local";
 const LOCAL_SOURCE_ROOT_HEX: &str = "6c6f63616c";
 const LEGACY_SOURCES: [&str; 2] = ["claude-code-session", "codex-session"];
 
+#[cfg(test)]
 pub(super) fn legacy_document_index(documents: &[Document]) -> HashMap<String, Vec<&Document>> {
     let mut index = HashMap::new();
     for document in documents
@@ -25,6 +30,7 @@ pub(super) fn legacy_document_index(documents: &[Document]) -> HashMap<String, V
     index
 }
 
+#[cfg(test)]
 pub(super) fn matching_legacy_document_for_summary<'doc>(
     index: &HashMap<String, Vec<&'doc Document>>,
     summary: &RememSessionSummary,
@@ -145,7 +151,7 @@ pub(super) fn matching_remem_document(
             session_ids
                 .iter()
                 .any(|session_id| document.url().ends_with(&hex_component(session_id)))
-                && contents_overlap(document.raw_content(), raw_content)
+                && canonical_contains_local(document.raw_content(), raw_content)
         })
         .collect();
     if !url_and_content.is_empty() {
@@ -157,7 +163,7 @@ pub(super) fn matching_remem_document(
         .copied()
         .filter(|document| {
             document.captured_at().timestamp() == captured_at.timestamp()
-                && contents_overlap(document.raw_content(), raw_content)
+                && canonical_contains_local(document.raw_content(), raw_content)
         })
         .collect();
     unique_remem_match(epoch_and_content, legacy_path)
@@ -217,8 +223,8 @@ fn hex_component(value: &str) -> String {
         .collect()
 }
 
-fn contents_overlap(left: &str, right: &str) -> bool {
-    left == right || left.starts_with(right) || right.starts_with(left)
+fn canonical_contains_local(canonical: &str, local: &str) -> bool {
+    canonical == local || canonical.starts_with(local)
 }
 
 fn is_local_remem_url(url: &str) -> bool {
@@ -404,6 +410,33 @@ mod tests {
         .unwrap()
         .unwrap();
         assert_eq!(matched.id(), remem_doc.id());
+    }
+
+    #[test]
+    fn longer_local_snapshot_cannot_claim_or_overwrite_canonical_remem() {
+        let session_id = "12345678-1234-1234-1234-123456789abc";
+        let remem_doc = document(
+            "remem-raw-session",
+            &format!(
+                "remem-raw://v1/{}/{}/{}",
+                LOCAL_SOURCE_ROOT_HEX,
+                hex_component("/repo"),
+                hex_component(session_id)
+            ),
+            "User: canonical prefix\n",
+            10,
+        );
+        let path = Path::new(
+            "/tmp/rollout-2026-07-20T00-00-00-12345678-1234-1234-1234-123456789abc.jsonl",
+        );
+        let matched = matching_remem_document(
+            &[remem_doc],
+            path,
+            Utc.timestamp_opt(10, 0).unwrap(),
+            "User: canonical prefix\nAssistant: local-only suffix\n",
+        )
+        .unwrap();
+        assert!(matched.is_none());
     }
 
     #[test]

--- a/apps/cli/src/ingest_sessions/legacy_migration.rs
+++ b/apps/cli/src/ingest_sessions/legacy_migration.rs
@@ -86,6 +86,22 @@ pub(super) fn matching_legacy_document_ids(
     Ok(Vec::new())
 }
 
+pub(super) fn legacy_document_covers_nonunique_summary(
+    documents: &[Document],
+    remem_session: &RememSession,
+    raw_content: &str,
+    last_epoch: i64,
+) -> bool {
+    remem_session.source_root == LOCAL_SOURCE_ROOT
+        && documents.iter().any(|document| {
+            LEGACY_SOURCES.contains(&document.source())
+                && url_matches_session_id(document.url(), &remem_session.session_id)
+                && (document.raw_content() == raw_content
+                    || (content_matches(document.raw_content(), raw_content)
+                        && document.updated_at().timestamp() >= last_epoch))
+        })
+}
+
 fn unique_match(matches: Vec<&Document>, remem_session: &RememSession) -> Result<Vec<DocumentId>> {
     match matches.as_slice() {
         [] => Ok(Vec::new()),
@@ -299,6 +315,31 @@ mod tests {
         let exact_documents = vec![exact];
         let exact_index = legacy_document_index(&exact_documents);
         assert_eq!(exact_index.get(session_id).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn nonunique_summary_uses_legacy_content_only_as_read_only_coverage() {
+        let legacy = document("codex-session", "/tmp/session-1.jsonl", "same", 10);
+        let documents = vec![legacy];
+
+        assert!(legacy_document_covers_nonunique_summary(
+            &documents,
+            &remem("local", "session-1"),
+            "same",
+            i64::MAX,
+        ));
+        assert!(!legacy_document_covers_nonunique_summary(
+            &documents,
+            &remem("local", "session-1"),
+            "same plus append",
+            i64::MAX,
+        ));
+        assert!(!legacy_document_covers_nonunique_summary(
+            &documents,
+            &remem("remote", "session-1"),
+            "same",
+            10,
+        ));
     }
 
     #[test]

--- a/apps/cli/src/ingest_sessions/quarantine.rs
+++ b/apps/cli/src/ingest_sessions/quarantine.rs
@@ -1,0 +1,189 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const QUARANTINE_ENV: &str = "REFINE_INGEST_QUARANTINE_PATH";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct QuarantineRecord {
+    pub url: String,
+    pub code: String,
+    pub message: String,
+    pub first_seen: DateTime<Utc>,
+    pub last_seen: DateTime<Utc>,
+    pub attempts: u64,
+}
+
+pub(super) struct QuarantineStore {
+    path: PathBuf,
+    records: BTreeMap<String, QuarantineRecord>,
+    dirty: bool,
+}
+
+impl QuarantineStore {
+    pub(super) fn load() -> Result<Self> {
+        Self::load_from(default_path()?)
+    }
+
+    fn load_from(path: PathBuf) -> Result<Self> {
+        let content = match std::fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("读取 ingest 隔离队列失败: {}", path.display()))
+            }
+        };
+
+        let mut records = BTreeMap::new();
+        for (index, line) in content.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let record: QuarantineRecord = serde_json::from_str(line).with_context(|| {
+                format!(
+                    "ingest 隔离队列第 {} 行损坏，拒绝静默跳过: {}",
+                    index + 1,
+                    path.display()
+                )
+            })?;
+            records.insert(record.url.clone(), record);
+        }
+
+        Ok(Self {
+            path,
+            records,
+            dirty: false,
+        })
+    }
+
+    pub(super) fn contains(&self, url: &str) -> bool {
+        self.records.contains_key(url)
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(super) fn record(&mut self, url: &str, code: &str, message: &str) {
+        let now = Utc::now();
+        match self.records.get_mut(url) {
+            Some(record) => {
+                record.code = code.to_string();
+                record.message = message.to_string();
+                record.last_seen = now;
+                record.attempts = record.attempts.saturating_add(1);
+            }
+            None => {
+                self.records.insert(
+                    url.to_string(),
+                    QuarantineRecord {
+                        url: url.to_string(),
+                        code: code.to_string(),
+                        message: message.to_string(),
+                        first_seen: now,
+                        last_seen: now,
+                        attempts: 1,
+                    },
+                );
+            }
+        }
+        self.dirty = true;
+    }
+
+    pub(super) fn resolve(&mut self, url: &str) {
+        if self.records.remove(url).is_some() {
+            self.dirty = true;
+        }
+    }
+
+    pub(super) fn save_if_dirty(&mut self) -> Result<()> {
+        if !self.dirty {
+            return Ok(());
+        }
+        let parent = self
+            .path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("隔离队列路径没有父目录: {}", self.path.display()))?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("创建 ingest 隔离目录失败: {}", parent.display()))?;
+
+        let file_name = self
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("ingest-quarantine.jsonl");
+        let temp_path = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
+        let write_result = (|| -> Result<()> {
+            let mut file = std::fs::File::create(&temp_path).with_context(|| {
+                format!("创建 ingest 隔离临时文件失败: {}", temp_path.display())
+            })?;
+            for record in self.records.values() {
+                serde_json::to_writer(&mut file, record).context("序列化 ingest 隔离记录失败")?;
+                file.write_all(b"\n")?;
+            }
+            file.sync_all()?;
+            std::fs::rename(&temp_path, &self.path).with_context(|| {
+                format!(
+                    "原子替换 ingest 隔离队列失败: {} -> {}",
+                    temp_path.display(),
+                    self.path.display()
+                )
+            })?;
+            Ok(())
+        })();
+        if write_result.is_err() {
+            let _ = std::fs::remove_file(&temp_path);
+        }
+        write_result?;
+        self.dirty = false;
+        Ok(())
+    }
+}
+
+fn default_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var(QUARANTINE_ENV) {
+        if !path.trim().is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    let home = dirs::home_dir().context("无法定位 HOME，不能保存 ingest 隔离队列")?;
+    Ok(home.join(".refine").join("ingest-quarantine.jsonl"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quarantine_round_trip_deduplicates_by_url() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("queue.jsonl");
+        let mut store = QuarantineStore::load_from(path.clone()).unwrap();
+        store.record("remem://one", "sensitive_words_detected", "blocked");
+        store.record("remem://one", "sensitive_words_detected", "blocked again");
+        store.save_if_dirty().unwrap();
+
+        let loaded = QuarantineStore::load_from(path).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded.records["remem://one"].attempts, 2);
+    }
+
+    #[test]
+    fn malformed_quarantine_fails_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("queue.jsonl");
+        std::fs::write(&path, "not-json\n").unwrap();
+        let error = QuarantineStore::load_from(path)
+            .err()
+            .expect("malformed queue must fail");
+        assert!(error.to_string().contains("拒绝静默跳过"));
+    }
+}

--- a/apps/cli/src/ingest_sessions/quarantine.rs
+++ b/apps/cli/src/ingest_sessions/quarantine.rs
@@ -3,6 +3,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 const QUARANTINE_ENV: &str = "REFINE_INGEST_QUARANTINE_PATH";
@@ -10,6 +12,8 @@ const QUARANTINE_ENV: &str = "REFINE_INGEST_QUARANTINE_PATH";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct QuarantineRecord {
     pub url: String,
+    #[serde(default)]
+    pub source_version: Option<String>,
     pub code: String,
     pub message: String,
     pub first_seen: DateTime<Utc>,
@@ -50,7 +54,10 @@ impl QuarantineStore {
                     path.display()
                 )
             })?;
-            records.insert(record.url.clone(), record);
+            records.insert(
+                record_key(&record.url, record.source_version.as_deref()),
+                record,
+            );
         }
 
         Ok(Self {
@@ -60,17 +67,18 @@ impl QuarantineStore {
         })
     }
 
-    pub(super) fn contains(&self, url: &str) -> bool {
-        self.records.contains_key(url)
+    pub(super) fn contains(&self, url: &str, source_version: Option<&str>) -> bool {
+        self.records.contains_key(&record_key(url, source_version))
     }
 
     pub(super) fn len(&self) -> usize {
         self.records.len()
     }
 
-    pub(super) fn count_matching(&self, urls: &HashSet<String>) -> usize {
-        urls.iter()
-            .filter(|url| self.records.contains_key(url.as_str()))
+    pub(super) fn count_matching(&self, identities: &HashSet<String>) -> usize {
+        identities
+            .iter()
+            .filter(|identity| self.records.contains_key(identity.as_str()))
             .count()
     }
 
@@ -78,9 +86,16 @@ impl QuarantineStore {
         &self.path
     }
 
-    pub(super) fn record(&mut self, url: &str, code: &str, message: &str) {
+    pub(super) fn record(
+        &mut self,
+        url: &str,
+        source_version: Option<&str>,
+        code: &str,
+        message: &str,
+    ) {
         let now = Utc::now();
-        match self.records.get_mut(url) {
+        let key = record_key(url, source_version);
+        match self.records.get_mut(&key) {
             Some(record) => {
                 record.code = code.to_string();
                 record.message = message.to_string();
@@ -89,9 +104,10 @@ impl QuarantineStore {
             }
             None => {
                 self.records.insert(
-                    url.to_string(),
+                    key,
                     QuarantineRecord {
                         url: url.to_string(),
+                        source_version: source_version.map(ToOwned::to_owned),
                         code: code.to_string(),
                         message: message.to_string(),
                         first_seen: now,
@@ -105,7 +121,9 @@ impl QuarantineStore {
     }
 
     pub(super) fn resolve(&mut self, url: &str) {
-        if self.records.remove(url).is_some() {
+        let previous_len = self.records.len();
+        self.records.retain(|_, record| record.url != url);
+        if self.records.len() != previous_len {
             self.dirty = true;
         }
     }
@@ -120,6 +138,7 @@ impl QuarantineStore {
             .ok_or_else(|| anyhow::anyhow!("隔离队列路径没有父目录: {}", self.path.display()))?;
         std::fs::create_dir_all(parent)
             .with_context(|| format!("创建 ingest 隔离目录失败: {}", parent.display()))?;
+        secure_default_parent(parent)?;
 
         let file_name = self
             .path
@@ -128,7 +147,11 @@ impl QuarantineStore {
             .unwrap_or("ingest-quarantine.jsonl");
         let temp_path = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
         let write_result = (|| -> Result<()> {
-            let mut file = std::fs::File::create(&temp_path).with_context(|| {
+            let mut options = std::fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            options.mode(0o600);
+            let mut file = options.open(&temp_path).with_context(|| {
                 format!("创建 ingest 隔离临时文件失败: {}", temp_path.display())
             })?;
             for record in self.records.values() {
@@ -154,6 +177,20 @@ impl QuarantineStore {
     }
 }
 
+pub(super) fn record_key(url: &str, source_version: Option<&str>) -> String {
+    format!("{url}\u{0}{}", source_version.unwrap_or_default())
+}
+
+fn secure_default_parent(parent: &Path) -> Result<()> {
+    #[cfg(unix)]
+    if dirs::home_dir().as_deref().map(|home| home.join(".refine")) == Some(parent.to_path_buf()) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("收紧 ingest 隔离目录权限失败: {}", parent.display()))?;
+    }
+    Ok(())
+}
+
 fn default_path() -> Result<PathBuf> {
     if let Ok(path) = std::env::var(QUARANTINE_ENV) {
         if !path.trim().is_empty() {
@@ -173,13 +210,26 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("queue.jsonl");
         let mut store = QuarantineStore::load_from(path.clone()).unwrap();
-        store.record("remem://one", "sensitive_words_detected", "blocked");
-        store.record("remem://one", "sensitive_words_detected", "blocked again");
+        store.record(
+            "remem://one",
+            Some("v1"),
+            "sensitive_words_detected",
+            "blocked",
+        );
+        store.record(
+            "remem://one",
+            Some("v1"),
+            "sensitive_words_detected",
+            "blocked again",
+        );
         store.save_if_dirty().unwrap();
 
         let loaded = QuarantineStore::load_from(path).unwrap();
         assert_eq!(loaded.len(), 1);
-        assert_eq!(loaded.records["remem://one"].attempts, 2);
+        assert_eq!(
+            loaded.records[&record_key("remem://one", Some("v1"))].attempts,
+            2
+        );
     }
 
     #[test]
@@ -198,14 +248,38 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("queue.jsonl");
         let mut store = QuarantineStore::load_from(path).unwrap();
-        store.record("remem://selected", "blocked", "selected");
-        store.record("file://unrelated", "blocked", "unrelated");
+        store.record("remem://selected", Some("v1"), "blocked", "selected");
+        store.record("file://unrelated", Some("v1"), "blocked", "unrelated");
 
-        let selected = HashSet::from(["remem://selected".to_string()]);
+        let selected = HashSet::from([record_key("remem://selected", Some("v1"))]);
         assert_eq!(store.count_matching(&selected), 1);
 
-        let other_provider = HashSet::from(["remem://other".to_string()]);
+        let other_provider = HashSet::from([record_key("remem://other", Some("v1"))]);
         assert_eq!(store.count_matching(&other_provider), 0);
         assert_eq!(store.len(), 2);
+    }
+
+    #[test]
+    fn changed_snapshot_is_not_blocked_by_old_rejection() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut store = QuarantineStore::load_from(temp.path().join("queue.jsonl")).unwrap();
+        store.record("remem://one", Some("v1"), "blocked", "old snapshot");
+        assert!(store.contains("remem://one", Some("v1")));
+        assert!(!store.contains("remem://one", Some("v2")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn quarantine_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("queue.jsonl");
+        let mut store = QuarantineStore::load_from(path.clone()).unwrap();
+        store.record("remem://one", Some("v1"), "blocked", "private detail");
+        store.save_if_dirty().unwrap();
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 }

--- a/apps/cli/src/ingest_sessions/quarantine.rs
+++ b/apps/cli/src/ingest_sessions/quarantine.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 use std::io::Write;
@@ -25,6 +26,7 @@ pub(super) struct QuarantineStore {
     path: PathBuf,
     records: BTreeMap<String, QuarantineRecord>,
     dirty: bool,
+    _lock_file: std::fs::File,
 }
 
 impl QuarantineStore {
@@ -33,6 +35,28 @@ impl QuarantineStore {
     }
 
     pub(super) fn load_from(path: PathBuf) -> Result<Self> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("隔离队列路径没有父目录: {}", path.display()))?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("创建 ingest 隔离目录失败: {}", parent.display()))?;
+        secure_default_parent(parent)?;
+        let lock_path = path.with_extension("lock");
+        let mut lock_options = std::fs::OpenOptions::new();
+        lock_options
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false);
+        #[cfg(unix)]
+        lock_options.mode(0o600);
+        let lock_file = lock_options
+            .open(&lock_path)
+            .with_context(|| format!("打开 ingest 隔离锁失败: {}", lock_path.display()))?;
+        lock_file
+            .lock_exclusive()
+            .with_context(|| format!("获取 ingest 隔离锁失败: {}", lock_path.display()))?;
+
         let content = match std::fs::read_to_string(&path) {
             Ok(content) => content,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
@@ -64,6 +88,7 @@ impl QuarantineStore {
             path,
             records,
             dirty: false,
+            _lock_file: lock_file,
         })
     }
 
@@ -223,6 +248,7 @@ mod tests {
             "blocked again",
         );
         store.save_if_dirty().unwrap();
+        drop(store);
 
         let loaded = QuarantineStore::load_from(path).unwrap();
         assert_eq!(loaded.len(), 1);
@@ -230,6 +256,38 @@ mod tests {
             loaded.records[&record_key("remem://one", Some("v1"))].attempts,
             2
         );
+    }
+
+    #[test]
+    fn concurrent_read_modify_write_preserves_both_updates() {
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("queue.jsonl");
+        let first_path = path.clone();
+        let second_path = path.clone();
+        let (locked_tx, locked_rx) = mpsc::channel();
+
+        let first = thread::spawn(move || {
+            let mut store = QuarantineStore::load_from(first_path).unwrap();
+            store.record("remem://one", Some("v1"), "blocked", "one");
+            locked_tx.send(()).unwrap();
+            thread::sleep(Duration::from_millis(100));
+            store.save_if_dirty().unwrap();
+        });
+        locked_rx.recv().unwrap();
+        let second = thread::spawn(move || {
+            let mut store = QuarantineStore::load_from(second_path).unwrap();
+            store.record("remem://two", Some("v1"), "blocked", "two");
+            store.save_if_dirty().unwrap();
+        });
+
+        first.join().unwrap();
+        second.join().unwrap();
+        let loaded = QuarantineStore::load_from(path).unwrap();
+        assert_eq!(loaded.len(), 2);
     }
 
     #[test]

--- a/apps/cli/src/ingest_sessions/quarantine.rs
+++ b/apps/cli/src/ingest_sessions/quarantine.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -28,7 +28,7 @@ impl QuarantineStore {
         Self::load_from(default_path()?)
     }
 
-    fn load_from(path: PathBuf) -> Result<Self> {
+    pub(super) fn load_from(path: PathBuf) -> Result<Self> {
         let content = match std::fs::read_to_string(&path) {
             Ok(content) => content,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
@@ -66,6 +66,12 @@ impl QuarantineStore {
 
     pub(super) fn len(&self) -> usize {
         self.records.len()
+    }
+
+    pub(super) fn count_matching(&self, urls: &HashSet<String>) -> usize {
+        urls.iter()
+            .filter(|url| self.records.contains_key(url.as_str()))
+            .count()
     }
 
     pub(super) fn path(&self) -> &Path {
@@ -185,5 +191,21 @@ mod tests {
             .err()
             .expect("malformed queue must fail");
         assert!(error.to_string().contains("拒绝静默跳过"));
+    }
+
+    #[test]
+    fn matching_count_ignores_records_outside_the_current_selection() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("queue.jsonl");
+        let mut store = QuarantineStore::load_from(path).unwrap();
+        store.record("remem://selected", "blocked", "selected");
+        store.record("file://unrelated", "blocked", "unrelated");
+
+        let selected = HashSet::from(["remem://selected".to_string()]);
+        assert_eq!(store.count_matching(&selected), 1);
+
+        let other_provider = HashSet::from(["remem://other".to_string()]);
+        assert_eq!(store.count_matching(&other_provider), 0);
+        assert_eq!(store.len(), 2);
     }
 }

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -177,12 +177,32 @@ fn session_needs_refresh_when_file_mtime_is_newer_than_saved_document() {
 }
 
 #[test]
-fn remem_summary_refreshes_only_when_source_is_newer_than_saved_document() {
-    let doc = Document::new("codex-session", "raw");
-    let saved_at = doc.updated_at().timestamp();
+fn remem_summary_compares_the_saved_source_snapshot_not_ingest_time() {
+    let mut summary = RememSessionSummary {
+        source_root: "local".to_string(),
+        project: "/repo".to_string(),
+        session_id: "session-1".to_string(),
+        first_epoch: 10,
+        last_epoch: 20,
+        message_count: 2,
+        user_message_count: 1,
+        assistant_message_count: 1,
+        user_message_samples: vec!["hello".to_string()],
+        legacy_identity_is_unique: true,
+    };
+    let mut versioned = Document::new("remem-raw-session", "raw");
+    versioned.set_source_version(Some(&remem_source_version(&summary)));
 
-    assert!(document_covers_remem_summary(&doc, saved_at));
-    assert!(!document_covers_remem_summary(&doc, saved_at + 1));
+    assert!(document_covers_remem_summary(&versioned, &summary));
+
+    // A backfilled message can leave last_epoch unchanged or older than the
+    // database write time. Message-count drift must still force a full fetch.
+    summary.message_count = 3;
+    summary.user_message_count = 2;
+    assert!(!document_covers_remem_summary(&versioned, &summary));
+
+    let unversioned = Document::new("remem-raw-session", "raw");
+    assert!(!document_covers_remem_summary(&unversioned, &summary));
 }
 
 #[test]
@@ -309,6 +329,7 @@ async fn process_single_session_links_items_to_saved_document_id() {
         captured_at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
         has_embedded_timestamp: true,
         raw_content: "User: fix the ingest bug".to_string(),
+        source_version: None,
         needs_chunk: false,
         chunks: Vec::new(),
         existing_document: None,
@@ -385,6 +406,7 @@ async fn process_single_session_refresh_replaces_old_items_and_preserves_raw_tra
         captured_at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
         has_embedded_timestamp: false,
         raw_content: "User: original transcript\nAssistant: final answer\n".to_string(),
+        source_version: None,
         needs_chunk: true,
         chunks: vec!["chunk summary input".to_string()],
         existing_document: Some(existing_doc.clone()),
@@ -449,6 +471,7 @@ async fn remem_save_removes_superseded_legacy_document_and_facets() {
         captured_at: Utc.with_ymd_and_hms(2026, 7, 20, 0, 0, 0).unwrap(),
         has_embedded_timestamp: true,
         raw_content: "User: old\nAssistant: new\n".to_string(),
+        source_version: Some("remem:v1:10:20:2:1:1".to_string()),
         needs_chunk: false,
         chunks: Vec::new(),
         existing_document: None,

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -203,6 +203,7 @@ fn remem_summary_compares_the_saved_source_snapshot_not_ingest_time() {
 
     let unversioned = Document::new("remem-raw-session", "raw");
     assert!(!document_covers_remem_summary(&unversioned, &summary));
+    assert!(legacy_document_covers_remem_summary(&unversioned, &summary));
 
     let original_updated_at = unversioned.updated_at();
     let backfilled = document_with_source_version(&unversioned, &remem_source_version(&summary));

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -151,6 +151,15 @@ fn session_needs_refresh_when_file_mtime_is_newer_than_saved_document() {
 }
 
 #[test]
+fn remem_summary_refreshes_only_when_source_is_newer_than_saved_document() {
+    let doc = Document::new("codex-session", "raw");
+    let saved_at = doc.updated_at().timestamp();
+
+    assert!(document_covers_remem_summary(&doc, saved_at));
+    assert!(!document_covers_remem_summary(&doc, saved_at + 1));
+}
+
+#[test]
 fn scoped_cursor_keeps_other_sources_discoverable() {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path();

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -55,6 +55,7 @@ async fn source_filter_is_rejected_without_explicit_legacy_rollback() {
             latest: None,
             dry_run: true,
             legacy_local_scan: false,
+            retry_quarantined: false,
         },
         Path::new("/tmp/refine-test.db"),
         doc_store,
@@ -495,4 +496,18 @@ async fn quota_hit_short_circuits_before_llm_call() {
         .expect_err("quota flag should skip the call");
 
     assert!(err.to_string().contains("LLM 配额已耗尽"));
+}
+
+#[test]
+fn content_rejection_survives_anyhow_context() {
+    let error = anyhow::Error::new(InfraError::LlmRejected {
+        code: "sensitive_words_detected".into(),
+        message: "blocked".into(),
+    })
+    .context("chunk 2/3 failed");
+
+    assert_eq!(
+        content_rejection(&error),
+        Some(("sensitive_words_detected".into(), "blocked".into()))
+    );
 }

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -5,10 +5,43 @@ use refine_core::error::InfraResult;
 use refine_core::infra::SqliteStore;
 use refine_core::knowledge::{DocumentId, DocumentRepository, Item, ItemRepository, ItemType};
 use refine_core::session::discover_sessions_in;
+use std::collections::VecDeque;
 use std::fs;
+use std::sync::Mutex;
 
 struct StaticLlmClient {
     response: String,
+}
+
+struct SequenceLlmClient {
+    responses: Mutex<VecDeque<String>>,
+    calls: AtomicUsize,
+}
+
+impl SequenceLlmClient {
+    fn new(responses: Vec<String>) -> Self {
+        Self {
+            responses: Mutex::new(VecDeque::from(responses)),
+            calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::Relaxed)
+    }
+}
+
+#[async_trait]
+impl LlmClient for SequenceLlmClient {
+    async fn complete(&self, _prompt: &str, _system: Option<&str>) -> InfraResult<String> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(self
+            .responses
+            .lock()
+            .expect("responses lock")
+            .pop_front()
+            .unwrap_or_else(|| "{}".to_string()))
+    }
 }
 
 #[tokio::test]
@@ -61,6 +94,45 @@ fn session_captured_at_prefers_session_started_at_then_file_mtime() {
 
     let fallback = session_captured_at(None, mtime);
     assert_eq!(fallback, DateTime::<Utc>::from(mtime));
+}
+
+#[test]
+fn log_preview_truncates_on_char_boundary() {
+    let message = "无法解析 facet 响应: 回回回";
+    let preview = log_preview(message, 10);
+
+    assert!(preview.ends_with("..."));
+    assert!(preview.is_char_boundary(preview.len()));
+}
+
+#[tokio::test]
+async fn facet_parse_error_retries_then_succeeds() {
+    let client = Arc::new(SequenceLlmClient::new(vec![
+        "not json".to_string(),
+        r#"{
+            "session_summary": "重试后成功",
+            "cognitive_level": "proficient",
+            "collaboration_mode": "pair_programming",
+            "decisions": [], "bugs_fixed": [], "patterns": [], "friction": [],
+            "project_progress": [], "questions": [], "knowledge_gained": [],
+            "tools_discovered": [], "architecture": [], "code_artifacts": []
+        }"#
+        .to_string(),
+    ]));
+    let quota_hit = Arc::new(AtomicBool::new(false));
+
+    let result = extract_and_parse_facets_with_retry_policy(
+        "content",
+        &(client.clone() as Arc<dyn LlmClient>),
+        &quota_hit,
+        2,
+        0,
+    )
+    .await
+    .expect("parse retry should recover");
+
+    assert_eq!(result.session_summary, "重试后成功");
+    assert_eq!(client.calls(), 2);
 }
 
 #[test]

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -177,38 +177,21 @@ fn session_needs_refresh_when_file_mtime_is_newer_than_saved_document() {
 }
 
 #[test]
-fn remem_summary_compares_the_saved_source_snapshot_not_ingest_time() {
-    let mut summary = RememSessionSummary {
-        source_root: "local".to_string(),
-        project: "/repo".to_string(),
-        session_id: "session-1".to_string(),
-        first_epoch: 10,
-        last_epoch: 20,
-        message_count: 2,
-        user_message_count: 1,
-        assistant_message_count: 1,
-        user_message_samples: vec!["hello".to_string()],
-        legacy_identity_is_unique: true,
-    };
+fn source_snapshot_uses_full_content_and_preserves_document_time() {
     let mut versioned = Document::new("remem-raw-session", "raw");
-    versioned.set_source_version(Some(&remem_source_version(&summary)));
-
-    assert!(document_covers_remem_summary(&versioned, &summary));
-
-    // A backfilled message can leave last_epoch unchanged or older than the
-    // database write time. Message-count drift must still force a full fetch.
-    summary.message_count = 3;
-    summary.user_message_count = 2;
-    assert!(!document_covers_remem_summary(&versioned, &summary));
+    let raw_version = content_source_version("remem", "raw");
+    versioned.set_source_version(Some(&raw_version));
+    assert_eq!(versioned.source_version(), Some(raw_version.as_str()));
+    assert_ne!(
+        raw_version,
+        content_source_version("remem", "raw corrected")
+    );
 
     let unversioned = Document::new("remem-raw-session", "raw");
-    assert!(!document_covers_remem_summary(&unversioned, &summary));
-    assert!(legacy_document_covers_remem_summary(&unversioned, &summary));
-
     let original_updated_at = unversioned.updated_at();
-    let backfilled = document_with_source_version(&unversioned, &remem_source_version(&summary));
+    let backfilled = document_with_source_version(&unversioned, &raw_version);
     assert_eq!(backfilled.updated_at(), original_updated_at);
-    assert!(document_covers_remem_summary(&backfilled, &summary));
+    assert_eq!(backfilled.source_version(), Some(raw_version.as_str()));
 }
 
 #[test]

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -9,6 +9,32 @@ use std::collections::VecDeque;
 use std::fs;
 use std::sync::Mutex;
 
+#[test]
+fn auto_provider_prefers_remem_when_the_probe_succeeds() {
+    let selection = select_auto_provider(|| Ok(vec!["summary"])).unwrap();
+    assert!(matches!(
+        selection,
+        AutoProviderSelection::Remem(values) if values == vec!["summary"]
+    ));
+}
+
+#[test]
+fn auto_provider_falls_back_only_for_a_missing_executable() {
+    let selection = select_auto_provider::<Vec<()>, _>(|| {
+        Err(std::io::Error::new(std::io::ErrorKind::NotFound, "remem").into())
+    })
+    .unwrap();
+    assert!(matches!(selection, AutoProviderSelection::LocalFallback));
+}
+
+#[test]
+fn auto_provider_keeps_remem_provider_errors_strict() {
+    let result =
+        select_auto_provider::<Vec<()>, _>(|| Err(anyhow::anyhow!("raw sessions contract drift")));
+    let error = result.expect_err("contract errors must not fall back to local");
+    assert!(error.to_string().contains("contract drift"));
+}
+
 struct StaticLlmClient {
     response: String,
 }
@@ -45,16 +71,16 @@ impl LlmClient for SequenceLlmClient {
 }
 
 #[tokio::test]
-async fn source_filter_is_rejected_without_explicit_legacy_rollback() {
+async fn source_filter_requires_explicit_local_provider() {
     let store = Arc::new(SqliteStore::in_memory().expect("in-memory sqlite store"));
     let doc_store: Arc<dyn DocumentRepository> = store;
     let error = handle_ingest_sessions(
         IngestOptions {
             source: Some(SessionSource::ClaudeCode),
+            provider: IngestProvider::Auto,
             limit: None,
             latest: None,
             dry_run: true,
-            legacy_local_scan: false,
             retry_quarantined: false,
         },
         Path::new("/tmp/refine-test.db"),
@@ -64,7 +90,7 @@ async fn source_filter_is_rejected_without_explicit_legacy_rollback() {
     .await
     .expect_err("source filtering must not guess a platform in remem mode");
 
-    assert!(error.to_string().contains("--legacy-local-scan"));
+    assert!(error.to_string().contains("--provider local"));
 }
 
 #[async_trait]

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -203,6 +203,11 @@ fn remem_summary_compares_the_saved_source_snapshot_not_ingest_time() {
 
     let unversioned = Document::new("remem-raw-session", "raw");
     assert!(!document_covers_remem_summary(&unversioned, &summary));
+
+    let original_updated_at = unversioned.updated_at();
+    let backfilled = document_with_source_version(&unversioned, &remem_source_version(&summary));
+    assert_eq!(backfilled.updated_at(), original_updated_at);
+    assert!(document_covers_remem_summary(&backfilled, &summary));
 }
 
 #[test]

--- a/apps/cli/src/insights.rs
+++ b/apps/cli/src/insights.rs
@@ -13,7 +13,15 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 const LLM_CONCURRENCY: usize = 10;
+const FINAL_REPORT_REQUEST_TIMEOUT_MILLIS: u64 = 300_000;
 const INSIGHTS_PROMPT_IDENTITY: &str = "insights-v2:route-v1:final-v1";
+
+fn final_report_retry_policy() -> LlmRetryPolicy {
+    LlmRetryPolicy {
+        request_timeout_millis: FINAL_REPORT_REQUEST_TIMEOUT_MILLIS,
+        ..LlmRetryPolicy::default()
+    }
+}
 
 #[allow(dead_code)]
 pub struct InsightsOptions {
@@ -193,7 +201,7 @@ pub async fn handle_insights(
         &client,
         &final_prompt,
         INSIGHTS_SYSTEM_PROMPT,
-        LlmRetryPolicy::default(),
+        final_report_retry_policy(),
         |attempt, max_retries, delay_secs, _err| {
             eprintln!(
                 "    ⏳ 重试 ({}/{}) 等待 {}s...",
@@ -226,4 +234,19 @@ pub async fn handle_insights(
     println!("\n报告已保存 (ID: {})", doc.id());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{final_report_retry_policy, FINAL_REPORT_REQUEST_TIMEOUT_MILLIS};
+
+    #[test]
+    fn final_report_allows_slow_large_synthesis_requests() {
+        let policy = final_report_retry_policy();
+        assert_eq!(policy.request_timeout_millis, 300_000);
+        assert_eq!(
+            policy.request_timeout_millis,
+            FINAL_REPORT_REQUEST_TIMEOUT_MILLIS
+        );
+    }
 }

--- a/apps/cli/src/insights.rs
+++ b/apps/cli/src/insights.rs
@@ -1,5 +1,6 @@
 //! insights v2 — 两级分析：本地聚类 + 10 路 LLM 并发
 
+use crate::insights_checkpoint::{DatasetSignature, InsightsCheckpoint, CHECKPOINT_VERSION};
 use anyhow::{Context, Result};
 use refine_core::infra::{llm_with_retry_policy, LlmClient, LlmRetryPolicy};
 use refine_core::knowledge::{Document, DocumentRepository, ItemRepository, ItemType};
@@ -57,20 +58,44 @@ pub async fn handle_insights(
         stats.total_bugfixes,
     );
 
+    let latest_updated_at = observations
+        .iter()
+        .map(|item| item.updated_at())
+        .max()
+        .context("Observation 集合缺少更新时间")?;
+    let signature = DatasetSignature {
+        checkpoint_version: CHECKPOINT_VERSION,
+        observation_count: observations.len(),
+        latest_updated_at,
+        with_prescription: options.with_prescription,
+    };
+    let mut checkpoint = InsightsCheckpoint::load_matching(signature)?;
+
     // Step 2: 规划 LLM 分析路由
     let routes = plan_routes(&cluster_result);
-    println!("规划 {} 路并发 LLM 分析...\n", routes.len());
+    let route_count = routes.len();
+    let cached_count = routes
+        .iter()
+        .filter(|route| checkpoint.contains_route(route.id))
+        .count();
+    println!(
+        "规划 {} 路 LLM 分析（checkpoint 命中 {} 路）...\n",
+        route_count, cached_count
+    );
 
     // Step 3: 并发执行 LLM 分析
     let semaphore = Arc::new(Semaphore::new(LLM_CONCURRENCY));
     let mut handles = Vec::new();
 
-    for route in routes {
+    for route in routes
+        .into_iter()
+        .filter(|route| !checkpoint.contains_route(route.id))
+    {
         let sem = semaphore.clone();
         let client = client.clone();
         let handle = tokio::spawn(async move {
             let _permit = sem.acquire().await.expect("semaphore closed");
-            let content = match llm_with_retry_policy(
+            let content = llm_with_retry_policy(
                 &client,
                 &route.prompt,
                 ROUTE_SYSTEM_PROMPT,
@@ -83,34 +108,67 @@ pub async fn handle_insights(
                 },
             )
             .await
-            {
-                Ok(c) => c,
-                Err(e) => format!("分析失败: {}", e),
-            };
-            eprintln!("  ✓ Route {}: {}", route.id, route.title);
-            RouteResult {
+            .map_err(|error| (route.id, route.title.clone(), error.to_string()))?;
+            Ok::<RouteResult, (usize, String, String)>(RouteResult {
                 route_id: route.id,
                 route_title: route.title,
                 content,
-            }
+            })
         });
         handles.push(handle);
     }
 
-    let mut route_results = Vec::new();
+    let mut completed_results = Vec::new();
+    let mut route_errors = Vec::new();
     for handle in handles {
-        if let Ok(result) = handle.await {
-            route_results.push(result);
+        match handle.await {
+            Ok(Ok(result)) => {
+                eprintln!("  ✓ Route {}: {}", result.route_id, result.route_title);
+                completed_results.push(result);
+            }
+            Ok(Err(error)) => {
+                eprintln!("  ✗ Route {}: {}: {}", error.0, error.1, error.2);
+                route_errors.push(error);
+            }
+            Err(error) => {
+                route_errors.push((0, "worker panic".into(), error.to_string()));
+            }
         }
+    }
+
+    if !completed_results.is_empty() {
+        checkpoint.extend(completed_results);
+        checkpoint.save()?;
+        println!(
+            "已保存 {}/{} 路中间结果: {}",
+            checkpoint.route_results.len(),
+            route_count,
+            InsightsCheckpoint::path()?.display()
+        );
+    }
+
+    if !route_errors.is_empty() {
+        anyhow::bail!(
+            "{} 路分析失败；已完成结果已 checkpoint，下次只重跑缺失路由",
+            route_errors.len()
+        );
+    }
+
+    if checkpoint.route_results.len() != route_count {
+        anyhow::bail!(
+            "路由结果不完整: {}/{}；拒绝生成残缺报告",
+            checkpoint.route_results.len(),
+            route_count
+        );
     }
 
     println!(
         "\n{} 路分析完成，合并生成最终报告...\n",
-        route_results.len()
+        checkpoint.route_results.len()
     );
 
     // Step 4: 合并 + 最终报告
-    let combined = merge_route_results(&route_results);
+    let combined = merge_route_results(&checkpoint.route_results);
     let final_prompt = build_final_prompt(&combined, stats, options.with_prescription);
 
     let report = llm_with_retry_policy(
@@ -126,7 +184,12 @@ pub async fn handle_insights(
         },
     )
     .await
-    .map_err(|e| anyhow::anyhow!("最终报告生成失败: {}", e))?;
+    .map_err(|e| {
+        anyhow::anyhow!(
+            "最终报告生成失败: {}；10 路中间结果已保留，下次将直接重试合并",
+            e
+        )
+    })?;
 
     println!("{}", report);
 
@@ -139,6 +202,8 @@ pub async fn handle_insights(
     doc.set_title(&title);
     doc.set_url(&format!("insights-v2://{}", doc.created_at().to_rfc3339()));
     doc_store.save(&doc).await.context("保存报告失败")?;
+
+    InsightsCheckpoint::clear()?;
 
     println!("\n报告已保存 (ID: {})", doc.id());
 

--- a/apps/cli/src/insights.rs
+++ b/apps/cli/src/insights.rs
@@ -2,8 +2,9 @@
 
 use crate::insights_checkpoint::{DatasetSignature, InsightsCheckpoint, CHECKPOINT_VERSION};
 use anyhow::{Context, Result};
+use chrono::{Duration, Utc};
 use refine_core::infra::{llm_with_retry_policy, LlmClient, LlmRetryPolicy};
-use refine_core::knowledge::{Document, DocumentRepository, ItemRepository, ItemType};
+use refine_core::knowledge::{Document, DocumentRepository, ItemRepository};
 use refine_core::session::{
     build_final_prompt, cluster_observations, merge_route_results, plan_routes, RouteResult,
     INSIGHTS_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT,
@@ -26,6 +27,9 @@ pub async fn handle_insights(
     doc_store: Arc<dyn DocumentRepository>,
     llm_client: Option<Arc<dyn LlmClient>>,
 ) -> Result<()> {
+    if matches!(options.period, Some(0)) {
+        anyhow::bail!("--period 必须大于 0");
+    }
     let client = match &llm_client {
         Some(c) => c.clone(),
         None => {
@@ -34,11 +38,21 @@ pub async fn handle_insights(
         }
     };
 
-    // Step 0: 加载全量 observation
-    let observations = item_store
-        .find_by_type(ItemType::Observation)
-        .await
-        .context("加载 Observation 失败")?;
+    let observations = match options.period {
+        Some(days) => {
+            let days = i64::try_from(days).context("--period 超出支持范围")?;
+            let now = Utc::now();
+            item_store
+                .find_observations_by_event_range(now - Duration::days(days), now)
+                .await
+        }
+        None => {
+            item_store
+                .find_by_type(refine_core::knowledge::ItemType::Observation)
+                .await
+        }
+    }
+    .context("加载 Observation 失败")?;
 
     if observations.is_empty() {
         println!("暂无观测数据。请先运行 `refine ingest-sessions` 导入会话。");
@@ -69,6 +83,7 @@ pub async fn handle_insights(
         observation_count: observations.len(),
         latest_updated_at,
         with_prescription: options.with_prescription,
+        period_days: options.period,
         llm_identity: client.cache_identity(),
         prompt_identity: INSIGHTS_PROMPT_IDENTITY.to_string(),
     };

--- a/apps/cli/src/insights.rs
+++ b/apps/cli/src/insights.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 const LLM_CONCURRENCY: usize = 10;
+const INSIGHTS_PROMPT_IDENTITY: &str = "insights-v2:route-v1:final-v1";
 
 #[allow(dead_code)]
 pub struct InsightsOptions {
@@ -68,6 +69,8 @@ pub async fn handle_insights(
         observation_count: observations.len(),
         latest_updated_at,
         with_prescription: options.with_prescription,
+        llm_identity: client.cache_identity(),
+        prompt_identity: INSIGHTS_PROMPT_IDENTITY.to_string(),
     };
     let mut checkpoint = InsightsCheckpoint::load_matching(signature)?;
 

--- a/apps/cli/src/insights_checkpoint.rs
+++ b/apps/cli/src/insights_checkpoint.rs
@@ -1,0 +1,195 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use refine_core::session::RouteResult;
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const CHECKPOINT_ENV: &str = "REFINE_INSIGHTS_CHECKPOINT_PATH";
+pub(crate) const CHECKPOINT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DatasetSignature {
+    pub checkpoint_version: u32,
+    pub observation_count: usize,
+    pub latest_updated_at: DateTime<Utc>,
+    pub with_prescription: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct InsightsCheckpoint {
+    pub signature: DatasetSignature,
+    pub route_results: Vec<RouteResult>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl InsightsCheckpoint {
+    pub(crate) fn load_matching(signature: DatasetSignature) -> Result<Self> {
+        let path = checkpoint_path()?;
+        Self::load_matching_from(&path, signature)
+    }
+
+    fn load_matching_from(path: &Path, signature: DatasetSignature) -> Result<Self> {
+        let content = match std::fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self::empty(signature));
+            }
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("读取 insights checkpoint 失败: {}", path.display()));
+            }
+        };
+        let checkpoint: Self = serde_json::from_str(&content).with_context(|| {
+            format!("insights checkpoint 损坏，拒绝静默忽略: {}", path.display())
+        })?;
+        if checkpoint.signature == signature {
+            Ok(checkpoint)
+        } else {
+            Ok(Self::empty(signature))
+        }
+    }
+
+    pub(crate) fn empty(signature: DatasetSignature) -> Self {
+        Self {
+            signature,
+            route_results: Vec::new(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    pub(crate) fn contains_route(&self, route_id: usize) -> bool {
+        self.route_results
+            .iter()
+            .any(|result| result.route_id == route_id)
+    }
+
+    pub(crate) fn extend(&mut self, results: impl IntoIterator<Item = RouteResult>) {
+        for result in results {
+            self.route_results
+                .retain(|existing| existing.route_id != result.route_id);
+            self.route_results.push(result);
+        }
+        self.route_results.sort_by_key(|result| result.route_id);
+        self.updated_at = Utc::now();
+    }
+
+    pub(crate) fn save(&self) -> Result<()> {
+        let path = checkpoint_path()?;
+        atomic_write_json(&path, self)
+    }
+
+    pub(crate) fn clear() -> Result<()> {
+        let path = checkpoint_path()?;
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error)
+                .with_context(|| format!("删除 insights checkpoint 失败: {}", path.display())),
+        }
+    }
+
+    pub(crate) fn path() -> Result<PathBuf> {
+        checkpoint_path()
+    }
+}
+
+fn checkpoint_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var(CHECKPOINT_ENV) {
+        if !path.trim().is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    let home = dirs::home_dir().context("无法定位 HOME，不能保存 insights checkpoint")?;
+    Ok(home.join(".refine").join("insights-checkpoint.json"))
+}
+
+fn atomic_write_json(path: &Path, value: &impl Serialize) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("checkpoint 路径没有父目录: {}", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("创建 checkpoint 目录失败: {}", parent.display()))?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("insights-checkpoint.json");
+    let temp_path = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
+    let result = (|| -> Result<()> {
+        let mut file = std::fs::File::create(&temp_path)
+            .with_context(|| format!("创建 checkpoint 临时文件失败: {}", temp_path.display()))?;
+        serde_json::to_writer_pretty(&mut file, value)
+            .context("序列化 insights checkpoint 失败")?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        std::fs::rename(&temp_path, path).with_context(|| {
+            format!(
+                "原子替换 insights checkpoint 失败: {} -> {}",
+                temp_path.display(),
+                path.display()
+            )
+        })?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checkpoint_replaces_route_by_id() {
+        let signature = DatasetSignature {
+            checkpoint_version: CHECKPOINT_VERSION,
+            observation_count: 1,
+            latest_updated_at: Utc::now(),
+            with_prescription: true,
+        };
+        let mut checkpoint = InsightsCheckpoint::empty(signature);
+        checkpoint.extend([RouteResult {
+            route_id: 1,
+            route_title: "first".into(),
+            content: "old".into(),
+        }]);
+        checkpoint.extend([RouteResult {
+            route_id: 1,
+            route_title: "first".into(),
+            content: "new".into(),
+        }]);
+        assert_eq!(checkpoint.route_results.len(), 1);
+        assert_eq!(checkpoint.route_results[0].content, "new");
+    }
+
+    #[test]
+    fn checkpoint_round_trip_requires_matching_signature() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("checkpoint.json");
+        let signature = DatasetSignature {
+            checkpoint_version: CHECKPOINT_VERSION,
+            observation_count: 3,
+            latest_updated_at: Utc::now(),
+            with_prescription: true,
+        };
+        let mut checkpoint = InsightsCheckpoint::empty(signature.clone());
+        checkpoint.extend([RouteResult {
+            route_id: 4,
+            route_title: "route".into(),
+            content: "done".into(),
+        }]);
+        atomic_write_json(&path, &checkpoint).unwrap();
+
+        let loaded = InsightsCheckpoint::load_matching_from(&path, signature.clone()).unwrap();
+        assert!(loaded.contains_route(4));
+
+        let mismatch = DatasetSignature {
+            observation_count: 4,
+            ..signature
+        };
+        let reset = InsightsCheckpoint::load_matching_from(&path, mismatch).unwrap();
+        assert!(reset.route_results.is_empty());
+    }
+}

--- a/apps/cli/src/insights_checkpoint.rs
+++ b/apps/cli/src/insights_checkpoint.rs
@@ -30,7 +30,7 @@ impl InsightsCheckpoint {
     }
 
     fn load_matching_from(path: &Path, signature: DatasetSignature) -> Result<Self> {
-        let content = match std::fs::read_to_string(&path) {
+        let content = match std::fs::read_to_string(path) {
             Ok(content) => content,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 return Ok(Self::empty(signature));

--- a/apps/cli/src/insights_checkpoint.rs
+++ b/apps/cli/src/insights_checkpoint.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 const CHECKPOINT_ENV: &str = "REFINE_INSIGHTS_CHECKPOINT_PATH";
-pub(crate) const CHECKPOINT_VERSION: u32 = 1;
+pub(crate) const CHECKPOINT_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct DatasetSignature {
@@ -14,6 +14,10 @@ pub(crate) struct DatasetSignature {
     pub observation_count: usize,
     pub latest_updated_at: DateTime<Utc>,
     pub with_prescription: bool,
+    #[serde(default)]
+    pub llm_identity: String,
+    #[serde(default)]
+    pub prompt_identity: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -148,6 +152,8 @@ mod tests {
             observation_count: 1,
             latest_updated_at: Utc::now(),
             with_prescription: true,
+            llm_identity: "test:model-a:endpoint-a".into(),
+            prompt_identity: "insights:test-v1".into(),
         };
         let mut checkpoint = InsightsCheckpoint::empty(signature);
         checkpoint.extend([RouteResult {
@@ -173,6 +179,8 @@ mod tests {
             observation_count: 3,
             latest_updated_at: Utc::now(),
             with_prescription: true,
+            llm_identity: "test:model-a:endpoint-a".into(),
+            prompt_identity: "insights:test-v1".into(),
         };
         let mut checkpoint = InsightsCheckpoint::empty(signature.clone());
         checkpoint.extend([RouteResult {
@@ -187,9 +195,16 @@ mod tests {
 
         let mismatch = DatasetSignature {
             observation_count: 4,
-            ..signature
+            ..signature.clone()
         };
         let reset = InsightsCheckpoint::load_matching_from(&path, mismatch).unwrap();
+        assert!(reset.route_results.is_empty());
+
+        let llm_mismatch = DatasetSignature {
+            llm_identity: "test:model-b:endpoint-b".into(),
+            ..signature
+        };
+        let reset = InsightsCheckpoint::load_matching_from(&path, llm_mismatch).unwrap();
         assert!(reset.route_results.is_empty());
     }
 }

--- a/apps/cli/src/insights_checkpoint.rs
+++ b/apps/cli/src/insights_checkpoint.rs
@@ -3,6 +3,8 @@ use chrono::{DateTime, Utc};
 use refine_core::session::RouteResult;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 const CHECKPOINT_ENV: &str = "REFINE_INSIGHTS_CHECKPOINT_PATH";
@@ -14,6 +16,8 @@ pub(crate) struct DatasetSignature {
     pub observation_count: usize,
     pub latest_updated_at: DateTime<Utc>,
     pub with_prescription: bool,
+    #[serde(default)]
+    pub period_days: Option<usize>,
     #[serde(default)]
     pub llm_identity: String,
     #[serde(default)]
@@ -114,13 +118,19 @@ fn atomic_write_json(path: &Path, value: &impl Serialize) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("checkpoint 路径没有父目录: {}", path.display()))?;
     std::fs::create_dir_all(parent)
         .with_context(|| format!("创建 checkpoint 目录失败: {}", parent.display()))?;
+    secure_default_parent(parent)?;
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("insights-checkpoint.json");
     let temp_path = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
     let result = (|| -> Result<()> {
-        let mut file = std::fs::File::create(&temp_path)
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options
+            .open(&temp_path)
             .with_context(|| format!("创建 checkpoint 临时文件失败: {}", temp_path.display()))?;
         serde_json::to_writer_pretty(&mut file, value)
             .context("序列化 insights checkpoint 失败")?;
@@ -141,6 +151,16 @@ fn atomic_write_json(path: &Path, value: &impl Serialize) -> Result<()> {
     result
 }
 
+fn secure_default_parent(parent: &Path) -> Result<()> {
+    #[cfg(unix)]
+    if dirs::home_dir().as_deref().map(|home| home.join(".refine")) == Some(parent.to_path_buf()) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("收紧 checkpoint 目录权限失败: {}", parent.display()))?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -152,6 +172,7 @@ mod tests {
             observation_count: 1,
             latest_updated_at: Utc::now(),
             with_prescription: true,
+            period_days: None,
             llm_identity: "test:model-a:endpoint-a".into(),
             prompt_identity: "insights:test-v1".into(),
         };
@@ -179,6 +200,7 @@ mod tests {
             observation_count: 3,
             latest_updated_at: Utc::now(),
             with_prescription: true,
+            period_days: None,
             llm_identity: "test:model-a:endpoint-a".into(),
             prompt_identity: "insights:test-v1".into(),
         };
@@ -206,5 +228,27 @@ mod tests {
         };
         let reset = InsightsCheckpoint::load_matching_from(&path, llm_mismatch).unwrap();
         assert!(reset.route_results.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn checkpoint_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("checkpoint.json");
+        let signature = DatasetSignature {
+            checkpoint_version: CHECKPOINT_VERSION,
+            observation_count: 1,
+            latest_updated_at: Utc::now(),
+            with_prescription: false,
+            period_days: Some(30),
+            llm_identity: "private-provider".into(),
+            prompt_identity: "prompt".into(),
+        };
+        atomic_write_json(&path, &InsightsCheckpoint::empty(signature)).unwrap();
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -23,8 +23,10 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    if let Err(e) = dotenvy::dotenv() {
-        eprintln!("提示: 未加载 .env 文件 ({})", e);
+    if let Err(error) = dotenvy::dotenv() {
+        if should_report_dotenv_error(&error) {
+            eprintln!("警告: 加载 .env 失败 ({error})");
+        }
     }
 
     tracing_subscriber::fmt()
@@ -72,4 +74,23 @@ async fn main() -> Result<()> {
     let engine = Arc::new(SearchEngine::new(repo));
 
     handlers::run(cli.command, store, engine, &db_path).await
+}
+
+fn should_report_dotenv_error(error: &dotenvy::Error) -> bool {
+    !error.not_found()
+}
+
+#[cfg(test)]
+mod dotenv_tests {
+    use super::should_report_dotenv_error;
+    use std::io;
+
+    #[test]
+    fn missing_dotenv_is_silent_but_real_io_errors_are_reported() {
+        let missing = dotenvy::Error::Io(io::ErrorKind::NotFound.into());
+        let denied = dotenvy::Error::Io(io::ErrorKind::PermissionDenied.into());
+
+        assert!(!should_report_dotenv_error(&missing));
+        assert!(should_report_dotenv_error(&denied));
+    }
 }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -36,27 +36,38 @@ async fn main() -> Result<()> {
         Some(raw) => PathBuf::from(raw),
         None => resolve_db_path(&[]),
     };
-    ensure_db_dir(&db_path).map_err(|e| anyhow::anyhow!(e))?;
-    match migrate_stale_dbs(&db_path) {
-        Ok(MigrationReport::NoOp) => {}
-        Ok(MigrationReport::Migrated {
-            sources,
-            rows_copied,
-        }) => {
-            eprintln!(
-                "[refine] migrated {} row(s) from legacy DB(s): {}",
+    let read_only_preview = cli.command.is_read_only_preview();
+    if !read_only_preview {
+        ensure_db_dir(&db_path).map_err(|e| anyhow::anyhow!(e))?;
+    }
+    if !read_only_preview {
+        match migrate_stale_dbs(&db_path) {
+            Ok(MigrationReport::NoOp) => {}
+            Ok(MigrationReport::Migrated {
+                sources,
                 rows_copied,
-                sources
-                    .iter()
-                    .map(|p| p.display().to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
+            }) => {
+                eprintln!(
+                    "[refine] migrated {} row(s) from legacy DB(s): {}",
+                    rows_copied,
+                    sources
+                        .iter()
+                        .map(|p| p.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+            Err(e) => eprintln!("[refine] warning: DB migration failed (continuing): {e}"),
         }
-        Err(e) => eprintln!("[refine] warning: DB migration failed (continuing): {e}"),
     }
 
-    let store = Arc::new(SqliteStore::open(&db_path).context("打开数据库失败")?);
+    let store = Arc::new(if read_only_preview {
+        SqliteStore::open_read_only(&db_path).context(
+            "以只读方式打开数据库失败（dry-run 不会创建或迁移数据库；请先运行一次正式命令）",
+        )?
+    } else {
+        SqliteStore::open(&db_path).context("打开数据库失败")?
+    });
     let repo: Arc<dyn ItemRepository> = store.clone();
     let engine = Arc::new(SearchEngine::new(repo));
 

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -6,6 +6,7 @@ mod cli;
 mod handlers;
 mod ingest_sessions;
 mod insights;
+mod insights_checkpoint;
 mod remem_sessions;
 mod support;
 

--- a/apps/cli/src/remem_sessions.rs
+++ b/apps/cli/src/remem_sessions.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use refine_core::session::{MessageRole, Session, SessionMessage, SessionMeta, SessionSource};
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -31,11 +31,15 @@ impl RememSession {
     }
 }
 
-pub(crate) fn load_remem_sessions(
+pub(crate) fn load_remem_session_summaries(
     limit: Option<usize>,
     latest: Option<usize>,
-) -> Result<Vec<RememSession>> {
-    load_remem_sessions_with_runner(&ProcessRunner, limit, latest)
+) -> Result<Vec<RememSessionSummary>> {
+    load_remem_session_summaries_with_runner(&ProcessRunner, limit, latest)
+}
+
+pub(crate) fn load_remem_session(summary: RememSessionSummary) -> Result<RememSession> {
+    load_one_session(&ProcessRunner, summary)
 }
 
 fn hex_component(value: &str) -> String {
@@ -87,20 +91,33 @@ struct SessionsEnvelope {
     project: Value,
     sample: i64,
     count: usize,
-    sessions: Vec<SessionSummary>,
+    sessions: Vec<RememSessionSummary>,
 }
 
 #[derive(Debug, Deserialize)]
-struct SessionSummary {
-    source_root: String,
-    project: String,
-    session_id: String,
-    first_epoch: i64,
-    last_epoch: i64,
-    message_count: i64,
-    user_message_count: i64,
-    assistant_message_count: i64,
-    user_message_samples: Vec<String>,
+pub(crate) struct RememSessionSummary {
+    pub source_root: String,
+    pub project: String,
+    pub session_id: String,
+    pub first_epoch: i64,
+    pub last_epoch: i64,
+    pub message_count: i64,
+    pub user_message_count: i64,
+    pub assistant_message_count: i64,
+    pub user_message_samples: Vec<String>,
+    #[serde(skip)]
+    pub legacy_identity_is_unique: bool,
+}
+
+impl RememSessionSummary {
+    pub(crate) fn stable_document_url(&self) -> String {
+        format!(
+            "remem-raw://v1/{}/{}/{}",
+            hex_component(&self.source_root),
+            hex_component(&self.project),
+            hex_component(&self.session_id)
+        )
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -128,11 +145,11 @@ struct RawMessage {
     created_at_epoch: i64,
 }
 
-fn load_remem_sessions_with_runner<R: Runner>(
+fn load_remem_session_summaries_with_runner<R: Runner>(
     runner: &R,
     limit: Option<usize>,
     latest: Option<usize>,
-) -> Result<Vec<RememSession>> {
+) -> Result<Vec<RememSessionSummary>> {
     ensure!(
         limit.is_none() || latest.is_none(),
         "limit and latest cannot be used together"
@@ -152,14 +169,26 @@ fn load_remem_sessions_with_runner<R: Runner>(
     if let Some(max) = latest.or(limit) {
         summaries.truncate(max);
     }
-    summaries
+    Ok(summaries)
+}
+
+#[cfg(test)]
+fn load_remem_sessions_with_runner<R: Runner>(
+    runner: &R,
+    limit: Option<usize>,
+    latest: Option<usize>,
+) -> Result<Vec<RememSession>> {
+    load_remem_session_summaries_with_runner(runner, limit, latest)?
         .into_iter()
         .map(|summary| load_one_session(runner, summary))
         .collect()
 }
 
-fn read_session_summaries<R: Runner>(runner: &R, args: &[String]) -> Result<Vec<SessionSummary>> {
-    let envelope: SessionsEnvelope = run_json(runner, args, "raw sessions")?;
+fn read_session_summaries<R: Runner>(
+    runner: &R,
+    args: &[String],
+) -> Result<Vec<RememSessionSummary>> {
+    let mut envelope: SessionsEnvelope = run_json(runner, args, "raw sessions")?;
     validate_nullable_i64(&envelope.since_epoch, "raw sessions since_epoch")?;
     validate_nullable_i64(&envelope.until_epoch, "raw sessions until_epoch")?;
     validate_nullable_string(&envelope.project, "raw sessions project")?;
@@ -210,10 +239,21 @@ fn read_session_summaries<R: Runner>(runner: &R, args: &[String]) -> Result<Vec<
             "raw sessions returned a duplicate selector tuple"
         );
     }
+    let mut identity_counts = HashMap::new();
+    for summary in &envelope.sessions {
+        *identity_counts
+            .entry((summary.source_root.clone(), summary.session_id.clone()))
+            .or_insert(0usize) += 1;
+    }
+    for summary in &mut envelope.sessions {
+        summary.legacy_identity_is_unique = identity_counts
+            .get(&(summary.source_root.clone(), summary.session_id.clone()))
+            == Some(&1);
+    }
     Ok(envelope.sessions)
 }
 
-fn load_one_session<R: Runner>(runner: &R, summary: SessionSummary) -> Result<RememSession> {
+fn load_one_session<R: Runner>(runner: &R, summary: RememSessionSummary) -> Result<RememSession> {
     let mut cursor: Option<String> = None;
     let mut seen_cursors = HashSet::new();
     let mut seen_ids = HashSet::new();
@@ -319,7 +359,7 @@ fn load_one_session<R: Runner>(runner: &R, summary: SessionSummary) -> Result<Re
     Ok(result)
 }
 
-fn validate_page(summary: &SessionSummary, envelope: &MessagesEnvelope) -> Result<()> {
+fn validate_page(summary: &RememSessionSummary, envelope: &MessagesEnvelope) -> Result<()> {
     ensure!(
         envelope.source_type == RAW_SOURCE_TYPE,
         "raw messages source_type drift"
@@ -372,7 +412,7 @@ fn validated_next_cursor(
     }
 }
 
-fn message_args(summary: &SessionSummary, cursor: Option<&str>) -> Vec<String> {
+fn message_args(summary: &RememSessionSummary, cursor: Option<&str>) -> Vec<String> {
     let mut args = strings(&[
         "raw",
         "messages",
@@ -538,6 +578,34 @@ mod tests {
             "remem-raw://v1/6c6f63616c/2f7265706f/7331"
         );
         assert!(runner.calls.borrow()[2].ends_with(&["--cursor".into(), "c1".into()]));
+    }
+
+    #[test]
+    fn summary_load_does_not_fetch_messages() {
+        let runner = FakeRunner::json(vec![sessions(1, vec![summary(3)])]);
+        let loaded = load_remem_session_summaries_with_runner(&runner, None, None).unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].message_count, 3);
+        assert_eq!(
+            loaded[0].stable_document_url(),
+            "remem-raw://v1/6c6f63616c/2f7265706f/7331"
+        );
+        assert_eq!(runner.calls.borrow().len(), 1);
+    }
+
+    #[test]
+    fn legacy_identity_uniqueness_is_computed_before_selection() {
+        let first = summary(1);
+        let mut second = summary(1);
+        second["project"] = Value::String("/other".into());
+        let runner = FakeRunner::json(vec![sessions(2, vec![first, second])]);
+
+        let loaded = load_remem_session_summaries_with_runner(&runner, None, Some(1)).unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert!(!loaded[0].legacy_identity_is_unique);
+        assert_eq!(runner.calls.borrow().len(), 1);
     }
 
     #[test]

--- a/apps/cli/src/remem_sessions.rs
+++ b/apps/cli/src/remem_sessions.rs
@@ -4,6 +4,7 @@ use refine_core::session::{MessageRole, Session, SessionMessage, SessionMeta, Se
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
+use std::io;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -64,6 +65,14 @@ trait Runner {
 }
 
 struct ProcessRunner;
+
+pub(crate) fn is_missing_remem_executable(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<io::Error>()
+            .is_some_and(|error| error.kind() == io::ErrorKind::NotFound)
+    })
+}
 
 impl Runner for ProcessRunner {
     fn run(&self, args: &[String]) -> Result<CommandResult> {
@@ -627,6 +636,22 @@ mod tests {
             stderr: Vec::new(),
         });
         assert!(load_remem_sessions_with_runner(&invalid, None, None).is_err());
+    }
+
+    #[test]
+    fn only_missing_launch_errors_are_fallback_candidates() {
+        let missing = Err::<(), _>(io::Error::new(io::ErrorKind::NotFound, "remem"))
+            .with_context(|| "run remem provider binary \"remem\"")
+            .expect_err("the wrapped launch error should be preserved");
+        assert!(is_missing_remem_executable(&missing));
+
+        let denied = Err::<(), _>(io::Error::new(io::ErrorKind::PermissionDenied, "remem"))
+            .with_context(|| "run remem provider binary \"remem\"")
+            .expect_err("the wrapped launch error should be preserved");
+        assert!(!is_missing_remem_executable(&denied));
+
+        let contract = anyhow::anyhow!("raw sessions contract drift");
+        assert!(!is_missing_remem_executable(&contract));
     }
 
     #[test]

--- a/apps/cli/src/support.rs
+++ b/apps/cli/src/support.rs
@@ -15,7 +15,9 @@ pub fn parse_item_type(raw: &str) -> Option<ItemType> {
 
 pub fn build_llm_client_from_env() -> Result<Arc<dyn LlmClient>> {
     build_core_llm_client_from_env().ok_or_else(|| {
-        anyhow!("未配置 LLM API Key，请设置 REFINE_ANTHROPIC_API_KEY 或 REFINE_OPENAI_API_KEY")
+        anyhow!(
+            "未配置 LLM API Key，请设置 REFINE_ANTHROPIC_API_KEY、REFINE_OPENAI_API_KEY 或 BASE_API_KEY"
+        )
     })
 }
 

--- a/apps/desktop/ui/vite.config.ts
+++ b/apps/desktop/ui/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   },
   clearScreen: false,
   server: {
+    host: '127.0.0.1',
     port: 8987,
     strictPort: true,
   },

--- a/apps/mirror/src/dashboard.rs
+++ b/apps/mirror/src/dashboard.rs
@@ -47,12 +47,12 @@ pub async fn handle_dashboard(
             .and_hms_opt(0, 0, 0)
             .ok_or_else(|| anyhow::anyhow!("invalid date"))?
             .and_utc();
-        repo.find_since(cutoff)
+        repo.find_observations_by_event_range(cutoff, chrono::Utc::now())
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))?
     } else {
         let cutoff = chrono::Utc::now() - chrono::Duration::days(90);
-        repo.find_since(cutoff)
+        repo.find_observations_by_event_range(cutoff, chrono::Utc::now())
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))?
     };

--- a/apps/mirror/src/main.rs
+++ b/apps/mirror/src/main.rs
@@ -19,8 +19,10 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    if let Err(e) = dotenvy::dotenv() {
-        eprintln!("Note: .env not loaded ({})", e);
+    if let Err(error) = dotenvy::dotenv() {
+        if should_report_dotenv_error(&error) {
+            eprintln!("Warning: failed to load .env ({error})");
+        }
     }
 
     tracing_subscriber::fmt()
@@ -56,5 +58,24 @@ async fn main() -> Result<()> {
             })?;
             profile::handle_profile(store.clone(), store, llm).await
         }
+    }
+}
+
+fn should_report_dotenv_error(error: &dotenvy::Error) -> bool {
+    !error.not_found()
+}
+
+#[cfg(test)]
+mod dotenv_tests {
+    use super::should_report_dotenv_error;
+    use std::io;
+
+    #[test]
+    fn missing_dotenv_is_silent_but_real_io_errors_are_reported() {
+        let missing = dotenvy::Error::Io(io::ErrorKind::NotFound.into());
+        let denied = dotenvy::Error::Io(io::ErrorKind::PermissionDenied.into());
+
+        assert!(!should_report_dotenv_error(&missing));
+        assert!(should_report_dotenv_error(&denied));
     }
 }

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -22,13 +22,13 @@ pub use compute::compute;
 pub use display::{indicator_display, layer_display};
 pub use persistence::{load_recent_scores, persist_score};
 pub use statusline::write_statusline;
-pub use types::{Indicator, LayerScore, ScoreResult, Signal};
+pub use types::{Indicator, LayerScore, ScoreResult, Signal, Trend};
 
-use baseline::apply_personal_baseline;
+use baseline::compute_personal_trends;
 use display::print_score;
 
 #[cfg(test)]
-use baseline::{signal_from_personal, PersonalBaseline};
+use baseline::{trend_from_personal, PersonalBaseline};
 
 #[cfg(test)]
 use compute::{
@@ -77,19 +77,17 @@ pub async fn handle_score(
         repo.find_all()
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))?
-    } else if let Some(ref since_str) = since {
-        let date = chrono::NaiveDate::parse_from_str(since_str, "%Y-%m-%d")
-            .map_err(|e| anyhow::anyhow!("invalid --since date '{}': {}", since_str, e))?;
-        let cutoff = date
-            .and_hms_opt(0, 0, 0)
-            .ok_or_else(|| anyhow::anyhow!("invalid date"))?
-            .and_utc();
-        repo.find_since(cutoff)
-            .await
-            .map_err(|e| anyhow::anyhow!("{}", e))?
     } else {
-        let cutoff = Utc::now() - chrono::Duration::days(90);
-        repo.find_since(cutoff)
+        let cutoff = if let Some(ref since_str) = since {
+            chrono::NaiveDate::parse_from_str(since_str, "%Y-%m-%d")
+                .map_err(|e| anyhow::anyhow!("invalid --since date '{}': {}", since_str, e))?
+                .and_hms_opt(0, 0, 0)
+                .ok_or_else(|| anyhow::anyhow!("invalid date"))?
+                .and_utc()
+        } else {
+            Utc::now() - chrono::Duration::days(90)
+        };
+        repo.find_observations_by_event_range(cutoff, Utc::now())
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))?
     };
@@ -119,21 +117,34 @@ pub async fn handle_score(
     }
     let cluster = cluster_observations(&items);
     let config = crate::config::load();
-    let mut result = compute(&cluster, &config.targets);
+    let result = compute(&cluster, &config.targets);
 
     // Try personal baseline: load history BEFORE persisting current score
     let history = load_recent_scores(365)?;
     let baseline = compute_personal_baseline(&history);
-    let using_personal = baseline.is_some();
-
-    if let Some(ref bl) = baseline {
-        apply_personal_baseline(&mut result, bl);
-    }
-
     persist_score(&result)?;
-    print_score(&result, using_personal);
+    let trends = baseline
+        .as_ref()
+        .map(|baseline| compute_personal_trends(&result, baseline));
+    print_score(&result, trends.as_ref());
 
-    // Data time range
+    let window = if all {
+        crate::lang::t!("all observations", "全部观测").to_string()
+    } else if let Some(since_date) = since.as_deref() {
+        crate::lang::t!(
+            format!("since {} (event time)", since_date),
+            format!("自 {} 起(事件时间)", since_date)
+        )
+    } else {
+        crate::lang::t!(
+            "rolling 90 days (event time)".to_string(),
+            "滚动 90 天(事件时间)".to_string()
+        )
+    };
+    println!("  {} {}", crate::lang::t!("Window:", "窗口:"), window);
+
+    // Items expose persistence timestamps here; the selection window above is
+    // based on the source document's event timestamp.
     if !items.is_empty() {
         let (min_t, max_t) = items.iter().fold(
             (DateTime::<Utc>::MAX_UTC, DateTime::<Utc>::MIN_UTC),
@@ -144,7 +155,7 @@ pub async fn handle_score(
         );
         println!(
             "  {} {} ~ {}",
-            crate::lang::t!("Data range:", "数据范围:"),
+            crate::lang::t!("Stored item range:", "入库条目范围:"),
             min_t.format("%Y-%m-%d"),
             max_t.format("%Y-%m-%d"),
         );
@@ -175,11 +186,11 @@ pub async fn handle_score(
     if let Some(llm) = llm {
         match crate::advice::generate_and_cache(&result, &llm).await {
             Ok(advice) => println!("\n  {} {}", crate::lang::t!("Advice:", "建议:"), advice),
-            Err(e) => tracing::debug!("advice generation skipped: {}", e),
+            Err(e) => tracing::error!("advice generation failed: {}", e),
         }
     }
 
-    if let Err(e) = write_statusline(&result, db_path) {
+    if let Err(e) = write_statusline(&result, db_path, trends.as_ref()) {
         tracing::warn!("failed to write statusline.txt: {}", e);
     }
     Ok(())

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -22,13 +22,16 @@ pub use compute::compute;
 pub use display::{indicator_display, layer_display};
 pub use persistence::{load_recent_scores, persist_score};
 pub use statusline::write_statusline;
-pub use types::{Indicator, LayerScore, ScoreResult, Signal, Trend};
+pub use types::{Indicator, LayerScore, ScoreResult, Signal};
 
 use baseline::compute_personal_trends;
 use display::print_score;
 
 #[cfg(test)]
 use baseline::{trend_from_personal, PersonalBaseline};
+
+#[cfg(test)]
+use types::Trend;
 
 #[cfg(test)]
 use compute::{

--- a/apps/mirror/src/score/baseline.rs
+++ b/apps/mirror/src/score/baseline.rs
@@ -1,5 +1,5 @@
 use chrono::{Duration, Utc};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use super::indicators::{canonical_indicator_key, indicator_direction, indicator_specs, Direction};
 use super::types::{ScoreResult, Trend};
@@ -44,7 +44,7 @@ fn extract_indicator(result: &ScoreResult, name: &str) -> Option<f64> {
 }
 
 /// Compute personal baseline from historical scores within the last 28 days.
-/// Returns None if fewer than BASELINE_MIN_ENTRIES scores exist in that window.
+/// Returns None if fewer than BASELINE_MIN_ENTRIES distinct days exist in that window.
 fn avg_from_scores(scores: &[&ScoreResult], indicator_name: &str) -> f64 {
     let (sum, count) = scores
         .iter()
@@ -62,7 +62,17 @@ fn avg_from_scores(scores: &[&ScoreResult], indicator_name: &str) -> f64 {
 
 pub fn compute_personal_baseline(history: &[ScoreResult]) -> Option<PersonalBaseline> {
     let cutoff = Utc::now() - Duration::days(BASELINE_WINDOW_DAYS);
-    let recent: Vec<&ScoreResult> = history.iter().filter(|s| s.timestamp >= cutoff).collect();
+    let mut by_day: BTreeMap<chrono::NaiveDate, &ScoreResult> = BTreeMap::new();
+    for score in history.iter().filter(|score| score.timestamp >= cutoff) {
+        let day = score.timestamp.date_naive();
+        match by_day.get(&day) {
+            Some(existing) if existing.timestamp >= score.timestamp => {}
+            _ => {
+                by_day.insert(day, score);
+            }
+        }
+    }
+    let recent: Vec<&ScoreResult> = by_day.into_values().collect();
 
     if recent.len() < BASELINE_MIN_ENTRIES {
         return None;

--- a/apps/mirror/src/score/baseline.rs
+++ b/apps/mirror/src/score/baseline.rs
@@ -1,9 +1,8 @@
 use chrono::{Duration, Utc};
 use std::collections::HashMap;
 
-use super::compute::analyze_tension;
-use super::indicators::{canonical_indicator_key, indicator_higher_is_better, indicator_specs};
-use super::types::{worst, ScoreResult, Signal};
+use super::indicators::{canonical_indicator_key, indicator_direction, indicator_specs, Direction};
+use super::types::{ScoreResult, Trend};
 
 /// Minimum number of historical scores to activate personal baseline
 const BASELINE_MIN_ENTRIES: usize = 7;
@@ -77,55 +76,107 @@ pub fn compute_personal_baseline(history: &[ScoreResult]) -> Option<PersonalBase
     Some(PersonalBaseline { averages })
 }
 
-/// Determine signal by comparing actual value against personal baseline.
-/// `higher_is_better`: true for metrics where higher = better (dreyfus, decision_quality, etc.)
-///                     false for metrics where lower = better (delegation, fragmentation, bug_decision)
-pub fn signal_from_personal(actual: f64, baseline: f64, higher_is_better: bool) -> Signal {
+/// Compare the current value with the rolling personal baseline. Band-targeted
+/// metrics do not have a meaningful monotonic direction and return `None`.
+pub(super) fn trend_from_personal(
+    actual: f64,
+    baseline: f64,
+    direction: Direction,
+) -> Option<Trend> {
     if baseline == 0.0 {
-        return Signal::Yellow;
+        return None;
     }
     let ratio = actual / baseline;
-    if higher_is_better {
-        if ratio >= 1.05 {
-            Signal::Green
-        } else if ratio >= 0.95 {
-            Signal::Yellow
+    match direction {
+        Direction::HigherBetter => Some(if ratio >= 1.05 {
+            Trend::Up
+        } else if ratio <= 0.95 {
+            Trend::Down
         } else {
-            Signal::Red
-        }
-    } else {
-        // Lower is better: ratio < 0.95 means actual is notably below baseline = good
-        if ratio <= 0.95 {
-            Signal::Green
-        } else if ratio <= 1.05 {
-            Signal::Yellow
+            Trend::Flat
+        }),
+        Direction::LowerBetter => Some(if ratio <= 0.95 {
+            Trend::Up
+        } else if ratio >= 1.05 {
+            Trend::Down
         } else {
-            Signal::Red
-        }
+            Trend::Flat
+        }),
+        Direction::Band => None,
     }
 }
 
-/// Apply personal baseline to override signals on a ScoreResult (in-place).
-pub(super) fn apply_personal_baseline(result: &mut ScoreResult, baseline: &PersonalBaseline) {
-    for layer in &mut result.layers {
-        for indicator in &mut layer.indicators {
-            let key = canonical_indicator_key(&indicator.name);
-            let Some(higher_is_better) = indicator_higher_is_better(key) else {
-                continue;
-            };
-            let Some(baseline_value) = baseline.average(key) else {
-                continue;
-            };
+#[derive(Debug, Clone, Default)]
+pub struct PersonalTrends {
+    per_indicator: HashMap<String, Trend>,
+    per_layer: [Option<Trend>; 3],
+}
 
-            indicator.signal =
-                signal_from_personal(indicator.actual, baseline_value, higher_is_better);
-        }
-
-        // Recalculate layer signal as worst of its indicators
-        let sigs: Vec<Signal> = layer.indicators.iter().map(|i| i.signal).collect();
-        layer.signal = worst(&sigs);
+impl PersonalTrends {
+    pub fn indicator(&self, name: &str) -> Option<Trend> {
+        self.per_indicator
+            .get(canonical_indicator_key(name))
+            .copied()
     }
 
-    // Recalculate tension after signal changes
-    result.tension = analyze_tension(&result.layers);
+    pub fn overall(&self) -> Option<Trend> {
+        aggregate(self.per_layer.iter().copied().flatten())
+    }
+}
+
+fn aggregate(trends: impl Iterator<Item = Trend>) -> Option<Trend> {
+    let mut has_up = false;
+    let mut has_down = false;
+    let mut any = false;
+    for trend in trends {
+        any = true;
+        match trend {
+            Trend::Up => has_up = true,
+            Trend::Down => has_down = true,
+            Trend::Flat => {}
+        }
+    }
+    if !any {
+        return None;
+    }
+    Some(match (has_up, has_down) {
+        (true, false) => Trend::Up,
+        (false, true) => Trend::Down,
+        _ => Trend::Flat,
+    })
+}
+
+/// Derive a read-only personal trend view. Absolute target signals remain
+/// untouched and retain the same meaning in daily, weekly, and persisted data.
+pub(super) fn compute_personal_trends(
+    result: &ScoreResult,
+    baseline: &PersonalBaseline,
+) -> PersonalTrends {
+    let mut per_indicator = HashMap::new();
+    let mut per_layer = [None, None, None];
+
+    for (index, layer) in result.layers.iter().enumerate() {
+        for indicator in &layer.indicators {
+            let key = canonical_indicator_key(&indicator.name);
+            let (Some(direction), Some(baseline_value)) =
+                (indicator_direction(key), baseline.average(key))
+            else {
+                continue;
+            };
+            if let Some(trend) = trend_from_personal(indicator.actual, baseline_value, direction) {
+                per_indicator.insert(key.to_string(), trend);
+            }
+        }
+
+        per_layer[index] = aggregate(layer.indicators.iter().filter_map(|indicator| {
+            per_indicator
+                .get(canonical_indicator_key(&indicator.name))
+                .copied()
+        }));
+    }
+
+    PersonalTrends {
+        per_indicator,
+        per_layer,
+    }
 }

--- a/apps/mirror/src/score/display.rs
+++ b/apps/mirror/src/score/display.rs
@@ -1,5 +1,6 @@
 use crate::lang::t;
 
+use super::baseline::PersonalTrends;
 use super::indicators::indicator_display_name;
 use super::types::{ScoreResult, Signal};
 
@@ -20,7 +21,7 @@ pub fn indicator_display(key: &str) -> &'static str {
 
 // ── Output ──
 
-pub(super) fn print_score(result: &ScoreResult, using_personal: bool) {
+pub(super) fn print_score(result: &ScoreResult, trends: Option<&PersonalTrends>) {
     println!("{}\n", t!("Mirror Cognitive Snapshot", "Mirror 认知镜像"));
     for layer in &result.layers {
         let details: Vec<String> = layer
@@ -32,11 +33,16 @@ pub(super) fn print_score(result: &ScoreResult, using_personal: bool) {
                 } else {
                     "✗"
                 };
+                let arrow = trends
+                    .and_then(|personal| personal.indicator(&i.name))
+                    .map(|trend| trend.arrow())
+                    .unwrap_or("");
                 format!(
-                    "{} {} {}",
+                    "{} {} {}{}",
                     indicator_display(&i.name),
                     i.display_value(),
-                    mark
+                    mark,
+                    arrow
                 )
             })
             .collect();
@@ -50,20 +56,20 @@ pub(super) fn print_score(result: &ScoreResult, using_personal: bool) {
     if let Some(ref tension) = result.tension {
         println!("\n  {}{}", t!("Tension: ", "张力: "), tension);
     }
-    if using_personal {
+    if trends.is_some() {
         println!(
             "  {}",
             t!(
-                "Baseline: personal (4-week rolling avg)",
-                "基线: 个人(4周均值)"
+                "✓ = meets the absolute target · arrow = vs your 4-week average",
+                "✓ = 达到绝对目标 · 箭头 = 相对你近 4 周均值"
             )
         );
     } else {
         println!(
             "  {}",
             t!(
-                "Baseline: default thresholds (insufficient data for personal baseline)",
-                "基线: 默认阈值(数据不足4周)"
+                "✓ = meets the absolute target · trend unavailable (less than 4 weeks of data)",
+                "✓ = 达到绝对目标 · 趋势不可用(数据不足4周)"
             )
         );
     }

--- a/apps/mirror/src/score/indicators.rs
+++ b/apps/mirror/src/score/indicators.rs
@@ -8,11 +8,18 @@ pub(super) enum IndicatorFormat {
     Integer,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Direction {
+    HigherBetter,
+    LowerBetter,
+    Band,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(super) struct IndicatorSpec {
     pub key: &'static str,
     pub format: IndicatorFormat,
-    pub higher_is_better: bool,
+    pub direction: Direction,
     aliases: &'static [&'static str],
     display_en: &'static str,
     display_zh: &'static str,
@@ -35,7 +42,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "dreyfus",
         format: IndicatorFormat::Fixed1,
-        higher_is_better: true,
+        direction: Direction::HigherBetter,
         aliases: &["Dreyfus"],
         display_en: "Dreyfus",
         display_zh: "Dreyfus",
@@ -43,7 +50,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "decision_quality",
         format: IndicatorFormat::Percent0,
-        higher_is_better: true,
+        direction: Direction::HigherBetter,
         aliases: &["Decision Quality", "决策质量"],
         display_en: "Decision Quality",
         display_zh: "决策质量",
@@ -51,7 +58,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "depth_output",
         format: IndicatorFormat::Percent0,
-        higher_is_better: true,
+        direction: Direction::HigherBetter,
         aliases: &["Depth Output", "深度产出比"],
         display_en: "Depth Output",
         display_zh: "深度产出比",
@@ -59,7 +66,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "knowledge_rate",
         format: IndicatorFormat::Fixed1,
-        higher_is_better: true,
+        direction: Direction::HigherBetter,
         aliases: &["Knowledge", "知识获取"],
         display_en: "Knowledge",
         display_zh: "知识获取",
@@ -67,7 +74,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "exploration",
         format: IndicatorFormat::Percent0,
-        higher_is_better: true,
+        direction: Direction::HigherBetter,
         aliases: &["Exploration", "探索率", "探索占比"],
         display_en: "Exploration",
         display_zh: "探索率",
@@ -75,7 +82,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "deep_invest",
         format: IndicatorFormat::Percent0,
-        higher_is_better: true,
+        direction: Direction::Band,
         aliases: &["Deep Invest", "深耕率", "深挖率", "深挖占比"],
         display_en: "Deep Invest",
         display_zh: "深耕率",
@@ -83,7 +90,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "fragmentation",
         format: IndicatorFormat::Percent0,
-        higher_is_better: false,
+        direction: Direction::LowerBetter,
         aliases: &["Fragmentation", "碎片化"],
         display_en: "Fragmentation",
         display_zh: "碎片化",
@@ -91,7 +98,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "delegation",
         format: IndicatorFormat::Percent0,
-        higher_is_better: false,
+        direction: Direction::LowerBetter,
         aliases: &["Delegation", "delegation", "委派率", "委派比"],
         display_en: "delegation",
         display_zh: "委派率",
@@ -99,7 +106,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "mode_diversity",
         format: IndicatorFormat::Integer,
-        higher_is_better: true,
+        direction: Direction::HigherBetter,
         aliases: &["Mode Diversity", "模式多样性"],
         display_en: "Mode Diversity",
         display_zh: "模式多样性",
@@ -107,7 +114,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "bug_decision",
         format: IndicatorFormat::Fixed2,
-        higher_is_better: false,
+        direction: Direction::LowerBetter,
         aliases: &["Bug/Decision", "bug/decision", "bug/决策"],
         display_en: "bug/decision",
         display_zh: "bug/决策",
@@ -115,7 +122,7 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
     IndicatorSpec {
         key: "friction_density",
         format: IndicatorFormat::Fixed1,
-        higher_is_better: false,
+        direction: Direction::LowerBetter,
         aliases: &["Friction", "摩擦密度"],
         display_en: "Friction",
         display_zh: "摩擦密度",
@@ -158,6 +165,6 @@ pub(super) fn format_indicator_value(name: &str, actual: f64) -> String {
     }
 }
 
-pub(super) fn indicator_higher_is_better(name: &str) -> Option<bool> {
-    indicator_spec(name).map(|spec| spec.higher_is_better)
+pub(super) fn indicator_direction(name: &str) -> Option<Direction> {
+    indicator_spec(name).map(|spec| spec.direction)
 }

--- a/apps/mirror/src/score/statusline.rs
+++ b/apps/mirror/src/score/statusline.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use std::path::Path;
 
+use super::baseline::PersonalTrends;
 use super::types::ScoreResult;
 
 /// Sanitize a string for safe single-line statusline output.
@@ -18,14 +19,22 @@ fn sanitize_single_line(s: &str) -> String {
 /// Format: "🪞🟡🔴🔴 🔥4天 <short_advice>"
 ///
 /// `short` is the short advice from the LLM advice cache (may be empty).
-pub fn build_statusline(result: &ScoreResult, short: &str) -> String {
+pub fn build_statusline(
+    result: &ScoreResult,
+    short: &str,
+    trends: Option<&PersonalTrends>,
+) -> String {
     let depth_e = result.layers[0].signal.emoji();
     let breadth_e = result.layers[1].signal.emoji();
     let collab_e = result.layers[2].signal.emoji();
+    let arrow = trends
+        .and_then(PersonalTrends::overall)
+        .map(|trend| trend.arrow())
+        .unwrap_or("");
 
     let streak = super::streak::current_streak();
 
-    let mut parts = vec![format!("🪞{}{}{}", depth_e, breadth_e, collab_e)];
+    let mut parts = vec![format!("🪞{}{}{}{}", depth_e, breadth_e, collab_e, arrow)];
     if streak >= 2 {
         parts.push(format!("🔥{}天", streak));
     }
@@ -43,7 +52,11 @@ pub fn build_statusline(result: &ScoreResult, short: &str) -> String {
 ///
 /// Uses an atomic write (temp file + rename) to prevent concurrent readers from
 /// observing a partially-written file.
-pub fn write_statusline(result: &ScoreResult, _db_path: &Path) -> Result<()> {
+pub fn write_statusline(
+    result: &ScoreResult,
+    _db_path: &Path,
+    trends: Option<&PersonalTrends>,
+) -> Result<()> {
     let short = match crate::advice::load_cached() {
         Ok(cached) => cached
             .map(|c| c.short)
@@ -55,7 +68,7 @@ pub fn write_statusline(result: &ScoreResult, _db_path: &Path) -> Result<()> {
         }
     };
 
-    let line = build_statusline(result, &short);
+    let line = build_statusline(result, &short, trends);
     let dir = crate::config::ensure_mirror_dir()?;
     let dest = dir.join("statusline.txt");
 
@@ -111,7 +124,7 @@ mod tests {
     #[test]
     fn build_statusline_compact_format() {
         let result = make_result([Signal::Green, Signal::Red, Signal::Yellow]);
-        let line = build_statusline(&result, "some advice");
+        let line = build_statusline(&result, "some advice", None);
         assert!(line.starts_with("🪞"), "should start with mirror emoji");
         assert!(line.contains("🟢"), "depth signal missing");
         assert!(line.contains("🔴"), "breadth signal missing");
@@ -122,7 +135,7 @@ mod tests {
     #[test]
     fn build_statusline_no_advice_no_trailing_space() {
         let result = make_result([Signal::Green, Signal::Green, Signal::Green]);
-        let line = build_statusline(&result, "");
+        let line = build_statusline(&result, "", None);
         assert!(!line.ends_with(' '), "should not have trailing space");
         assert!(line.starts_with("🪞🟢🟢🟢"));
     }
@@ -130,16 +143,43 @@ mod tests {
     #[test]
     fn build_statusline_ends_with_advice() {
         let result = make_result([Signal::Red, Signal::Red, Signal::Red]);
-        let line = build_statusline(&result, "tip");
+        let line = build_statusline(&result, "tip", None);
         assert!(line.ends_with("tip"), "advice should be last: {}", line);
         assert!(line.starts_with("🪞🔴🔴🔴"));
+    }
+
+    #[test]
+    fn build_statusline_appends_one_personal_trend_arrow() {
+        use crate::score::baseline::{compute_personal_trends, PersonalBaseline};
+
+        let mut result = make_result([Signal::Green, Signal::Yellow, Signal::Red]);
+        let indicators = [
+            ("dreyfus", 4.0),
+            ("exploration", 20.0),
+            ("bug_decision", 0.3),
+        ];
+        for (layer, (name, actual)) in result.layers.iter_mut().zip(indicators) {
+            layer.indicators[0].name = name.into();
+            layer.indicators[0].actual = actual;
+        }
+        let baseline = PersonalBaseline::from_averages(&[
+            ("dreyfus", 3.0),
+            ("exploration", 15.0),
+            ("bug_decision", 0.6),
+        ]);
+        let trends = compute_personal_trends(&result, &baseline);
+        let line = build_statusline(&result, "", Some(&trends));
+
+        assert!(line.starts_with("🪞🟢🟡🔴↑"));
+        assert_eq!(line.chars().filter(|c| "↑→↓".contains(*c)).count(), 1);
+        assert!(!line.contains('\n'));
     }
 
     #[test]
     fn write_statusline_creates_file() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let result = make_result([Signal::Green, Signal::Red, Signal::Yellow]);
-        let line = build_statusline(&result, "test-advice");
+        let line = build_statusline(&result, "test-advice", None);
         let path = dir.path().join("statusline.txt");
         std::fs::write(&path, &line)?;
         let content = std::fs::read_to_string(&path)?;

--- a/apps/mirror/src/score/tests/baseline.rs
+++ b/apps/mirror/src/score/tests/baseline.rs
@@ -242,30 +242,35 @@ fn test_personal_baseline_mixed_legacy_schema_repro() {
 }
 
 #[test]
-fn test_signal_from_personal() {
-    // higher_is_better = true
-    // actual = 105% of baseline → green
-    assert_eq!(signal_from_personal(10.5, 10.0, true), Signal::Green);
-    // actual = 100% of baseline → yellow (within ±5%)
-    assert_eq!(signal_from_personal(10.0, 10.0, true), Signal::Yellow);
-    // actual = 90% of baseline → red
-    assert_eq!(signal_from_personal(9.0, 10.0, true), Signal::Red);
+fn test_trend_from_personal() {
+    use crate::score::indicators::Direction;
 
-    // higher_is_better = false (lower is better)
-    // actual = 90% of baseline → green (notably lower = good)
-    assert_eq!(signal_from_personal(9.0, 10.0, false), Signal::Green);
-    // actual = 100% of baseline → yellow
-    assert_eq!(signal_from_personal(10.0, 10.0, false), Signal::Yellow);
-    // actual = 110% of baseline → red (higher = bad)
-    assert_eq!(signal_from_personal(11.0, 10.0, false), Signal::Red);
-
-    // Edge: baseline == 0 → yellow
-    assert_eq!(signal_from_personal(5.0, 0.0, true), Signal::Yellow);
-    assert_eq!(signal_from_personal(0.0, 0.0, false), Signal::Yellow);
+    assert_eq!(
+        trend_from_personal(10.5, 10.0, Direction::HigherBetter),
+        Some(Trend::Up)
+    );
+    assert_eq!(
+        trend_from_personal(10.0, 10.0, Direction::HigherBetter),
+        Some(Trend::Flat)
+    );
+    assert_eq!(
+        trend_from_personal(9.0, 10.0, Direction::HigherBetter),
+        Some(Trend::Down)
+    );
+    assert_eq!(
+        trend_from_personal(9.0, 10.0, Direction::LowerBetter),
+        Some(Trend::Up)
+    );
+    assert_eq!(
+        trend_from_personal(11.0, 10.0, Direction::LowerBetter),
+        Some(Trend::Down)
+    );
+    assert_eq!(trend_from_personal(20.0, 10.0, Direction::Band), None);
+    assert_eq!(trend_from_personal(5.0, 0.0, Direction::HigherBetter), None);
 }
 
 #[test]
-fn test_apply_personal_baseline() {
+fn test_personal_trends_do_not_override_absolute_signals() {
     let now = Utc::now();
 
     // Baseline averages
@@ -283,8 +288,7 @@ fn test_apply_personal_baseline() {
         ("friction_density", 1.0), // lower is better
     ]);
 
-    // Current score: all significantly above baseline
-    let mut result = make_score_result(
+    let result = make_score_result(
         3.5,  // dreyfus: 3.5/3.0 = 1.167 → green (higher is better)
         60.0, // dq: 60/50 = 1.20 → green
         12.0, // do: 12/10 = 1.20 → green
@@ -299,25 +303,27 @@ fn test_apply_personal_baseline() {
         now,
     );
 
-    apply_personal_baseline(&mut result, &baseline);
+    let signals_before: Vec<Signal> = result
+        .layers
+        .iter()
+        .flat_map(|layer| layer.indicators.iter().map(|indicator| indicator.signal))
+        .collect();
+    let trends = compute_personal_trends(&result, &baseline);
+    let signals_after: Vec<Signal> = result
+        .layers
+        .iter()
+        .flat_map(|layer| layer.indicators.iter().map(|indicator| indicator.signal))
+        .collect();
 
-    // All indicators should be green
-    for layer in &result.layers {
-        for indicator in &layer.indicators {
-            assert_eq!(
-                indicator.signal,
-                Signal::Green,
-                "expected green for {} (actual={})",
-                indicator.name,
-                indicator.actual,
-            );
-        }
-        assert_eq!(layer.signal, Signal::Green);
-    }
+    assert_eq!(signals_after, signals_before);
+    assert_eq!(trends.indicator("dreyfus"), Some(Trend::Up));
+    assert_eq!(trends.indicator("fragmentation"), Some(Trend::Up));
+    assert_eq!(trends.indicator("deep_invest"), None);
+    assert_eq!(trends.overall(), Some(Trend::Up));
 }
 
 #[test]
-fn test_apply_personal_baseline_regression() {
+fn test_personal_trends_detect_regression_without_recoloring() {
     let now = Utc::now();
 
     let baseline = PersonalBaseline::from_averages(&[
@@ -335,7 +341,7 @@ fn test_apply_personal_baseline_regression() {
     ]);
 
     // Current: all significantly worse than baseline
-    let mut result = make_score_result(
+    let result = make_score_result(
         3.0,  // dreyfus: 3.0/4.0 = 0.75 → red
         50.0, // dq: 50/70 = 0.71 → red
         10.0, // do: 10/15 = 0.67 → red
@@ -350,18 +356,15 @@ fn test_apply_personal_baseline_regression() {
         now,
     );
 
-    apply_personal_baseline(&mut result, &baseline);
+    let layer_signals = result.layers.clone().map(|layer| layer.signal);
+    let trends = compute_personal_trends(&result, &baseline);
 
-    for layer in &result.layers {
-        for indicator in &layer.indicators {
-            assert_eq!(
-                indicator.signal,
-                Signal::Red,
-                "expected red for {} (actual={})",
-                indicator.name,
-                indicator.actual,
-            );
-        }
-        assert_eq!(layer.signal, Signal::Red);
-    }
+    assert_eq!(
+        result.layers.clone().map(|layer| layer.signal),
+        layer_signals
+    );
+    assert_eq!(trends.indicator("dreyfus"), Some(Trend::Down));
+    assert_eq!(trends.indicator("fragmentation"), Some(Trend::Down));
+    assert_eq!(trends.indicator("deep_invest"), None);
+    assert_eq!(trends.overall(), Some(Trend::Down));
 }

--- a/apps/mirror/src/score/tests/baseline.rs
+++ b/apps/mirror/src/score/tests/baseline.rs
@@ -150,6 +150,30 @@ fn test_personal_baseline_insufficient_data() {
 }
 
 #[test]
+fn repeated_scores_on_one_day_do_not_manufacture_a_baseline() {
+    let now = Utc::now();
+    let history = (0..10)
+        .map(|seconds| {
+            make_score_result(
+                3.5,
+                60.0,
+                10.0,
+                0.5,
+                20.0,
+                25.0,
+                15.0,
+                30.0,
+                4.0,
+                0.2,
+                0.8,
+                now - Duration::seconds(seconds),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert!(compute_personal_baseline(&history).is_none());
+}
+
+#[test]
 fn test_personal_baseline_old_data_excluded() {
     let now = Utc::now();
     // 10 entries but all older than 28 days

--- a/apps/mirror/src/score/types.rs
+++ b/apps/mirror/src/score/types.rs
@@ -59,6 +59,25 @@ impl std::fmt::Display for Signal {
     }
 }
 
+/// Direction relative to the user's rolling 28-day average. `Up` always means
+/// improvement after accounting for whether lower or higher values are better.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Trend {
+    Up,
+    Flat,
+    Down,
+}
+
+impl Trend {
+    pub const fn arrow(self) -> &'static str {
+        match self {
+            Trend::Up => "↑",
+            Trend::Flat => "→",
+            Trend::Down => "↓",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Indicator {
     pub name: String,

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -119,12 +119,6 @@ pub async fn handle_weekly(
 
     println!("{}", report);
 
-    // Save the full report as the sentinel file for the MOTD weekly reminder.
-    // The MOTD reads this on Mondays to show a one-line reminder.
-    if let Err(e) = save_last_weekly_md(&report) {
-        tracing::warn!("failed to save last-weekly.md: {}", e);
-    }
-
     save_weekly_record(&this_score)?;
     let doc_id = save_report_to_document(
         &doc_repo,
@@ -144,6 +138,9 @@ pub async fn handle_weekly(
             format!("周报已保存 (ID: {})", doc_id)
         )
     );
+
+    save_last_weekly_md(&report)
+        .context("weekly report saved, but failed to write the MOTD sentinel")?;
 
     Ok(())
 }
@@ -207,6 +204,13 @@ fn build_weekly_report(
         t!(
             "Metrics-derived report — for coaching run `refine cognitive-portrait`",
             "指标驱动报告 — 教练分析请运行 `refine cognitive-portrait`"
+        )
+    ));
+    lines.push(format!(
+        "> {}",
+        t!(
+            "Window: rolling 7 days (event time) · signals: absolute targets",
+            "窗口: 滚动 7 天(事件时间) · 信号灯: 绝对目标"
         )
     ));
 

--- a/apps/server/src/extraction.rs
+++ b/apps/server/src/extraction.rs
@@ -149,6 +149,7 @@ async fn canonicalize_document(
         raw_content: doc.raw_content().to_string(),
         source: doc.source().to_string(),
         url: doc.url().to_string(),
+        source_version: doc.source_version().map(ToOwned::to_owned),
         captured_at: doc.captured_at(),
         created_at: existing.created_at(),
         updated_at: doc.updated_at(),

--- a/apps/server/src/handlers.rs
+++ b/apps/server/src/handlers.rs
@@ -37,10 +37,11 @@ use crate::state::AppState;
 // Only `/`, `/dashboard`, and `/health` are public. Every `/v1/*` handler must
 // keep `AuthenticatedUser` in its signature so request_guard.rs remains the
 // single auth boundary.
-pub async fn health() -> impl IntoResponse {
+pub async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     ok(json!({
         "message": "Refine cloud API (Rust) is running",
-        "contract_version": SERVER_CONTRACT_VERSION
+        "contract_version": SERVER_CONTRACT_VERSION,
+        "llm_configured": state.llm_client.is_some()
     }))
 }
 

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -25,7 +25,11 @@ const MAX_FALLBACK_ATTEMPTS: usize = FALLBACK_PORTS.len();
 
 #[tokio::main]
 async fn main() {
-    let _ = dotenvy::dotenv();
+    if let Err(error) = dotenvy::dotenv() {
+        if !error.not_found() {
+            eprintln!("Warning: failed to load .env ({error})");
+        }
+    }
 
     tracing_subscriber::fmt()
         .with_env_filter("refine_server=info,refine_core=info")
@@ -219,7 +223,7 @@ fn requires_api_token_for_bind(addr: &SocketAddr) -> bool {
 mod tests {
     use super::{build_app, parse_bind_addr, requires_api_token_for_bind, DEFAULT_SERVER_PORT};
     use crate::state::{AppState, AuthConfig};
-    use axum::body::Body;
+    use axum::body::{to_bytes, Body};
     use axum::http::{header, HeaderValue, Method, Request, StatusCode};
     use axum::Router;
     use serde_json::json;
@@ -280,6 +284,13 @@ mod tests {
             .expect("dispatch health request");
 
         assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read health response");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&body).expect("health response is JSON");
+        assert_eq!(payload.get("success"), Some(&json!(true)));
+        assert_eq!(payload.get("llm_configured"), Some(&json!(false)));
     }
 
     #[tokio::test]

--- a/docs/11_API_SPEC.md
+++ b/docs/11_API_SPEC.md
@@ -131,9 +131,15 @@ GET /health
 ```json
 {
   "success": true,
-  "message": "Refine cloud API (Rust) is running"
+  "message": "Refine cloud API (Rust) is running",
+  "contract_version": "1.0",
+  "llm_configured": true
 }
 ```
+
+`llm_configured` is a non-secret readiness flag. When it is `false`, query
+routes remain available but strict extraction jobs will fail until the server
+is restarted with an LLM credential source.
 
 **超出免费额度（403）**：
 ```json

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -27,8 +27,46 @@ The installer is idempotent. It can be used for first install and for upgrades f
 - Installs desktop UI dependencies with `bun install` when Bun is available.
 - Writes macOS user LaunchAgents under `~/Library/LaunchAgents/`.
 - Starts or reloads the local server and UI dev service.
-- Schedules daily ingest at 08:00 and weekly insights on Monday at 09:00.
+- Schedules daily ingest at 08:00 and weekly insights on Sunday at 09:00.
 - Enables local dashboard/API access with `REFINE_DEV_ANON=1` by default.
+- Creates `~/.refine` with user-only permissions. It never migrates or copies
+  LLM credentials; when they are absent it prints the read-only configure
+  command.
+
+## Configure LLM credentials for launchd
+
+The canonical unattended credential file is `~/.refine/llm.env`. It must be a
+regular, non-symlink file owned by the current user with no group/other bits
+(normally mode `0600`). Scheduled scripts do not source `~/.zshrc`.
+
+Review a migration without changing files:
+
+```bash
+bash scripts/configure-llm-env.sh --check
+```
+
+After reviewing the redacted check, perform the one-time migration of literal
+`export BASE_URL=...`, `export BASE_API_KEY=...`, and `export BASE_MODEL=...`
+definitions:
+
+```bash
+bash scripts/configure-llm-env.sh --migrate
+```
+
+If the supported variables are already exported in the current shell, the
+explicit alternative is:
+
+```bash
+bash scripts/configure-llm-env.sh --from-env
+```
+
+The loader precedence is current non-empty process credentials, then the
+secure file, then an explicitly supplied repository `.env` fallback. It
+supports the Anthropic aliases `REFINE_ANTHROPIC_API_KEY`,
+`ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_API_KEY`; the OpenAI aliases
+`REFINE_OPENAI_API_KEY` and `OPENAI_API_KEY`; and the compatibility
+`BASE_API_KEY`, together with their URL/model variables. Values are never
+printed by the loader, migration helper, or credential preflight.
 
 ## Auth Modes
 
@@ -80,7 +118,7 @@ scripts/install-local.sh --no-start
 | --- | --- | --- | --- |
 | `com.lifcc.refine-server` | Local API/dashboard | RunAtLoad + KeepAlive | `~/Library/Logs/refine-server.log` |
 | `com.lifcc.refine-daily-ingest` | `refine ingest-sessions` + `mirror score` | Daily 08:00 | `~/Library/Logs/refine-daily-ingest.log` |
-| `com.lifcc.refine-weekly-insights` | `refine insights --prescription` | Monday 09:00 | `~/Library/Logs/refine-insights.log` |
+| `com.lifcc.refine-weekly-insights` | `refine insights --prescription` | Sunday 09:00 | `~/Library/Logs/refine-insights.log` |
 | `com.lifcc.refine-ui-dev` | Desktop UI Vite dev server | RunAtLoad + KeepAlive | `.run/launchd-refine-ui.*.log` |
 
 ## Health Check
@@ -91,7 +129,12 @@ Run:
 scripts/doctor-local.sh
 ```
 
-The doctor checks installed binaries, LaunchAgents, `/health`, a protected `/v1/*` API route, database freshness, log files, and UI dependencies. Use `scripts/doctor-local.sh --no-ui-dev` for installs that intentionally disable the desktop UI dev service.
+The doctor checks installed binaries, LaunchAgents, a launchd-like clean
+environment credential preflight, `/health`, a protected `/v1/*` API route,
+database freshness, log files, and UI dependencies. It fails when unattended
+credentials are missing or the secure file has invalid ownership, type, or
+permissions. Use `scripts/doctor-local.sh --no-ui-dev` for installs that
+intentionally disable the desktop UI dev service.
 
 Common symptoms:
 

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -23,7 +23,7 @@ The installer is idempotent. It can be used for first install and for upgrades f
 
 ## What The Installer Does
 
-- Installs `refine`, `mirror`, and `refine-server` with `cargo install --path`.
+- Installs `refine`, `mirror`, and `refine-server` with `cargo install --locked --path`.
 - Installs desktop UI dependencies with `bun install` when Bun is available.
 - Writes macOS user LaunchAgents under `~/Library/LaunchAgents/`.
 - Starts or reloads the local server and UI dev service.

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -26,7 +26,8 @@ The installer is idempotent. It can be used for first install and for upgrades f
 - Installs `refine`, `mirror`, and `refine-server` with `cargo install --locked --path`.
 - Installs desktop UI dependencies with `bun install` when Bun is available.
 - Writes macOS user LaunchAgents under `~/Library/LaunchAgents/`.
-- Starts or reloads the local server and UI dev service.
+- Starts or reloads the local server and UI dev service. The server uses the
+  same validated LLM credential loader as scheduled jobs.
 - Schedules daily ingest at 08:00 and weekly insights on Sunday at 09:00.
 - Enables local dashboard/API access with `REFINE_DEV_ANON=1` by default.
 - Creates `~/.refine` with user-only permissions. It never migrates or copies
@@ -68,6 +69,11 @@ supports the Anthropic aliases `REFINE_ANTHROPIC_API_KEY`,
 `BASE_API_KEY`, together with their URL/model variables. Values are never
 printed by the loader, migration helper, or credential preflight.
 
+The server health response includes `llm_configured` so `doctor-local.sh` can
+detect a query-only server that would reject extraction jobs. Its append-only
+logs include a timestamped startup boundary, making errors from an earlier
+process distinguishable from the current run.
+
 ## Auth Modes
 
 Default local mode:
@@ -84,7 +90,10 @@ Token mode:
 REFINE_API_TOKEN=your-token scripts/install-local.sh --token-auth
 ```
 
-Token mode writes the token to `~/.refine/refine-server.token` with mode `0600` and points the server LaunchAgent at `~/.refine/run-refine-server.sh`. The token is not written into the plist. Clients must send `Authorization: Bearer <token>`.
+Token mode writes the token to `~/.refine/refine-server.token` with mode `0600`
+and passes only that file path to the shared server startup wrapper. The token
+value is not written into the plist. Clients must send
+`Authorization: Bearer <token>`.
 
 ## Useful Variants
 

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -11,11 +11,13 @@ Use the installer from the repository root:
 scripts/install-local.sh
 ```
 
-Session ingestion also requires a compatible `remem` binary on `PATH` (or an
-explicit `REFINE_REMEM_BIN` path). Refine treats remem subprocess and JSON
-contract failures as ingest failures; it does not silently fall back to local
-transcript scanning. The temporary `--legacy-local-scan` option is the only
-rollback path during the one-release transition window.
+Session ingestion defaults to `--provider auto`: it prefers a compatible
+`remem` binary on `PATH` (or an explicit `REFINE_REMEM_BIN` path), and uses the
+local Claude/Codex scanner only when that executable is absent. Remem
+subprocess, malformed JSON, contract, and pagination failures are ingest
+failures and never silently fall back. Use `--provider remem` for strict remem
+operation or `--provider local` for supported local discovery; the deprecated
+`--legacy-local-scan` option remains an alias for `--provider local`.
 
 The installer is idempotent. It can be used for first install and for upgrades from a newer checkout.
 

--- a/docs/SPEC-session-insights.md
+++ b/docs/SPEC-session-insights.md
@@ -11,10 +11,12 @@
 | 来源 | 入口 | 格式 |
 |------|------|------|
 | remem raw archive | `remem raw sessions/messages --json` | 完整 user/assistant 消息和精确 selector tuple |
-| 本地 Claude/Codex 文件 | `--legacy-local-scan` | 仅一个发布周期的显式回滚路径 |
+| 本地 Claude/Codex 文件 | `--provider local` | 本地文件发现与 JSONL 解析 |
 
-默认路径不直接扫描文件系统。refine 逐页读取 remem 快照，并严格校验
-`source_type`、selector、排序、游标、计数和首尾时间；provider 失败或契约漂移时整次导入显式失败。
+默认 `auto` 路径优先逐页读取 remem 快照，并严格校验 `source_type`、
+selector、排序、游标、计数和首尾时间；只有 remem 可执行文件不存在时才
+自动选择本地文件发现。provider 失败或契约漂移时整次导入显式失败，不会
+静默切换到本地扫描。
 
 ### 现有架构
 
@@ -28,8 +30,9 @@
 ### 两个 CLI 命令
 
 ```
-refine ingest-sessions [--limit N | --latest N] [--dry-run]
-refine ingest-sessions --legacy-local-scan [--source claude|codex]
+refine ingest-sessions [--provider auto|remem|local] [--limit N | --latest N] [--dry-run]
+refine ingest-sessions --provider local [--source claude|codex]
+refine ingest-sessions --legacy-local-scan [--source claude|codex]  # deprecated alias
 refine insights [--period 30d] [--format terminal|json]
 ```
 
@@ -71,9 +74,9 @@ pub enum ItemType {
 // 统一的会话结构（跨 Claude Code / Codex）
 pub struct Session {
     pub id: String,                    // session UUID
-    pub source: SessionSource,         // RememRaw（默认）| ClaudeCode | Codex（回滚）
+    pub source: SessionSource,         // RememRaw（auto 首选）| ClaudeCode | Codex
     pub project: Option<String>,       // 项目路径
-    pub file_path: String,             // remem 稳定 URL 或回滚路径文件名
+    pub file_path: String,             // remem 稳定 URL 或本地扫描路径文件名
     pub started_at: DateTime<Utc>,
     pub ended_at: Option<DateTime<Utc>>,
     pub messages: Vec<SessionMessage>,
@@ -110,10 +113,11 @@ pub struct SessionMeta {
 }
 ```
 
-### Provider 与回滚解析规则
+### Provider 解析规则
 
-默认路径只接收 remem 的 raw archive JSON 契约，不调用 JSONL parser。以下 JSONL
-规则仅适用于显式 `--legacy-local-scan` 回滚路径。
+`auto` 和 `remem` 的 remem 路径只接收 raw archive JSON 契约，不调用 JSONL
+parser；`local` 路径使用以下 JSONL 规则。`--legacy-local-scan` 只是
+`--provider local` 的兼容别名，不代表临时回滚。
 
 #### Claude Code 会话 JSONL
 
@@ -199,8 +203,8 @@ pub struct SessionMeta {
 - 每个 remem Session 对应一个 Document；`url` 为 exact tuple 的稳定十六进制编码
 - URL 已存在且 `raw_content` 相同则跳过；内容变化则保留 Document identity 并原子替换 Items
 - 对 `source_root=local`，按 session filename + 内容优先、首时间 + 内容次级匹配旧路径 Document；remem 替代项保存与旧 Document/items 删除在同一事务提交，匹配不唯一则 fail closed
-- 回滚扫描若命中已有 remem identity，则继续刷新该稳定 URL；不会恢复路径 URL 并生成第二套 facets
-- provider 失败、分页游标停滞或 selector/count/order 漂移时显式失败，不回退为本地扫描
+- local 扫描若命中已有 remem identity，则继续刷新该稳定 URL；不会恢复路径 URL 并生成第二套 facets
+- auto 仅在 remem 可执行文件不存在时选择 local；provider 失败、分页游标停滞或 selector/count/order 漂移时显式失败，不回退为本地扫描
 
 ## Files Changed
 
@@ -271,9 +275,9 @@ pub struct SessionMeta {
 
 ## Done-when
 
-1. `refine ingest-sessions` 默认只从 remem raw archive 读取、校验并提取完整会话
+1. `refine ingest-sessions` 默认使用 auto：优先读取并校验 remem raw archive，remem 可执行文件不存在时扫描本地会话
 2. `refine insights` 能输出 L1-L4 四层分析报告
 3. 相同 raw 内容第二次运行会跳过，内容变化会原位刷新
 4. `cargo check` + `cargo test` 通过
 5. 至少 3 个真实会话的 facet 提取结果质量可接受
-6. remem 不可用或契约漂移时命令非零退出，只有显式回滚开关才扫描本地文件
+6. remem 非零退出、契约漂移或分页错误时命令非零退出；只有 remem 可执行文件不存在时 auto 才扫描本地文件，`--provider local` 可显式选择本地路径

--- a/docs/SPEC-session-insights.md
+++ b/docs/SPEC-session-insights.md
@@ -33,7 +33,7 @@ selector、排序、游标、计数和首尾时间；只有 remem 可执行文�
 refine ingest-sessions [--provider auto|remem|local] [--limit N | --latest N] [--dry-run]
 refine ingest-sessions --provider local [--source claude|codex]
 refine ingest-sessions --legacy-local-scan [--source claude|codex]  # deprecated alias
-refine insights [--period 30d] [--format terminal|json]
+refine insights [--period 30]
 ```
 
 ### 数据流

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -55,15 +55,19 @@ cargo install --path apps/mirror
 cargo install --path apps/server
 ```
 
-### Configure LLM (optional but recommended)
+### Configure LLM (recommended for scheduled analysis)
 
 ```bash
-cat > .env << 'EOF'
-REFINE_OPENAI_API_KEY=your_key
-REFINE_OPENAI_BASE_URL=https://api.openai.com
-REFINE_OPENAI_MODEL=gpt-4o
-EOF
+bash scripts/configure-llm-env.sh --check
+bash scripts/configure-llm-env.sh --migrate
 ```
+
+Use `bash scripts/configure-llm-env.sh --from-env` when supported variables
+are already exported in the current shell. The unattended loader reads the
+user-owned `~/.refine/llm.env` without sourcing `~/.zshrc`; process credentials
+win over that file. A repository `.env` remains an explicit development
+fallback only, and scheduled scripts pass it to the loader after the process
+and secure-file sources.
 
 ## 3. Run Sync Stack (Server + Extension)
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -122,13 +122,25 @@ refine ingest-sessions
 refine ingest-sessions --latest 20
 refine ingest-sessions --dry-run
 
-# Temporary one-release rollback only
+# Provider selection: auto is the default; local is a supported provider
+refine ingest-sessions --provider remem
+refine ingest-sessions --provider local
+refine ingest-sessions --provider local --source claude
+refine ingest-sessions --provider local --source codex
+# Deprecated compatibility alias for --provider local
 refine ingest-sessions --legacy-local-scan --source claude
-refine ingest-sessions --legacy-local-scan --source codex
 refine insights --prescription
 mirror dashboard
 mirror score
 ```
+
+`--provider auto` tries the remem raw archive first and falls back to local
+Claude/Codex discovery only when the remem executable cannot be launched
+because it is absent. Remem nonzero exits, malformed JSON, contract drift, and
+pagination errors fail the command instead of falling back. Use `--provider
+remem` to require remem, or `--provider local` to select local discovery
+directly. `--source` is valid with the local provider; the deprecated
+`--legacy-local-scan` flag is its backward-compatible alias.
 
 On the first remem-backed run, refine supersedes a matching local path-keyed
 session Document/items and saves the replacement facets in one transaction.

--- a/docs/cognitive-portraits/refine-data-pipelines.md
+++ b/docs/cognitive-portraits/refine-data-pipelines.md
@@ -10,7 +10,7 @@
 
 共识别 **9 条产出链路**，其中 **6 条调 LLM**、**5 条写 refine.db**、其余写本地文件或 stdout：
 
-- 1 条数据流入口（`refine ingest-sessions`，remem raw archive → refine.db）
+- 1 条数据流入口（`refine ingest-sessions`，auto/remem/local provider → refine.db）
 - 1 条核心 LLM 聚合链路（`refine insights --prescription`，~10+1 次 LLM 并发）
 - 4 条 mirror 子命令（`score` / `motd` / `dashboard` / `weekly` / `profile`）
 - 2 条由 launchd 调度的 shell 脚本（daily/weekly）
@@ -23,7 +23,7 @@
 ## 链路全景图
 
 ```
-remem raw archive
+auto/remem: remem raw archive；local: filesystem scan
  (完整 user/assistant 消息)
        │
        │ parse + LLM facet extract (3 并发 × 最多 5 次重试)
@@ -94,15 +94,15 @@ remem raw archive
 
 | 字段 | 内容 |
 |---|---|
-| 命令入口 | `refine ingest-sessions [--limit N\|--latest N] [--dry-run]`；一个发布周期内可显式使用 `--legacy-local-scan [--source claude\|codex]` |
+| 命令入口 | `refine ingest-sessions [--provider auto\|remem\|local] [--limit N\|--latest N] [--dry-run]`；`--legacy-local-scan` 是 `--provider local` 的弃用别名 |
 | 代码位置 | `apps/cli/src/cli.rs:74-88` → `apps/cli/src/handlers.rs:32-58` → `apps/cli/src/ingest_sessions.rs:41-199`（处理函数 `handle_ingest_sessions`，`process_single_session`，`llm_call_with_retry`，`extract_and_parse_facets_with_retry`）|
 | 触发方式 | 手动；由 `scripts/daily-refresh.sh` 每天 08:00 调用；由 `scripts/weekly-insights.sh` 每周一 09:00 调用 |
-| 数据来源 | `remem raw sessions --json` 枚举 exact tuple，`remem raw messages --json` 读取完整快照分页；本地扫描只在显式回滚开关下运行 |
+| 数据来源 | `auto/remem` 使用 `remem raw sessions --json` 枚举 exact tuple、`remem raw messages --json` 读取完整快照分页；`local` 使用本地扫描；auto 仅在 remem 可执行文件缺失时回退到 local |
 | 处理步骤 | 1) 校验 session summary；2) 按 `--latest` 或 `--limit` 裁剪；3) 逐页校验 selector/order/cursor/count/epoch；4) 用稳定 URL + raw 内容跳过或刷新；5) 保守匹配本地旧路径 identity；6) filter/chunk；7) 默认串行（`REFINE_INGEST_CONCURRENCY` 可配置）执行 LLM facet 抽取；8) 在同一事务保存 remem Document/Items 并删除已取代旧 Document/items |
 | LLM 调用 | **是**；每会话 1 次（或每分块 1 次，需要 chunking 时可能 N 次）+ 1 次最终合并；默认并发度 1；最多 5 次重试，base delay 10s，退避 `10 * 2^attempt` 秒 |
 | 输出目标 | **refine.db**：`documents` 表（每会话 1 行，source = `remem-raw-session`）+ `items` 表（每会话 N 行，`item_type='observation'`）|
 | 输出 schema | `Document { id, source, url=remem-raw://v1/<hex tuple>, title, raw_content }`；`Item { id, item_type='observation', ..., document_id }`；内容变化时保留 Document identity 并替换关联 Items |
-| 依赖 | 兼容的 `remem` 二进制（`PATH` 或 `REFINE_REMEM_BIN`）和 LLM key；provider 错误会 fail closed |
+| 依赖 | `auto/remem` 需要兼容的 `remem` 二进制（`PATH` 或 `REFINE_REMEM_BIN`），`local` 不需要；所有 provider 都需要 LLM key；provider/契约错误会 fail closed，auto 仅对缺失可执行文件回退 |
 | 已知问题 | 网络波动 / API cooldown 时单会话可能耗尽 5 次重试失败；`daily-refresh.sh` 会根据 exit code 记录 `~/.refine/last-refresh-ok`，失败时不更新时间戳 |
 
 ---
@@ -247,10 +247,10 @@ remem raw archive
 
 ### 1. 数据流入点
 
-**只有链路 1 `refine ingest-sessions` 是数据流入口**（默认从 remem raw archive 做 LLM 抽取）。所有其他链路（2~9）都是在 refine.db 里对已有 Observation 做聚合/加工/叙事。因此：
+**只有链路 1 `refine ingest-sessions` 是数据流入口**（auto 默认探测 remem raw archive，缺少可执行文件时回退到 local；也可显式选择 remem/local）。所有其他链路（2~9）都是在 refine.db 里对已有 Observation 做聚合/加工/叙事。因此：
 
 - **链路 1 质量决定整条管道质量**。facet prompt 改动、chunking 策略、filter 策略的变化会扩散到下游所有报告。
-- 断掉链路 1（如 API key 失效、remem 不可用或契约漂移）会让导入显式失败；不会把 provider 错误降级成空输入。
+- 断掉链路 1（如 API key 失效或 provider 契约漂移）会让导入显式失败；auto 仅在 remem 可执行文件缺失时回退到 local，不会把 provider 错误降级成空输入。
 
 ### 2. LLM 成本分布
 
@@ -310,7 +310,7 @@ remem raw archive
 
 | 链路 | 使用 env |
 |---|---|
-| 链路 1 ingest-sessions | `remem`（或 `REFINE_REMEM_BIN`）；LLM key；可选 `REFINE_DB_PATH`、`REFINE_INGEST_CONCURRENCY` |
+| 链路 1 ingest-sessions | `--provider auto\|remem` 时为 `remem`（或 `REFINE_REMEM_BIN`），`--provider local` 时为本地扫描；LLM key；可选 `REFINE_DB_PATH`、`REFINE_INGEST_CONCURRENCY` |
 | 链路 2 insights | LLM key；可选 `REFINE_DB_PATH` |
 | 链路 3 score | 可选 LLM key（advice 可跳过）；可选 `REFINE_DB_PATH` |
 | 链路 4 dashboard | 可选 `REFINE_DB_PATH` |

--- a/docs/cognitive-portraits/refine-data-pipelines.md
+++ b/docs/cognitive-portraits/refine-data-pipelines.md
@@ -353,7 +353,7 @@ auto/remem: remem raw archive；local: filesystem scan
 
 - 执行：`/bin/bash /Users/lifcc/Desktop/code/AI/tools/refine/scripts/weekly-insights.sh`
 - 工作目录：`/Users/lifcc/Desktop/code/AI/tools/refine`
-- 触发：每周日 09:00（`Weekday=1`，macOS launchd）
+- 触发：每周日 09:00（`Weekday=0`，macOS launchd）
 - 日志：`~/Library/Logs/refine-insights.log`
 - 脚本做的事：
   1. 通过共享 loader 加载 LLM env；缺少 unattended key 时在 ingest 前失败

--- a/docs/cognitive-portraits/refine-data-pipelines.md
+++ b/docs/cognitive-portraits/refine-data-pipelines.md
@@ -113,9 +113,9 @@ auto/remem: remem raw archive；local: filesystem scan
 |---|---|
 | 命令入口 | `refine insights [--period N] [--prescription]` |
 | 代码位置 | `apps/cli/src/cli.rs:89-97` → `apps/cli/src/handlers.rs:59-76` → `apps/cli/src/insights.rs:24-125`（`handle_insights`，`llm_with_retry`）；路由规划在 `packages/core/src/session/analysis_routes.rs:18` 的 `plan_routes` |
-| 触发方式 | 手动；由 `scripts/weekly-insights.sh` 每周一 09:00 通过 launchd 自动触发 |
+| 触发方式 | 手动；由 `scripts/weekly-insights.sh` 每周日 09:00 通过 launchd 自动触发 |
 | 数据来源 | `item_store.find_by_type(ItemType::Observation)` — 全量 Observation（当前实现**未按 `--period` 过滤**时间窗口） |
-| 处理步骤 | 1) 加载所有 Observation；2) `cluster_observations()` 纯 Rust 本地聚类（按 project + facet 汇总）；3) `plan_routes()` 规划 N 路分析路由（项目总览 / 决策模式 / bug 模式 / 认知演化 / 技术雷达 / AI 协作 / 工作流 / 各项目深挖 / 知识网络 / 摩擦深挖，最少补齐到 10 路）；4) **10 路并发** LLM 调用 (`Semaphore::new(10)`)，system prompt = `ROUTE_SYSTEM_PROMPT`；5) `merge_route_results()` 合并；6) 调 1 次 LLM 做最终报告（system prompt = `INSIGHTS_SYSTEM_PROMPT`，是否含 L4 处方由 `with_prescription` 决定）；7) 保存 |
+| 处理步骤 | 1) 加载所有 Observation；2) `cluster_observations()` 纯 Rust 本地聚类（按 project + facet 汇总）；3) `plan_routes()` 规划 N 路分析路由（项目总览 / 决策模式 / bug 模式 / 认知演化 / 技术雷达 / AI 协作 / 工作流 / 各项目深挖 / 知识网络 / 摩擦深挖，最少补齐到 10 路）；4) **10 路并发** LLM 调用 (`Semaphore::new(10)`)，system prompt = `ROUTE_SYSTEM_PROMPT`；5) `merge_route_results()` 合并；6) 调 1 次 LLM 做最终报告（system prompt = `INSIGHTS_SYSTEM_PROMPT`，是否含 L4 处方由 `with_prescription` 决定；大上下文合并请求的单次超时为 300 秒）；7) 保存 |
 | LLM 调用 | **是**；一次运行 ≈ **N+1 次**（N 通常为 10 路）；并发度 10；每次独立 5 次重试（和链路 1 同样的 exponential backoff 策略） |
 | 输出目标 | **stdout**（完整 markdown 报告）+ **refine.db** `documents` 表 (source=`session-insights-v2`，URL = `insights-v2://<rfc3339>`) |
 | 输出 schema | Markdown 文档；`Document.title = "Session Insights v2 YYYY-MM-DD HH:MM"`；`raw_content` 为完整的合并报告 |

--- a/docs/cognitive-portraits/refine-data-pipelines.md
+++ b/docs/cognitive-portraits/refine-data-pipelines.md
@@ -215,13 +215,13 @@ auto/remem: remem raw archive；local: filesystem scan
 |---|---|
 | 命令入口 | `/Users/lifcc/Desktop/code/AI/tools/refine/scripts/weekly-insights.sh` |
 | 代码位置 | `scripts/weekly-insights.sh`（52 行） |
-| 触发方式 | launchd `com.lifcc.refine-weekly-insights.plist` — **每周一 09:00** |
-| 数据来源 | 依赖 `.env` 加载环境变量 |
-| 处理步骤 | 1) 加载 `.env`；2) 打印 preflight (PATH/refine/cwd/env)；3) `refine ingest-sessions`（链路 1）；4) `refine insights --prescription`（链路 2）；5) `osascript` 发送 macOS 通知 |
+| 触发方式 | launchd `com.lifcc.refine-weekly-insights.plist` — **每周日 09:00** |
+| 数据来源 | 共享 LLM loader：当前进程 → `~/.refine/llm.env` → 显式传入的仓库 `.env` fallback |
+| 处理步骤 | 1) 通过共享 loader 做凭据 preflight（不读取 `~/.zshrc`）；2) 打印仅含 `<set>/<unset>` 和来源的 preflight；3) `refine ingest-sessions`（链路 1）；4) `refine insights --prescription`（链路 2）；5) `osascript` 发送 macOS 通知 |
 | LLM 调用 | **是（间接）**：= 链路 1 + 链路 2 的总和（单会话 N 次 + insights ≈ 11 次） |
 | 输出目标 | `~/Library/Logs/refine-insights.log`（日志） + 链路 1/2 的所有写入目标 |
 | 输出 schema | 无自身 schema，复用下游 |
-| 依赖 | `.env` 内的 LLM API key；依赖 `refine` 二进制绝对路径 `/Users/lifcc/.cargo/bin/refine` |
+| 依赖 | `~/.refine/llm.env` 内的 LLM API key（开发时可显式 fallback 到 `.env`）；依赖 `refine` 二进制绝对路径 `/Users/lifcc/.cargo/bin/refine` |
 | 已知问题 | `set -euo pipefail` 但对子命令 exit code 做了 `if ... 2>&1; then ... else ... fi` 兜底，只记录日志不中断；launchd 不重试失败 |
 
 ---
@@ -265,7 +265,7 @@ auto/remem: remem raw archive；local: filesystem scan
 | 链路 3 `score` (advice) | 1 次（72h 缓存） | 1 | 命中缓存后 0 次 |
 | 链路 4 `dashboard` / 链路 6 `motd` | **0 次** | — | 纯本地 |
 
-**每周一 9:00 的 launchd 任务（链路 8）= 链路 1 + 链路 2 的合计**，是 LLM 预算最集中的时间窗口。
+**每周日 09:00 的 launchd 任务（链路 8）= 链路 1 + 链路 2 的合计**，是 LLM 预算最集中的时间窗口。
 
 ### 3. 稳定性风险
 
@@ -297,6 +297,9 @@ auto/remem: remem raw archive；local: filesystem scan
 | `REFINE_OPENAI_API_KEY` | OpenAI API key（次优先级） | 或 `OPENAI_API_KEY` |
 | `REFINE_OPENAI_MODEL` | OpenAI 模型名 | |
 | `REFINE_OPENAI_BASE_URL` | OpenAI API base URL | |
+| `BASE_API_KEY` | 兼容网关 API key | 与 `BASE_URL`、`BASE_MODEL` 配套 |
+| `BASE_URL` | 兼容网关 URL | 由共享 loader 解析 |
+| `BASE_MODEL` | 兼容网关模型名 | 由共享 loader 解析 |
 
 ### 数据库 / 路径
 
@@ -329,7 +332,7 @@ auto/remem: remem raw archive；local: filesystem scan
 | `com.lifcc.refine-server` | `~/Library/LaunchAgents/com.lifcc.refine-server.plist` | 常驻 | **PID 4706 running** |
 | `com.lifcc.refine-ui-dev` | `~/Library/LaunchAgents/com.lifcc.refine-ui-dev.plist` | 常驻 | **PID 4696 running** |
 | `com.lifcc.refine-daily-ingest` | `~/Library/LaunchAgents/com.lifcc.refine-daily-ingest.plist` | **每天 08:00** | 未运行（调度中）；**last exit=1**（最近一次 ingest 失败） |
-| `com.lifcc.refine-weekly-insights` | `~/Library/LaunchAgents/com.lifcc.refine-weekly-insights.plist` | **每周一 09:00** | 未运行（调度中）；last exit=0 |
+| `com.lifcc.refine-weekly-insights` | `~/Library/LaunchAgents/com.lifcc.refine-weekly-insights.plist` | **每周日 09:00** | 未运行（调度中）；last exit=0 |
 
 ### 任务详情
 
@@ -350,10 +353,10 @@ auto/remem: remem raw archive；local: filesystem scan
 
 - 执行：`/bin/bash /Users/lifcc/Desktop/code/AI/tools/refine/scripts/weekly-insights.sh`
 - 工作目录：`/Users/lifcc/Desktop/code/AI/tools/refine`
-- 触发：每周一 09:00（`Weekday=1`）
+- 触发：每周日 09:00（`Weekday=1`，macOS launchd）
 - 日志：`~/Library/Logs/refine-insights.log`
 - 脚本做的事：
-  1. 从 `.env` 加载 env
+  1. 通过共享 loader 加载 LLM env；缺少 unattended key 时在 ingest 前失败
   2. `refine ingest-sessions`（链路 1，补捕最近 24h 新会话）
   3. `refine insights --prescription`（链路 2）
   4. `osascript` 通知 "Weekly insights 报告已生成"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -17,6 +17,7 @@ tracing.workspace = true
 reqwest.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+sha2.workspace = true
 dirs = "5"
 
 [dev-dependencies]

--- a/packages/core/src/error.rs
+++ b/packages/core/src/error.rs
@@ -38,6 +38,11 @@ pub enum InfraError {
     #[error("LLM 响应解析失败: {0}")]
     LlmParse(String),
 
+    /// The provider rejected the prompt for a deterministic policy reason.
+    /// Retrying the same input cannot succeed, so callers must quarantine it.
+    #[error("LLM 内容被拒绝 ({code}): {message}")]
+    LlmRejected { code: String, message: String },
+
     #[error("HTTP 错误: {0}")]
     Http(String),
 

--- a/packages/core/src/error.rs
+++ b/packages/core/src/error.rs
@@ -35,6 +35,9 @@ pub enum InfraError {
     #[error("LLM 请求失败: {0}")]
     LlmRequest(String),
 
+    #[error("LLM HTTP 错误 ({status}): {message}")]
+    LlmHttp { status: u16, message: String },
+
     #[error("LLM 响应解析失败: {0}")]
     LlmParse(String),
 

--- a/packages/core/src/infra/llm.rs
+++ b/packages/core/src/infra/llm.rs
@@ -22,29 +22,25 @@ pub trait LlmClient: Send + Sync {
 ///
 /// 优先级：
 /// 1. Anthropic (`REFINE_ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY`)
-/// 2. OpenAI (`REFINE_OPENAI_API_KEY` / `OPENAI_API_KEY`)
+/// 2. OpenAI-compatible (`REFINE_OPENAI_API_KEY` / `OPENAI_API_KEY` / `BASE_API_KEY`)
 pub fn build_llm_client_from_env() -> Option<Arc<dyn LlmClient>> {
-    if let Some(api_key) = env_var(&[
-        "REFINE_ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_API_KEY",
-    ]) {
-        let mut client = ClaudeClient::new(&api_key);
-        if let Some(model) = env_var(&["REFINE_ANTHROPIC_MODEL"]) {
+    if let Some(config) = anthropic_config_from_env() {
+        let mut client = ClaudeClient::new(&config.api_key);
+        if let Some(model) = config.model {
             client = client.with_model(&model);
         }
-        if let Some(base_url) = env_var(&["REFINE_ANTHROPIC_BASE_URL", "ANTHROPIC_BASE_URL"]) {
+        if let Some(base_url) = config.base_url {
             client = client.with_base_url(&base_url);
         }
         return Some(Arc::new(client));
     }
 
-    if let Some(api_key) = env_var(&["REFINE_OPENAI_API_KEY", "OPENAI_API_KEY"]) {
-        let mut client = OpenAIClient::new(&api_key);
-        if let Some(model) = env_var(&["REFINE_OPENAI_MODEL"]) {
+    if let Some(config) = openai_config_from_env() {
+        let mut client = OpenAIClient::new(&config.api_key);
+        if let Some(model) = config.model {
             client = client.with_model(&model);
         }
-        if let Some(base_url) = env_var(&["REFINE_OPENAI_BASE_URL"]) {
+        if let Some(base_url) = config.base_url {
             client = client.with_base_url(&base_url);
         }
         return Some(Arc::new(client));
@@ -170,7 +166,7 @@ impl OpenAIClient {
     }
 
     pub fn with_base_url(mut self, url: &str) -> Self {
-        self.base_url = url.to_string();
+        self.base_url = normalize_openai_base_url(url);
         self
     }
 }
@@ -250,6 +246,40 @@ fn env_var(keys: &[&str]) -> Option<String> {
         .filter(|value| !value.trim().is_empty())
 }
 
+struct LlmEnvConfig {
+    api_key: String,
+    model: Option<String>,
+    base_url: Option<String>,
+}
+
+fn anthropic_config_from_env() -> Option<LlmEnvConfig> {
+    Some(LlmEnvConfig {
+        api_key: env_var(&[
+            "REFINE_ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_API_KEY",
+        ])?,
+        model: env_var(&["REFINE_ANTHROPIC_MODEL"]),
+        base_url: env_var(&["REFINE_ANTHROPIC_BASE_URL", "ANTHROPIC_BASE_URL"]),
+    })
+}
+
+fn openai_config_from_env() -> Option<LlmEnvConfig> {
+    Some(LlmEnvConfig {
+        api_key: env_var(&["REFINE_OPENAI_API_KEY", "OPENAI_API_KEY", "BASE_API_KEY"])?,
+        model: env_var(&["REFINE_OPENAI_MODEL", "BASE_MODEL"]),
+        base_url: env_var(&["REFINE_OPENAI_BASE_URL", "BASE_URL"]),
+    })
+}
+
+fn normalize_openai_base_url(url: &str) -> String {
+    url.trim()
+        .trim_end_matches('/')
+        .strip_suffix("/v1")
+        .unwrap_or_else(|| url.trim().trim_end_matches('/'))
+        .to_string()
+}
+
 /// Mock 客户端（测试用）
 #[cfg(test)]
 pub struct MockLlmClient {
@@ -274,11 +304,112 @@ impl LlmClient for MockLlmClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    const LLM_ENV_KEYS: &[&str] = &[
+        "REFINE_ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "REFINE_ANTHROPIC_MODEL",
+        "REFINE_ANTHROPIC_BASE_URL",
+        "ANTHROPIC_BASE_URL",
+        "REFINE_OPENAI_API_KEY",
+        "OPENAI_API_KEY",
+        "REFINE_OPENAI_MODEL",
+        "REFINE_OPENAI_BASE_URL",
+        "BASE_API_KEY",
+        "BASE_MODEL",
+        "BASE_URL",
+    ];
 
     #[tokio::test]
     async fn test_mock_client() {
         let client = MockLlmClient::new("test response");
         let result = client.complete("hello", None).await.unwrap();
         assert_eq!(result, "test response");
+    }
+
+    #[test]
+    fn openai_config_accepts_base_aliases() {
+        let Ok(_env_lock) = ENV_LOCK.lock() else {
+            panic!("failed to lock env");
+        };
+        with_clean_llm_env(|| {
+            std::env::set_var("BASE_API_KEY", "base-key");
+            std::env::set_var("BASE_MODEL", "base-model");
+            std::env::set_var("BASE_URL", "https://example.test/openai");
+
+            let Some(config) = openai_config_from_env() else {
+                panic!("missing openai config");
+            };
+            assert_eq!(config.api_key, "base-key");
+            assert_eq!(config.model.as_deref(), Some("base-model"));
+            assert_eq!(
+                config.base_url.as_deref(),
+                Some("https://example.test/openai")
+            );
+        });
+    }
+
+    #[test]
+    fn refine_openai_vars_override_base_aliases() {
+        let Ok(_env_lock) = ENV_LOCK.lock() else {
+            panic!("failed to lock env");
+        };
+        with_clean_llm_env(|| {
+            std::env::set_var("REFINE_OPENAI_API_KEY", "refine-key");
+            std::env::set_var("REFINE_OPENAI_MODEL", "refine-model");
+            std::env::set_var("REFINE_OPENAI_BASE_URL", "https://refine.example.test");
+            std::env::set_var("BASE_API_KEY", "base-key");
+            std::env::set_var("BASE_MODEL", "base-model");
+            std::env::set_var("BASE_URL", "https://base.example.test");
+
+            let Some(config) = openai_config_from_env() else {
+                panic!("missing openai config");
+            };
+            assert_eq!(config.api_key, "refine-key");
+            assert_eq!(config.model.as_deref(), Some("refine-model"));
+            assert_eq!(
+                config.base_url.as_deref(),
+                Some("https://refine.example.test")
+            );
+        });
+    }
+
+    #[test]
+    fn normalize_openai_base_url_accepts_root_or_v1_endpoint() {
+        assert_eq!(
+            normalize_openai_base_url("https://api.example.test"),
+            "https://api.example.test"
+        );
+        assert_eq!(
+            normalize_openai_base_url("https://api.example.test/v1"),
+            "https://api.example.test"
+        );
+        assert_eq!(
+            normalize_openai_base_url("https://api.example.test/openai/v1/"),
+            "https://api.example.test/openai"
+        );
+    }
+
+    fn with_clean_llm_env(test: impl FnOnce()) {
+        let saved = LLM_ENV_KEYS
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect::<Vec<_>>();
+
+        for key in LLM_ENV_KEYS {
+            std::env::remove_var(key);
+        }
+
+        test();
+
+        for (key, value) in saved {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
     }
 }

--- a/packages/core/src/infra/llm.rs
+++ b/packages/core/src/infra/llm.rs
@@ -119,7 +119,7 @@ impl LlmClient for ClaudeClient {
 
         if !resp.status().is_success() {
             let err = resp.text().await.unwrap_or_default();
-            return Err(InfraError::LlmRequest(format!("API 错误: {}", err)));
+            return Err(classify_provider_error(&err));
         }
 
         let data: ClaudeResponse = resp
@@ -211,7 +211,7 @@ impl LlmClient for OpenAIClient {
 
         if !resp.status().is_success() {
             let err = resp.text().await.unwrap_or_default();
-            return Err(InfraError::LlmRequest(format!("API 错误: {}", err)));
+            return Err(classify_provider_error(&err));
         }
 
         let data: OpenAIResponse = resp
@@ -244,6 +244,40 @@ fn env_var(keys: &[&str]) -> Option<String> {
     keys.iter()
         .find_map(|key| std::env::var(key).ok())
         .filter(|value| !value.trim().is_empty())
+}
+
+fn classify_provider_error(body: &str) -> InfraError {
+    let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
+    let error = parsed.as_ref().and_then(|value| value.get("error"));
+    let code = error
+        .and_then(|value| value.get("code"))
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let message = error
+        .and_then(|value| value.get("message"))
+        .and_then(|value| value.as_str())
+        .unwrap_or(body)
+        .trim();
+
+    if is_content_rejection(code) || is_content_rejection(message) {
+        return InfraError::LlmRejected {
+            code: if code.is_empty() {
+                "content_rejected".to_string()
+            } else {
+                code.to_string()
+            },
+            message: message.to_string(),
+        };
+    }
+
+    InfraError::LlmRequest(format!("API 错误: {}", body))
+}
+
+fn is_content_rejection(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase();
+    normalized.contains("sensitive_words_detected")
+        || normalized.contains("content_policy")
+        || normalized.contains("moderation")
 }
 
 struct LlmEnvConfig {
@@ -391,6 +425,36 @@ mod tests {
             normalize_openai_base_url("https://api.example.test/openai/v1/"),
             "https://api.example.test/openai"
         );
+    }
+
+    #[test]
+    fn sensitive_words_error_is_structured_as_non_retryable_rejection() {
+        let error = classify_provider_error(
+            r#"{"error":{"message":"sensitive_words_detected","code":"sensitive_words_detected"}}"#,
+        );
+        assert!(matches!(
+            error,
+            InfraError::LlmRejected { ref code, .. } if code == "sensitive_words_detected"
+        ));
+    }
+
+    #[test]
+    fn sensitive_words_message_without_code_is_still_non_retryable() {
+        let error = classify_provider_error(
+            r#"{"error":{"message":"request blocked: sensitive_words_detected"}}"#,
+        );
+        assert!(matches!(
+            error,
+            InfraError::LlmRejected { ref code, .. } if code == "content_rejected"
+        ));
+    }
+
+    #[test]
+    fn unknown_provider_error_stays_request_error() {
+        let error = classify_provider_error(
+            r#"{"error":{"message":"upstream unavailable","code":"upstream_error"}}"#,
+        );
+        assert!(matches!(error, InfraError::LlmRequest(_)));
     }
 
     fn with_clean_llm_env(test: impl FnOnce()) {

--- a/packages/core/src/infra/llm.rs
+++ b/packages/core/src/infra/llm.rs
@@ -3,6 +3,7 @@
 use crate::error::{InfraError, InfraResult};
 use async_trait::async_trait;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 
 /// LLM 客户端接口
@@ -83,7 +84,11 @@ impl ClaudeClient {
 #[async_trait]
 impl LlmClient for ClaudeClient {
     fn cache_identity(&self) -> String {
-        format!("anthropic:{}:{}", self.model, self.base_url)
+        format!(
+            "anthropic:{}:{}",
+            self.model,
+            endpoint_identity(&self.base_url)
+        )
     }
 
     async fn complete(&self, prompt: &str, system: Option<&str>) -> InfraResult<String> {
@@ -118,8 +123,9 @@ impl LlmClient for ClaudeClient {
         }
 
         if !resp.status().is_success() {
+            let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            return Err(classify_provider_error(&err));
+            return Err(classify_provider_error(status, &err));
         }
 
         let data: ClaudeResponse = resp
@@ -173,7 +179,11 @@ impl OpenAIClient {
 #[async_trait]
 impl LlmClient for OpenAIClient {
     fn cache_identity(&self) -> String {
-        format!("openai:{}:{}", self.model, self.base_url)
+        format!(
+            "openai:{}:{}",
+            self.model,
+            endpoint_identity(&self.base_url)
+        )
     }
 
     async fn complete(&self, prompt: &str, system: Option<&str>) -> InfraResult<String> {
@@ -210,8 +220,9 @@ impl LlmClient for OpenAIClient {
         }
 
         if !resp.status().is_success() {
+            let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            return Err(classify_provider_error(&err));
+            return Err(classify_provider_error(status, &err));
         }
 
         let data: OpenAIResponse = resp
@@ -246,7 +257,7 @@ fn env_var(keys: &[&str]) -> Option<String> {
         .filter(|value| !value.trim().is_empty())
 }
 
-fn classify_provider_error(body: &str) -> InfraError {
+fn classify_provider_error(status: reqwest::StatusCode, body: &str) -> InfraError {
     let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
     let error = parsed.as_ref().and_then(|value| value.get("error"));
     let code = error
@@ -259,7 +270,10 @@ fn classify_provider_error(body: &str) -> InfraError {
         .unwrap_or(body)
         .trim();
 
-    if is_content_rejection(code) || is_content_rejection(message) {
+    if status.is_client_error()
+        && status != reqwest::StatusCode::REQUEST_TIMEOUT
+        && is_content_rejection(code, message)
+    {
         return InfraError::LlmRejected {
             code: if code.is_empty() {
                 "content_rejected".to_string()
@@ -270,14 +284,25 @@ fn classify_provider_error(body: &str) -> InfraError {
         };
     }
 
-    InfraError::LlmRequest(format!("API 错误: {}", body))
+    InfraError::LlmHttp {
+        status: status.as_u16(),
+        message: body.to_string(),
+    }
 }
 
-fn is_content_rejection(value: &str) -> bool {
-    let normalized = value.to_ascii_lowercase();
-    normalized.contains("sensitive_words_detected")
-        || normalized.contains("content_policy")
-        || normalized.contains("moderation")
+fn is_content_rejection(code: &str, message: &str) -> bool {
+    let code = code.trim().to_ascii_lowercase();
+    matches!(
+        code.as_str(),
+        "sensitive_words_detected" | "content_filter" | "content_policy_violation"
+    ) || message
+        .to_ascii_lowercase()
+        .contains("sensitive_words_detected")
+}
+
+fn endpoint_identity(endpoint: &str) -> String {
+    let digest = Sha256::digest(endpoint.as_bytes());
+    format!("endpoint-sha256:{digest:x}")
 }
 
 struct LlmEnvConfig {
@@ -430,6 +455,7 @@ mod tests {
     #[test]
     fn sensitive_words_error_is_structured_as_non_retryable_rejection() {
         let error = classify_provider_error(
+            reqwest::StatusCode::BAD_REQUEST,
             r#"{"error":{"message":"sensitive_words_detected","code":"sensitive_words_detected"}}"#,
         );
         assert!(matches!(
@@ -441,6 +467,7 @@ mod tests {
     #[test]
     fn sensitive_words_message_without_code_is_still_non_retryable() {
         let error = classify_provider_error(
+            reqwest::StatusCode::BAD_REQUEST,
             r#"{"error":{"message":"request blocked: sensitive_words_detected"}}"#,
         );
         assert!(matches!(
@@ -452,9 +479,41 @@ mod tests {
     #[test]
     fn unknown_provider_error_stays_request_error() {
         let error = classify_provider_error(
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
             r#"{"error":{"message":"upstream unavailable","code":"upstream_error"}}"#,
         );
-        assert!(matches!(error, InfraError::LlmRequest(_)));
+        assert!(matches!(error, InfraError::LlmHttp { status: 503, .. }));
+    }
+
+    #[test]
+    fn generic_moderation_message_from_5xx_is_not_quarantined() {
+        let error = classify_provider_error(
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"error":{"message":"moderation service unavailable"}}"#,
+        );
+        assert!(matches!(error, InfraError::LlmHttp { status: 503, .. }));
+    }
+
+    #[test]
+    fn openai_content_filter_code_is_quarantined() {
+        let error = classify_provider_error(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"blocked","code":"content_filter"}}"#,
+        );
+        assert!(
+            matches!(error, InfraError::LlmRejected { ref code, .. } if code == "content_filter")
+        );
+    }
+
+    #[test]
+    fn cache_identity_never_exposes_endpoint_credentials_or_query() {
+        let client = OpenAIClient::new("key")
+            .with_base_url("https://user:secret@example.test/openai?token=private-value");
+        let identity = client.cache_identity();
+        assert!(identity.contains("endpoint-sha256:"));
+        for secret in ["user", "secret", "token", "private-value"] {
+            assert!(!identity.contains(secret));
+        }
     }
 
     fn with_clean_llm_env(test: impl FnOnce()) {

--- a/packages/core/src/infra/llm_retry.rs
+++ b/packages/core/src/infra/llm_retry.rs
@@ -8,11 +8,13 @@ use std::time::Duration;
 
 pub const DEFAULT_MAX_RETRIES: usize = 5;
 pub const DEFAULT_RETRY_BASE_DELAY_SECS: u64 = 10;
+pub const DEFAULT_REQUEST_TIMEOUT_MILLIS: u64 = 90_000;
 
 #[derive(Clone, Copy, Debug)]
 pub struct LlmRetryPolicy {
     pub max_retries: usize,
     pub base_delay_secs: u64,
+    pub request_timeout_millis: u64,
 }
 
 impl Default for LlmRetryPolicy {
@@ -20,6 +22,7 @@ impl Default for LlmRetryPolicy {
         Self {
             max_retries: DEFAULT_MAX_RETRIES,
             base_delay_secs: DEFAULT_RETRY_BASE_DELAY_SECS,
+            request_timeout_millis: DEFAULT_REQUEST_TIMEOUT_MILLIS,
         }
     }
 }
@@ -50,6 +53,7 @@ where
     F: FnMut(usize, usize, u64, &InfraError),
 {
     let max_retries = policy.max_retries.max(1);
+    let request_timeout = Duration::from_millis(policy.request_timeout_millis.max(1));
 
     for attempt in 0..max_retries {
         if is_quota_exhausted() {
@@ -58,7 +62,20 @@ where
             });
         }
 
-        match client.complete(prompt, Some(system)).await {
+        let result = match tokio::time::timeout(
+            request_timeout,
+            client.complete(prompt, Some(system)),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(InfraError::LlmRequest(format!(
+                "LLM 请求超时: {}ms",
+                request_timeout.as_millis()
+            ))),
+        };
+
+        match result {
             Ok(response) => return Ok(response),
             Err(err @ InfraError::RateLimited { retry_after_secs }) => {
                 set_quota_exhausted(retry_after_secs);
@@ -89,7 +106,13 @@ fn is_retryable_error(err: &InfraError) -> bool {
         || msg.contains("429")
         || msg.contains("Upstream")
         || msg.contains("timeout")
+        || msg.contains("timed out")
+        || msg.contains("请求超时")
         || msg.contains("empty response")
+        || msg.contains("stream disconnected before completion")
+        || msg.contains("stream closed before")
+        || msg.contains("INTERNAL_ERROR; received from peer")
+        || msg.contains("internal_server_error")
 }
 
 fn backoff_delay_secs(base_delay_secs: u64, attempt: usize) -> u64 {
@@ -141,6 +164,33 @@ mod tests {
         }
     }
 
+    struct SlowThenOkClient {
+        calls: AtomicUsize,
+    }
+
+    impl SlowThenOkClient {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl LlmClient for SlowThenOkClient {
+        async fn complete(&self, _prompt: &str, _system: Option<&str>) -> InfraResult<String> {
+            let call = self.calls.fetch_add(1, Ordering::Relaxed);
+            if call == 0 {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Ok("ok".into())
+        }
+    }
+
     struct QuotaTestGuard {
         _dir: TempDir,
     }
@@ -177,6 +227,7 @@ mod tests {
             LlmRetryPolicy {
                 max_retries: 3,
                 base_delay_secs: 0,
+                ..LlmRetryPolicy::default()
             },
             |_attempt, _max_retries, _delay_secs, _err| {},
         )
@@ -204,6 +255,7 @@ mod tests {
             LlmRetryPolicy {
                 max_retries: 5,
                 base_delay_secs: 0,
+                ..LlmRetryPolicy::default()
             },
             |_attempt, _max_retries, _delay_secs, _err| {},
         )
@@ -213,6 +265,97 @@ mod tests {
         assert!(matches!(err, InfraError::LlmRequest(_)));
         assert!(err.to_string().contains("invalid api key"));
         assert_eq!(client.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn retries_on_stream_disconnect_then_succeeds() {
+        let _env_guard = QUOTA_TEST_LOCK.lock().await;
+        let _quota_guard = QuotaTestGuard::new();
+
+        let client = Arc::new(SequenceClient::new(vec![
+            Err(InfraError::LlmRequest(
+                "stream error: stream disconnected before completion".into(),
+            )),
+            Ok("ok".into()),
+        ]));
+
+        let result = llm_with_retry_policy(
+            &(client.clone() as Arc<dyn LlmClient>),
+            "prompt",
+            "system",
+            LlmRetryPolicy {
+                max_retries: 3,
+                base_delay_secs: 0,
+                ..LlmRetryPolicy::default()
+            },
+            |_attempt, _max, _delay, _err| {},
+        )
+        .await;
+
+        match result {
+            Ok(value) => assert_eq!(value, "ok"),
+            Err(err) => panic!("expected retry to succeed, got {err}"),
+        }
+        assert_eq!(client.calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn retries_on_stream_internal_error_then_succeeds() {
+        let _env_guard = QUOTA_TEST_LOCK.lock().await;
+        let _quota_guard = QuotaTestGuard::new();
+
+        let client = Arc::new(SequenceClient::new(vec![
+            Err(InfraError::LlmRequest(
+                r#"API 错误: {"error":{"message":"stream error: stream ID 3953; INTERNAL_ERROR; received from peer","type":"server_error","param":"","code":"internal_server_error"}}"#.into(),
+            )),
+            Ok("ok".into()),
+        ]));
+
+        let result = llm_with_retry_policy(
+            &(client.clone() as Arc<dyn LlmClient>),
+            "prompt",
+            "system",
+            LlmRetryPolicy {
+                max_retries: 3,
+                base_delay_secs: 0,
+                ..LlmRetryPolicy::default()
+            },
+            |_attempt, _max, _delay, _err| {},
+        )
+        .await;
+
+        match result {
+            Ok(value) => assert_eq!(value, "ok"),
+            Err(err) => panic!("expected internal stream error retry to succeed, got {err}"),
+        }
+        assert_eq!(client.calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn retries_on_request_timeout_then_succeeds() {
+        let _env_guard = QUOTA_TEST_LOCK.lock().await;
+        let _quota_guard = QuotaTestGuard::new();
+
+        let client = Arc::new(SlowThenOkClient::new());
+
+        let result = llm_with_retry_policy(
+            &(client.clone() as Arc<dyn LlmClient>),
+            "prompt",
+            "system",
+            LlmRetryPolicy {
+                max_retries: 3,
+                base_delay_secs: 0,
+                request_timeout_millis: 10,
+            },
+            |_attempt, _max, _delay, _err| {},
+        )
+        .await;
+
+        match result {
+            Ok(value) => assert_eq!(value, "ok"),
+            Err(err) => panic!("expected timeout retry to succeed, got {err}"),
+        }
+        assert_eq!(client.calls(), 2);
     }
 
     #[tokio::test]
@@ -231,6 +374,7 @@ mod tests {
             LlmRetryPolicy {
                 max_retries: 5,
                 base_delay_secs: 0,
+                ..LlmRetryPolicy::default()
             },
             |_attempt, _max_retries, _delay_secs, _err| {},
         )

--- a/packages/core/src/infra/llm_retry.rs
+++ b/packages/core/src/infra/llm_retry.rs
@@ -268,6 +268,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn does_not_retry_content_rejection() {
+        let _env_guard = QUOTA_TEST_LOCK.lock().await;
+        let _quota_guard = QuotaTestGuard::new();
+
+        let client = Arc::new(SequenceClient::new(vec![Err(InfraError::LlmRejected {
+            code: "sensitive_words_detected".into(),
+            message: "blocked".into(),
+        })]));
+
+        let error = llm_with_retry_policy(
+            &(client.clone() as Arc<dyn LlmClient>),
+            "prompt",
+            "system",
+            LlmRetryPolicy {
+                max_retries: 5,
+                base_delay_secs: 0,
+                request_timeout_millis: 100,
+            },
+            |_attempt, _max_retries, _delay_secs, _err| {},
+        )
+        .await
+        .expect_err("content rejection must fail without retry");
+
+        assert!(matches!(error, InfraError::LlmRejected { .. }));
+        assert_eq!(client.calls(), 1);
+    }
+
+    #[tokio::test]
     async fn retries_on_stream_disconnect_then_succeeds() {
         let _env_guard = QUOTA_TEST_LOCK.lock().await;
         let _quota_guard = QuotaTestGuard::new();

--- a/packages/core/src/infra/llm_retry.rs
+++ b/packages/core/src/infra/llm_retry.rs
@@ -99,6 +99,12 @@ where
 }
 
 fn is_retryable_error(err: &InfraError) -> bool {
+    if let InfraError::LlmHttp { status, .. } = err {
+        return *status == 408 || *status == 425 || (500..=599).contains(status);
+    }
+    if matches!(err, InfraError::LlmRejected { .. }) {
+        return false;
+    }
     let msg = err.to_string();
     msg.contains("cooldown")
         || msg.contains("service_busy")
@@ -123,6 +129,18 @@ fn backoff_delay_secs(base_delay_secs: u64, attempt: usize) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn typed_http_status_controls_retryability() {
+        assert!(is_retryable_error(&InfraError::LlmHttp {
+            status: 503,
+            message: "moderation service unavailable".into(),
+        }));
+        assert!(!is_retryable_error(&InfraError::LlmHttp {
+            status: 400,
+            message: "bad request".into(),
+        }));
+    }
     use crate::infra::quota_state::{is_exhausted as is_quota_exhausted, set_quota_file_override};
     use async_trait::async_trait;
     use std::collections::VecDeque;

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -123,6 +123,19 @@ fn migrate_items_add_document_columns(conn: &Connection) -> InfraResult<()> {
 }
 
 fn migrate_documents_url_unique(conn: &Connection) -> InfraResult<()> {
+    let unique_index_exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM pragma_index_list('documents')
+             WHERE name = 'idx_documents_url' AND \"unique\" = 1",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    if unique_index_exists > 0 {
+        return Ok(());
+    }
+
     conn.execute_batch(
         "UPDATE items
          SET document_id = (
@@ -278,8 +291,8 @@ fn migrate_extraction_jobs_conversation_fk(conn: &Connection) -> InfraResult<()>
 
 #[cfg(test)]
 mod tests {
-    use super::prepare_sqlite_db;
-    use rusqlite::Connection;
+    use super::{migrate_documents_url_unique, prepare_sqlite_db};
+    use rusqlite::{Connection, OpenFlags};
 
     #[test]
     fn prepare_sqlite_db_rebuilds_legacy_items_with_document_fk() {
@@ -356,6 +369,21 @@ mod tests {
             err.to_string().contains("FOREIGN KEY constraint failed"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn documents_url_migration_is_read_only_after_unique_index_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("refine.db");
+        {
+            let conn = Connection::open(&path).expect("open writable database");
+            prepare_sqlite_db(&conn).expect("prepare database");
+        }
+
+        let conn = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .expect("open read-only database");
+        migrate_documents_url_unique(&conn)
+            .expect("an already-migrated database must not require writes");
     }
 
     #[test]

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -29,6 +29,7 @@ pub fn prepare_sqlite_db(conn: &Connection) -> InfraResult<()> {
     tx.execute_batch(include_str!("schema.sql"))
         .map_err(|e| InfraError::Database(e.to_string()))?;
     migrate_items_add_document_columns(&tx)?;
+    migrate_documents_add_source_version(&tx)?;
     migrate_documents_url_unique(&tx)?;
     migrate_items_document_fk(&tx)?;
     migrate_extraction_jobs_conversation_fk(&tx)?;
@@ -119,6 +120,14 @@ fn migrate_items_add_document_columns(conn: &Connection) -> InfraResult<()> {
     }
     conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_items_document ON items(document_id)")
         .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(())
+}
+
+fn migrate_documents_add_source_version(conn: &Connection) -> InfraResult<()> {
+    if !column_exists(conn, "documents", "source_version")? {
+        conn.execute_batch("ALTER TABLE documents ADD COLUMN source_version TEXT")
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+    }
     Ok(())
 }
 
@@ -291,7 +300,7 @@ fn migrate_extraction_jobs_conversation_fk(conn: &Connection) -> InfraResult<()>
 
 #[cfg(test)]
 mod tests {
-    use super::{migrate_documents_url_unique, prepare_sqlite_db};
+    use super::{column_exists, migrate_documents_url_unique, prepare_sqlite_db};
     use rusqlite::{Connection, OpenFlags};
 
     #[test]
@@ -334,6 +343,9 @@ mod tests {
         .unwrap_or_else(|err| panic!("seed legacy schema: {err}"));
 
         prepare_sqlite_db(&conn).unwrap_or_else(|err| panic!("prepare sqlite db: {err}"));
+
+        assert!(column_exists(&conn, "documents", "source_version")
+            .expect("inspect migrated documents columns"));
 
         let document_id: Option<String> = conn
             .query_row(

--- a/packages/core/src/infra/schema.sql
+++ b/packages/core/src/infra/schema.sql
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS documents (
     raw_content TEXT NOT NULL,
     source TEXT NOT NULL,
     url TEXT NOT NULL,
+    source_version TEXT,
     captured_at TEXT NOT NULL,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL

--- a/packages/core/src/infra/sqlite/conversation_ops.rs
+++ b/packages/core/src/infra/sqlite/conversation_ops.rs
@@ -530,6 +530,7 @@ mod tests {
     use serde_json::json;
     use std::path::PathBuf;
     use std::sync::Arc;
+    use tokio::sync::Barrier;
     use uuid::Uuid;
 
     fn temp_db_path() -> PathBuf {
@@ -770,17 +771,22 @@ mod tests {
 
         let path1 = path.clone();
         let path2 = path.clone();
+        let barrier = Arc::new(Barrier::new(2));
 
+        let barrier1 = barrier.clone();
         let h1 = tokio::spawn(async move {
             let store = SqliteStore::open(&path1).expect("store 1");
             let store: Arc<dyn ConversationRepository> = Arc::new(store);
+            barrier1.wait().await;
             store
                 .insert_or_fetch_conversation_by_idempotency(&record1)
                 .await
         });
+        let barrier2 = barrier;
         let h2 = tokio::spawn(async move {
             let store = SqliteStore::open(&path2).expect("store 2");
             let store: Arc<dyn ConversationRepository> = Arc::new(store);
+            barrier2.wait().await;
             store
                 .insert_or_fetch_conversation_by_idempotency(&record2)
                 .await

--- a/packages/core/src/infra/sqlite/doc_ops.rs
+++ b/packages/core/src/infra/sqlite/doc_ops.rs
@@ -6,14 +6,15 @@ use rusqlite::{params, Connection, OptionalExtension};
 
 pub(super) fn save(conn: &Connection, doc: &Document) -> InfraResult<()> {
     conn.execute(
-        "INSERT INTO documents (id, title, raw_content, source, url, captured_at, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+        "INSERT INTO documents (id, title, raw_content, source, url, source_version, captured_at, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
          ON CONFLICT(url) DO UPDATE SET
              title = CASE
                  WHEN excluded.title IS NULL OR TRIM(excluded.title) = '' THEN documents.title
                  ELSE excluded.title
              END,
              raw_content = excluded.raw_content,
+             source_version = excluded.source_version,
              captured_at = excluded.captured_at,
              updated_at = excluded.updated_at",
         params![
@@ -22,6 +23,7 @@ pub(super) fn save(conn: &Connection, doc: &Document) -> InfraResult<()> {
             doc.raw_content(),
             doc.source(),
             doc.url(),
+            doc.source_version(),
             doc.captured_at().to_rfc3339(),
             doc.created_at().to_rfc3339(),
             doc.updated_at().to_rfc3339(),
@@ -33,7 +35,7 @@ pub(super) fn save(conn: &Connection, doc: &Document) -> InfraResult<()> {
 
 pub(super) fn find_by_id(conn: &Connection, id: &str) -> InfraResult<Option<Document>> {
     let mut stmt = conn
-        .prepare("SELECT id, title, raw_content, source, url, captured_at, created_at, updated_at FROM documents WHERE id = ?1")
+        .prepare("SELECT id, title, raw_content, source, url, source_version, captured_at, created_at, updated_at FROM documents WHERE id = ?1")
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     stmt.query_row([id], |row| row_to_document(row).map_err(to_row_err))
@@ -43,7 +45,7 @@ pub(super) fn find_by_id(conn: &Connection, id: &str) -> InfraResult<Option<Docu
 
 pub(super) fn find_by_url(conn: &Connection, url: &str) -> InfraResult<Option<Document>> {
     let mut stmt = conn
-        .prepare("SELECT id, title, raw_content, source, url, captured_at, created_at, updated_at FROM documents WHERE url = ?1")
+        .prepare("SELECT id, title, raw_content, source, url, source_version, captured_at, created_at, updated_at FROM documents WHERE url = ?1")
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     stmt.query_row([url], |row| row_to_document(row).map_err(to_row_err))
@@ -60,7 +62,7 @@ pub(super) fn find_recent(
     let offset = std::cmp::min(offset, i64::MAX as usize) as i64;
 
     let mut stmt = conn
-        .prepare("SELECT id, title, raw_content, source, url, captured_at, created_at, updated_at FROM documents ORDER BY captured_at DESC, created_at DESC LIMIT ?1 OFFSET ?2")
+        .prepare("SELECT id, title, raw_content, source, url, source_version, captured_at, created_at, updated_at FROM documents ORDER BY captured_at DESC, created_at DESC LIMIT ?1 OFFSET ?2")
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     let rows = stmt
@@ -101,7 +103,7 @@ pub(super) fn search_text(
 
     let mut stmt = conn
         .prepare(
-            "SELECT d.id, d.title, d.raw_content, d.source, d.url, d.captured_at, d.created_at, d.updated_at
+            "SELECT d.id, d.title, d.raw_content, d.source, d.url, d.source_version, d.captured_at, d.created_at, d.updated_at
              FROM documents d
              JOIN documents_fts fts ON d.rowid = fts.rowid
              WHERE documents_fts MATCH ?1
@@ -150,14 +152,17 @@ fn row_to_document(row: &rusqlite::Row) -> InfraResult<Document> {
     let url: String = row
         .get(4)
         .map_err(|e| InfraError::Database(e.to_string()))?;
-    let captured_at_raw: String = row
+    let source_version: Option<String> = row
         .get(5)
         .map_err(|e| InfraError::Database(e.to_string()))?;
-    let created_at_raw: String = row
+    let captured_at_raw: String = row
         .get(6)
         .map_err(|e| InfraError::Database(e.to_string()))?;
-    let updated_at_raw: String = row
+    let created_at_raw: String = row
         .get(7)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let updated_at_raw: String = row
+        .get(8)
         .map_err(|e| InfraError::Database(e.to_string()))?;
 
     let parse_dt = |raw: &str, label: &str| -> InfraResult<DateTime<Utc>> {
@@ -172,6 +177,7 @@ fn row_to_document(row: &rusqlite::Row) -> InfraResult<Document> {
         raw_content,
         source,
         url,
+        source_version,
         captured_at: parse_dt(&captured_at_raw, "captured_at")?,
         created_at: parse_dt(&created_at_raw, "created_at")?,
         updated_at: parse_dt(&updated_at_raw, "updated_at")?,

--- a/packages/core/src/infra/sqlite/mod.rs
+++ b/packages/core/src/infra/sqlite/mod.rs
@@ -40,6 +40,14 @@ impl SqliteStore {
         Ok(Self { worker })
     }
 
+    /// Open an existing database without running migrations or allowing writes.
+    /// Used by preview commands whose read-only promise must include startup.
+    pub fn open_read_only(path: impl AsRef<Path>) -> InfraResult<Self> {
+        let mode = OpenMode::ReadOnlyFile(PathBuf::from(path.as_ref()));
+        let worker = start_worker(mode)?;
+        Ok(Self { worker })
+    }
+
     /// 内存数据库（测试用）
     pub fn in_memory() -> InfraResult<Self> {
         let worker = start_worker(OpenMode::InMemory)?;

--- a/packages/core/src/infra/sqlite/rows.rs
+++ b/packages/core/src/infra/sqlite/rows.rs
@@ -25,6 +25,18 @@ pub(crate) fn configure_connection(conn: &Connection, in_memory: bool) -> InfraR
     Ok(())
 }
 
+pub(crate) fn configure_read_only_connection(conn: &Connection) -> InfraResult<()> {
+    conn.busy_timeout(Duration::from_secs(5))
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    conn.execute_batch(
+        "PRAGMA foreign_keys = ON;
+         PRAGMA temp_store = MEMORY;
+         PRAGMA query_only = ON;",
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(())
+}
+
 pub(super) fn to_fts_query(query: &str) -> Option<String> {
     let terms: Vec<String> = query
         .split_whitespace()

--- a/packages/core/src/infra/sqlite/worker.rs
+++ b/packages/core/src/infra/sqlite/worker.rs
@@ -1,10 +1,10 @@
-use super::rows::configure_connection;
+use super::rows::{configure_connection, configure_read_only_connection};
 use super::{conversation_ops, doc_ops, ops};
 use crate::conversation::{ConversationRecord, EventRecord, ExtractionJobRecord};
 use crate::error::{InfraError, InfraResult};
 use crate::knowledge::{Document, Item, ItemType};
 use chrono::{DateTime, Utc};
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 use std::path::PathBuf;
 use std::sync::mpsc;
 use tokio::sync::oneshot;
@@ -15,6 +15,7 @@ const WORKER_INIT_FAILED: &str = "sqlite worker init failed";
 pub(super) enum OpenMode {
     InMemory,
     File(PathBuf),
+    ReadOnlyFile(PathBuf),
 }
 
 pub(super) enum SqliteCommand {
@@ -205,9 +206,9 @@ fn run_worker(
     rx: mpsc::Receiver<SqliteCommand>,
     init_tx: mpsc::SyncSender<InfraResult<()>>,
 ) {
-    let (conn, in_memory) = match mode {
+    let (conn, in_memory, read_only) = match mode {
         OpenMode::InMemory => match Connection::open_in_memory() {
-            Ok(conn) => (conn, true),
+            Ok(conn) => (conn, true, false),
             Err(err) => {
                 send_init_result(
                     &init_tx,
@@ -218,7 +219,7 @@ fn run_worker(
             }
         },
         OpenMode::File(path) => match Connection::open(path) {
-            Ok(conn) => (conn, false),
+            Ok(conn) => (conn, false, false),
             Err(err) => {
                 send_init_result(
                     &init_tx,
@@ -228,9 +229,28 @@ fn run_worker(
                 return;
             }
         },
+        OpenMode::ReadOnlyFile(path) => match Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        ) {
+            Ok(conn) => (conn, false, true),
+            Err(err) => {
+                send_init_result(
+                    &init_tx,
+                    Err(InfraError::Database(err.to_string())),
+                    "open read-only file connection",
+                );
+                return;
+            }
+        },
     };
 
-    if let Err(err) = configure_connection(&conn, in_memory).and_then(|_| ops::init_schema(&conn)) {
+    let configured = if read_only {
+        configure_read_only_connection(&conn)
+    } else {
+        configure_connection(&conn, in_memory).and_then(|_| ops::init_schema(&conn))
+    };
+    if let Err(err) = configured {
         send_init_result(&init_tx, Err(err), "configure schema");
         return;
     }

--- a/packages/core/src/knowledge/document.rs
+++ b/packages/core/src/knowledge/document.rs
@@ -13,6 +13,7 @@ pub struct RestoreDocumentParams {
     pub raw_content: String,
     pub source: String,
     pub url: String,
+    pub source_version: Option<String>,
     pub captured_at: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -26,6 +27,8 @@ pub struct Document {
     raw_content: String,
     source: String,
     url: String,
+    #[serde(default)]
+    source_version: Option<String>,
     captured_at: DateTime<Utc>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
@@ -40,6 +43,7 @@ impl Document {
             raw_content: raw_content.to_string(),
             source: source.to_string(),
             url: String::new(),
+            source_version: None,
             captured_at: now,
             created_at: now,
             updated_at: now,
@@ -53,6 +57,7 @@ impl Document {
             raw_content: params.raw_content,
             source: params.source,
             url: params.url,
+            source_version: params.source_version,
             captured_at: params.captured_at,
             created_at: params.created_at,
             updated_at: params.updated_at,
@@ -76,6 +81,9 @@ impl Document {
     pub fn url(&self) -> &str {
         &self.url
     }
+    pub fn source_version(&self) -> Option<&str> {
+        self.source_version.as_deref()
+    }
     pub fn captured_at(&self) -> DateTime<Utc> {
         self.captured_at
     }
@@ -95,6 +103,11 @@ impl Document {
 
     pub fn set_url(&mut self, url: &str) {
         self.url = url.to_string();
+        self.updated_at = Utc::now();
+    }
+
+    pub fn set_source_version(&mut self, source_version: Option<&str>) {
+        self.source_version = source_version.map(ToOwned::to_owned);
         self.updated_at = Utc::now();
     }
 

--- a/packages/core/src/session/report.rs
+++ b/packages/core/src/session/report.rs
@@ -3,11 +3,12 @@
 //! 将 10 路 LLM 分析结果合并为最终报告
 
 use super::clustering::GlobalStats;
+use serde::{Deserialize, Serialize};
 
 const MAX_FINAL_CONTEXT: usize = 30_000;
 
 /// 单路分析结果
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouteResult {
     pub route_id: usize,
     pub route_title: String,

--- a/packages/core/tests/sqlite_roundtrip.rs
+++ b/packages/core/tests/sqlite_roundtrip.rs
@@ -12,6 +12,40 @@ use serde_json::json;
 use std::collections::HashSet;
 
 #[tokio::test]
+async fn read_only_store_never_runs_schema_migrations_or_accepts_writes() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("legacy.db");
+    {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE marker (value TEXT NOT NULL);
+             INSERT INTO marker VALUES ('unchanged');",
+        )
+        .unwrap();
+    }
+    let before = std::fs::read(&path).unwrap();
+    let store = SqliteStore::open_read_only(&path).unwrap();
+    let item = Item::new_knowledge("must fail", "read only");
+    assert!(store.save(&item).await.is_err());
+    drop(store);
+    assert_eq!(std::fs::read(&path).unwrap(), before);
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    assert_eq!(
+        conn.query_row("SELECT value FROM marker", [], |row| row
+            .get::<_, String>(0))
+            .unwrap(),
+        "unchanged"
+    );
+    assert!(conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='documents'",
+            [],
+            |_| Ok(())
+        )
+        .is_err());
+}
+
+#[tokio::test]
 async fn roundtrip_preserves_timestamps_and_content() {
     let store = SqliteStore::in_memory().expect("failed to create sqlite store");
 

--- a/packages/core/tests/sqlite_roundtrip.rs
+++ b/packages/core/tests/sqlite_roundtrip.rs
@@ -119,6 +119,7 @@ async fn document_save_refreshes_existing_url_content() {
     let mut second = Document::new("claude", "newer content");
     second.set_title("Newer title");
     second.set_url(url);
+    second.set_source_version(Some("source:v1:2"));
     let second_captured_at = second.captured_at();
     let second_updated_at = second.updated_at();
     refine_core::knowledge::DocumentRepository::save(&store, &second)
@@ -137,11 +138,13 @@ async fn document_save_refreshes_existing_url_content() {
     assert_eq!(by_url.id(), first.id());
     assert_eq!(by_url.title(), Some("Newer title"));
     assert_eq!(by_url.raw_content(), "newer content");
+    assert_eq!(by_url.source_version(), Some("source:v1:2"));
     assert_eq!(by_url.captured_at(), second_captured_at);
     assert_eq!(by_url.updated_at(), second_updated_at);
     assert!(by_url.updated_at() >= first_updated_at);
     assert_eq!(by_id.title(), Some("Newer title"));
     assert_eq!(by_id.raw_content(), "newer content");
+    assert_eq!(by_id.source_version(), Some("source:v1:2"));
     assert_eq!(by_id.captured_at(), second_captured_at);
     assert_eq!(by_id.updated_at(), second_updated_at);
 }
@@ -203,6 +206,7 @@ async fn document_find_recent_orders_by_latest_capture_after_duplicate_url_refre
         raw_content: "older content".to_string(),
         source: "claude".to_string(),
         url: "https://claude.ai/chat/older".to_string(),
+        source_version: None,
         captured_at: older_capture,
         created_at: older_capture,
         updated_at: older_capture,
@@ -217,6 +221,7 @@ async fn document_find_recent_orders_by_latest_capture_after_duplicate_url_refre
         raw_content: "newer content".to_string(),
         source: "claude".to_string(),
         url: "https://claude.ai/chat/newer".to_string(),
+        source_version: None,
         captured_at: middle_capture,
         created_at: middle_capture,
         updated_at: middle_capture,
@@ -231,6 +236,7 @@ async fn document_find_recent_orders_by_latest_capture_after_duplicate_url_refre
         raw_content: "recaptured content".to_string(),
         source: "claude".to_string(),
         url: older.url().to_string(),
+        source_version: None,
         captured_at: newest_capture,
         created_at: newest_capture,
         updated_at: newest_capture,

--- a/scripts/configure-llm-env.sh
+++ b/scripts/configure-llm-env.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/load-llm-env.sh
+source "${SCRIPT_DIR}/load-llm-env.sh"
+
+# Keep every temporary and backup private.  This script is the only workflow
+# that intentionally copies an LLM credential during an explicit migration.
+umask 077
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/configure-llm-env.sh [--check | --migrate | --from-env]
+
+Modes:
+  --check      Validate the secure file and report whether ~/.zshrc is ready
+               to migrate. This is the default and never writes files.
+  --migrate    Migrate literal export BASE_URL, BASE_API_KEY, and BASE_MODEL
+               definitions from ~/.zshrc into ~/.refine/llm.env.
+  --from-env   Write supported variables that are already exported in this
+               process into ~/.refine/llm.env. This does not edit ~/.zshrc.
+
+The migration mode is intentionally limited to literal definitions. It does
+not evaluate ~/.zshrc, run zsh startup code, or accept shell expressions.
+EOF
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+home_dir="${HOME:-}"
+[[ -n "$home_dir" ]] || die 'HOME is not set'
+
+mode=''
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      [[ -z "$mode" ]] || die 'choose exactly one configuration mode'
+      mode='check'
+      ;;
+    --migrate)
+      [[ -z "$mode" ]] || die 'choose exactly one configuration mode'
+      mode='migrate'
+      ;;
+    --from-env)
+      [[ -z "$mode" ]] || die 'choose exactly one configuration mode'
+      mode='from-env'
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+  shift
+done
+[[ -n "$mode" ]] || mode='check'
+
+secure_file="$(refine_llm_env_file_path)" || die 'cannot determine the secure LLM env file'
+zshrc_file="${REFINE_ZSHRC_FILE:-${home_dir}/.zshrc}"
+source_begin='# >>> Refine LLM env (managed) >>>'
+source_end='# <<< Refine LLM env (managed) <<<'
+
+tmp_env=''
+tmp_zshrc=''
+cleanup() {
+  [[ -z "$tmp_env" || ! -e "$tmp_env" ]] || rm -f "$tmp_env"
+  [[ -z "$tmp_zshrc" || ! -e "$tmp_zshrc" ]] || rm -f "$tmp_zshrc"
+}
+trap cleanup EXIT HUP INT TERM
+
+write_quoted_assignment() {
+  local key="$1"
+  local value="$2"
+  if [[ "$value" == *\'* ]]; then
+    die "${key} contains an unsupported single quote; refusing to write it"
+  fi
+  printf "export %s='%s'\n" "$key" "$value"
+}
+
+zshrc_line_mentions_migration_key() {
+  local line="$1" key
+
+  # Use the same exported-assignment prefix accepted by the shared parser.
+  # Extract only the left-hand side so names such as MIMO_BASE_URL and shell
+  # references in unrelated commands never enter strict migration parsing.
+  case "$line" in
+    export[[:space:]]*)
+      line="${line#export}"
+      while [[ "$line" == [[:space:]]* ]]; do
+        line="${line#?}"
+      done
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  if [[ "$line" == *=* ]]; then
+    key="${line%%=*}"
+  else
+    # Keep malformed exact exports in scope so the strict parser can fail
+    # closed instead of silently ignoring them.
+    key="$line"
+  fi
+  while [[ "$key" == *[[:space:]] ]]; do
+    key="${key%?}"
+  done
+
+  case "$key" in
+    BASE_URL|BASE_API_KEY|BASE_MODEL)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+MIGRATION_BASE_URL=''
+MIGRATION_BASE_API_KEY=''
+MIGRATION_BASE_MODEL=''
+MIGRATION_REMOVE_LINES=' '
+MIGRATION_DEFINITION_COUNT=0
+MIGRATION_SOURCE_BLOCK_COUNT=0
+MIGRATION_SOURCE_END_COUNT=0
+
+collect_zsh_definitions() {
+  local line line_number=0 parse_rc trimmed key value
+
+  MIGRATION_BASE_URL=''
+  MIGRATION_BASE_API_KEY=''
+  MIGRATION_BASE_MODEL=''
+  MIGRATION_REMOVE_LINES=' '
+  MIGRATION_DEFINITION_COUNT=0
+  MIGRATION_SOURCE_BLOCK_COUNT=0
+  MIGRATION_SOURCE_END_COUNT=0
+
+  if [[ -L "$zshrc_file" ]]; then
+    die "zshrc is a symlink and was rejected: ${zshrc_file}"
+  fi
+  if [[ ! -f "$zshrc_file" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    line="${line%$'\r'}"
+    trimmed="$line"
+    while [[ "$trimmed" == [[:space:]]* ]]; do
+      trimmed="${trimmed#?}"
+    done
+
+    if [[ "$trimmed" == "$source_begin" ]]; then
+      MIGRATION_SOURCE_BLOCK_COUNT=$((MIGRATION_SOURCE_BLOCK_COUNT + 1))
+      continue
+    fi
+    if [[ "$trimmed" == "$source_end" ]]; then
+      MIGRATION_SOURCE_END_COUNT=$((MIGRATION_SOURCE_END_COUNT + 1))
+      continue
+    fi
+    [[ -z "$trimmed" || "$trimmed" == \#* ]] && continue
+    zshrc_line_mentions_migration_key "$trimmed" || continue
+
+    case "$trimmed" in
+      export[[:space:]]*)
+        ;;
+      *)
+        die "${zshrc_file}:${line_number}: BASE_* definitions must be literal exported assignments"
+        ;;
+    esac
+
+    if refine_llm_env_parse_assignment "$trimmed" 1; then
+      parse_rc=0
+    else
+      parse_rc=$?
+    fi
+    if [[ "$parse_rc" -ne 0 ]]; then
+      die "${zshrc_file}:${line_number}: malformed BASE_* definition; refusing migration"
+    fi
+    key="$REFINE_LLM_ENV_PARSED_KEY"
+    value="$REFINE_LLM_ENV_PARSED_VALUE"
+    case "$key" in
+      BASE_URL)
+        [[ -n "$MIGRATION_BASE_URL" ]] && die "${zshrc_file}:${line_number}: duplicate BASE_URL definition"
+        MIGRATION_BASE_URL="$value"
+        ;;
+      BASE_API_KEY)
+        [[ -n "$MIGRATION_BASE_API_KEY" ]] && die "${zshrc_file}:${line_number}: duplicate BASE_API_KEY definition"
+        MIGRATION_BASE_API_KEY="$value"
+        ;;
+      BASE_MODEL)
+        [[ -n "$MIGRATION_BASE_MODEL" ]] && die "${zshrc_file}:${line_number}: duplicate BASE_MODEL definition"
+        MIGRATION_BASE_MODEL="$value"
+        ;;
+      *)
+        die "${zshrc_file}:${line_number}: only BASE_URL, BASE_API_KEY, and BASE_MODEL may be migrated"
+        ;;
+    esac
+    [[ -n "$value" ]] || die "${zshrc_file}:${line_number}: ${key} has no value"
+    MIGRATION_REMOVE_LINES="${MIGRATION_REMOVE_LINES}${line_number} "
+    MIGRATION_DEFINITION_COUNT=$((MIGRATION_DEFINITION_COUNT + 1))
+  done < "$zshrc_file"
+
+  if [[ "$MIGRATION_SOURCE_BLOCK_COUNT" -gt 1 || "$MIGRATION_SOURCE_END_COUNT" -gt 1 || \
+    "$MIGRATION_SOURCE_BLOCK_COUNT" -ne "$MIGRATION_SOURCE_END_COUNT" ]]; then
+    die "${zshrc_file}: malformed or duplicate Refine LLM source block"
+  fi
+}
+
+require_complete_migration_definitions() {
+  [[ "$MIGRATION_BASE_URL" != '' ]] || die "missing literal export BASE_URL=... in ${zshrc_file}"
+  [[ "$MIGRATION_BASE_API_KEY" != '' ]] || die "missing literal export BASE_API_KEY=... in ${zshrc_file}"
+  [[ "$MIGRATION_BASE_MODEL" != '' ]] || die "missing literal export BASE_MODEL=... in ${zshrc_file}"
+}
+
+line_is_removed() {
+  local line_number="$1"
+  case "$MIGRATION_REMOVE_LINES" in
+    *" ${line_number} "*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+validate_transformed_zshrc() {
+  local path="$1"
+  local line trimmed begin_count=0 end_count=0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    trimmed="$line"
+    while [[ "$trimmed" == [[:space:]]* ]]; do
+      trimmed="${trimmed#?}"
+    done
+    if [[ "$trimmed" == "$source_begin" ]]; then
+      begin_count=$((begin_count + 1))
+    elif [[ "$trimmed" == "$source_end" ]]; then
+      end_count=$((end_count + 1))
+    elif [[ -n "$trimmed" && "$trimmed" != \#* ]] && zshrc_line_mentions_migration_key "$trimmed"; then
+      die "${path}: migrated BASE_* definition remains; refusing replacement"
+    fi
+  done < "$path"
+
+  [[ "$begin_count" -eq 1 && "$end_count" -eq 1 ]] || die "${path}: generated source block validation failed"
+  if command -v zsh >/dev/null 2>&1 && ! zsh -n "$path" >/dev/null 2>&1; then
+    die "${path}: generated zsh syntax validation failed"
+  fi
+}
+
+secure_file_is_present() {
+  [[ -L "$secure_file" || -e "$secure_file" ]]
+}
+
+write_managed_source_block() {
+  printf '\n%s\n' "$source_begin"
+  printf '%s\n' "if [ -r \"\${REFINE_LLM_ENV_FILE:-\$HOME/.refine/llm.env}\" ]; then"
+  printf '%s\n' "  . \"\${REFINE_LLM_ENV_FILE:-\$HOME/.refine/llm.env}\""
+  printf '%s\n' 'fi'
+  printf '%s\n' "$source_end"
+}
+
+backup_zshrc() {
+  local backup_dir="${home_dir}/.refine/backups" backup_index=0
+
+  mkdir -p "$backup_dir"
+  chmod 700 "$backup_dir" || die "cannot secure backup directory: ${backup_dir}"
+  MIGRATION_BACKUP_FILE="${backup_dir}/zshrc.$(date +%Y%m%d%H%M%S).bak"
+  while [[ -e "$MIGRATION_BACKUP_FILE" ]]; do
+    backup_index=$((backup_index + 1))
+    MIGRATION_BACKUP_FILE="${backup_dir}/zshrc.$(date +%Y%m%d%H%M%S).${backup_index}.bak"
+  done
+  cp "$zshrc_file" "$MIGRATION_BACKUP_FILE" || die 'cannot create zshrc backup'
+  chmod 600 "$MIGRATION_BACKUP_FILE"
+}
+
+check_mode() {
+  local secure_ready=0
+
+  if secure_file_is_present; then
+    refine_llm_env_validate_secure_file "$secure_file" || exit 1
+    if [[ "$REFINE_LLM_ENV_FILE_HAS_API_KEY" == '1' ]]; then
+      secure_ready=1
+      printf 'CHECK: secure LLM env file is valid (API key: <set>; values withheld)\n'
+    else
+      printf 'CHECK: secure LLM env file is valid but has no supported API key\n'
+    fi
+  else
+    printf 'CHECK: secure LLM env file is not present yet: %s\n' "$secure_file"
+  fi
+
+  if [[ -f "$zshrc_file" ]]; then
+    collect_zsh_definitions
+    if [[ "$MIGRATION_DEFINITION_COUNT" -gt 0 ]]; then
+      require_complete_migration_definitions
+      [[ "$MIGRATION_DEFINITION_COUNT" -eq 3 ]] || die "${zshrc_file}: expected exactly one BASE_URL, BASE_API_KEY, and BASE_MODEL definition"
+      printf 'CHECK: ~/.zshrc has 3 literal BASE_* definitions ready for --migrate (no changes made)\n'
+    elif [[ "$secure_ready" == '1' ]]; then
+      printf 'CHECK: no pending BASE_* migration; secure credentials are available\n'
+    else
+      die "no complete literal BASE_* definitions found and unattended credentials are not configured"
+    fi
+  elif [[ "$secure_ready" == '1' ]]; then
+    printf 'CHECK: ~/.zshrc is absent; secure credentials are available\n'
+  else
+      die "${home_dir}/.zshrc is absent and unattended credentials are not configured"
+  fi
+}
+
+migrate_mode() {
+  local env_dir line line_number=0
+
+  if secure_file_is_present; then
+    refine_llm_env_validate_secure_file "$secure_file" || exit 1
+  fi
+  collect_zsh_definitions
+
+  if [[ "$MIGRATION_DEFINITION_COUNT" -eq 0 ]]; then
+    if secure_file_is_present && [[ "$REFINE_LLM_ENV_FILE_HAS_API_KEY" == '1' ]]; then
+      if [[ "$MIGRATION_SOURCE_BLOCK_COUNT" -eq 1 ]]; then
+        printf 'MIGRATE: no pending literal BASE_* definitions; secure file and source block were left unchanged\n'
+        return 0
+      fi
+      [[ -f "$zshrc_file" ]] || die "cannot add the managed source block because ${zshrc_file} does not exist"
+      tmp_zshrc="$(mktemp "${zshrc_file}.tmp.XXXXXX")" || die 'cannot create zshrc temporary file'
+      while IFS= read -r line || [[ -n "$line" ]]; do
+        printf '%s\n' "$line" >> "$tmp_zshrc"
+      done < "$zshrc_file"
+      write_managed_source_block >> "$tmp_zshrc"
+      chmod 600 "$tmp_zshrc"
+      validate_transformed_zshrc "$tmp_zshrc"
+      backup_zshrc
+      mv "$tmp_zshrc" "$zshrc_file"
+      tmp_zshrc=''
+      printf 'MIGRATE: secure LLM env file was valid; added one managed source block; backup=%s\n' "$MIGRATION_BACKUP_FILE"
+      return 0
+    fi
+    require_complete_migration_definitions
+  fi
+  require_complete_migration_definitions
+  [[ "$MIGRATION_DEFINITION_COUNT" -eq 3 ]] || die "${zshrc_file}: expected exactly one BASE_URL, BASE_API_KEY, and BASE_MODEL definition"
+  [[ "$MIGRATION_SOURCE_BLOCK_COUNT" -le 1 ]] || die "${zshrc_file}: duplicate Refine LLM source block"
+
+  if secure_file_is_present; then
+    die "secure LLM env file already exists; refusing to overwrite it while BASE_* definitions remain in ${zshrc_file}"
+  fi
+  [[ -f "$zshrc_file" ]] || die "cannot migrate because ${zshrc_file} does not exist"
+
+  env_dir="${secure_file%/*}"
+  [[ "$env_dir" != "$secure_file" ]] || env_dir='.'
+  mkdir -p "$env_dir"
+  chmod 700 "$env_dir" || die "cannot secure the LLM env directory: ${env_dir}"
+
+  tmp_env="$(mktemp "${secure_file}.tmp.XXXXXX")" || die 'cannot create secure env temporary file'
+  tmp_zshrc="$(mktemp "${zshrc_file}.tmp.XXXXXX")" || die 'cannot create zshrc temporary file'
+
+  {
+    write_quoted_assignment BASE_URL "$MIGRATION_BASE_URL"
+    write_quoted_assignment BASE_API_KEY "$MIGRATION_BASE_API_KEY"
+    write_quoted_assignment BASE_MODEL "$MIGRATION_BASE_MODEL"
+  } > "$tmp_env"
+  chmod 600 "$tmp_env"
+  refine_llm_env_validate_secure_file "$tmp_env" || die 'generated secure env file failed validation'
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    if ! line_is_removed "$line_number"; then
+      printf '%s\n' "$line" >> "$tmp_zshrc"
+    fi
+  done < "$zshrc_file"
+  if [[ "$MIGRATION_SOURCE_BLOCK_COUNT" -eq 0 ]]; then
+    write_managed_source_block >> "$tmp_zshrc"
+  fi
+  chmod 600 "$tmp_zshrc"
+  validate_transformed_zshrc "$tmp_zshrc"
+
+  backup_zshrc
+
+  mv "$tmp_env" "$secure_file"
+  tmp_env=''
+  mv "$tmp_zshrc" "$zshrc_file"
+  tmp_zshrc=''
+  printf 'MIGRATE: wrote secure LLM env file and removed 3 literal BASE_* definitions; backup=%s\n' "$MIGRATION_BACKUP_FILE"
+}
+
+from_env_mode() {
+  local env_dir key value found_api=0
+
+  if secure_file_is_present; then
+    refine_llm_env_validate_secure_file "$secure_file" || exit 1
+    printf 'FROM-ENV: secure LLM env file already exists; no files changed\n'
+    return 0
+  fi
+
+  env_dir="${secure_file%/*}"
+  [[ "$env_dir" != "$secure_file" ]] || env_dir='.'
+  mkdir -p "$env_dir"
+  chmod 700 "$env_dir" || die "cannot secure the LLM env directory: ${env_dir}"
+  tmp_env="$(mktemp "${secure_file}.tmp.XXXXXX")" || die 'cannot create secure env temporary file'
+
+  for key in "${REFINE_LLM_ENV_SUPPORTED_KEYS[@]}"; do
+    value="${!key:-}"
+    if [[ -n "$value" ]]; then
+      write_quoted_assignment "$key" "$value" >> "$tmp_env"
+      if refine_llm_env_is_api_key "$key"; then
+        found_api=1
+      fi
+    fi
+  done
+  [[ "$found_api" -eq 1 ]] || die 'no supported exported API key found; nothing was written'
+  chmod 600 "$tmp_env"
+  refine_llm_env_validate_secure_file "$tmp_env" || die 'generated secure env file failed validation'
+  mv "$tmp_env" "$secure_file"
+  tmp_env=''
+  printf 'FROM-ENV: wrote supported exported variables to the secure LLM env file (values withheld)\n'
+}
+
+case "$mode" in
+  check)
+    check_mode
+    ;;
+  migrate)
+    migrate_mode
+    ;;
+  from-env)
+    from_env_mode
+    ;;
+esac

--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -14,6 +14,11 @@ if [ -f .env ]; then
   set +a
 fi
 
+# launchd does not inherit interactive shell variables; fall back to BASE_* from zsh.
+# shellcheck source=scripts/load-llm-env.sh
+source "${SCRIPT_DIR}/load-llm-env.sh"
+load_refine_llm_env
+
 QUOTA_FILE="$HOME/.refine/quota_exhausted_until"
 if [ -f "$QUOTA_FILE" ]; then
   UNTIL=$(cat "$QUOTA_FILE")
@@ -30,7 +35,8 @@ echo "=== $(date) ==="
 echo "Preflight: PATH=$PATH"
 echo "Preflight: refine=$(command -v refine) mirror=$(command -v mirror)"
 echo "Preflight: cwd=$(pwd)"
-echo "Preflight: env REFINE_DB_PATH=${REFINE_DB_PATH:-<unset>} REFINE_ANTHROPIC_MODEL=${REFINE_ANTHROPIC_MODEL:-<unset>}"
+echo "Preflight: env REFINE_DB_PATH=${REFINE_DB_PATH:-<unset>} REFINE_ANTHROPIC_MODEL=${REFINE_ANTHROPIC_MODEL:-<unset>} REFINE_OPENAI_MODEL=${REFINE_OPENAI_MODEL:-<unset>} BASE_MODEL=${BASE_MODEL:-<unset>}"
+echo "Preflight: keys REFINE_ANTHROPIC_API_KEY=$([ -n "${REFINE_ANTHROPIC_API_KEY:-}" ] && echo '<set>' || echo '<unset>') REFINE_OPENAI_API_KEY=$([ -n "${REFINE_OPENAI_API_KEY:-}" ] && echo '<set>' || echo '<unset>') BASE_API_KEY=$([ -n "${BASE_API_KEY:-}" ] && echo '<set>' || echo '<unset>')"
 
 # 1. Ingest new sessions (capture exit code without aborting the script)
 echo "Step 1: ingest-sessions"

--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -31,6 +31,8 @@ fi
 
 echo "=== $(date) ==="
 
+FAILED_STEPS=()
+
 # Preflight: environment diagnostics for troubleshooting
 echo "Preflight: PATH=$PATH"
 echo "Preflight: refine=$(command -v refine) mirror=$(command -v mirror)"
@@ -49,14 +51,34 @@ fi
 
 # 2. Refresh mirror score + LLM advice (run regardless of ingest result)
 echo "Step 2: mirror score"
-mirror score 2>&1
+score_rc=0
+mirror score 2>&1 || score_rc=$?
+if [ "$score_rc" -ne 0 ]; then
+  echo "ERROR: Step 2 mirror score failed with exit code ${score_rc}" >&2
+  FAILED_STEPS+=("mirror score")
+fi
 
 # 3. Weekly report on Sundays — generates ~/.mirror/last-weekly.md for Monday MOTD reminder.
-# Non-fatal: weekly requires LLM API access and may fail without network/key.
+# A missing weekly report is user-visible and must affect the final status.
 DOW=$(date +%u)  # 1=Monday … 7=Sunday
 if [ "$DOW" = "7" ]; then
   echo "Step 3: mirror weekly (Sunday)"
-  mirror weekly 2>&1 || echo "Step 3: mirror weekly failed (non-fatal)"
+  weekly_rc=0
+  mirror weekly 2>&1 || weekly_rc=$?
+  if [ "$weekly_rc" -ne 0 ]; then
+    echo "ERROR: Step 3 mirror weekly failed with exit code ${weekly_rc}" >&2
+    FAILED_STEPS+=("mirror weekly")
+  fi
+fi
+
+echo "Step 4: wal checkpoint"
+db_path="${REFINE_DB_PATH:-$HOME/Library/Application Support/refine/refine.db}"
+if command -v sqlite3 >/dev/null 2>&1 && [ -f "$db_path" ]; then
+  if ! sqlite3 "$db_path" 'PRAGMA wal_checkpoint(TRUNCATE);' >/dev/null; then
+    echo "WARN: WAL checkpoint failed: $db_path" >&2
+  fi
+else
+  echo "WARN: WAL checkpoint skipped: sqlite3 or database missing" >&2
 fi
 
 echo "Done."
@@ -67,7 +89,12 @@ if [ "$ingest_ok" -eq 1 ]; then
   date -u +%Y-%m-%dT%H:%M:%SZ > ~/.refine/last-refresh-ok
 fi
 
-# Propagate ingest failure to exit status for launchd/cron health monitoring
 if [ "$ingest_ok" -eq 0 ]; then
+  FAILED_STEPS+=("ingest-sessions")
+fi
+
+# Propagate every user-visible failure to launchd/cron monitoring.
+if [ ${#FAILED_STEPS[@]} -gt 0 ]; then
+  echo "ERROR: run finished with failures: ${FAILED_STEPS[*]}" >&2
   exit 1
 fi

--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -3,21 +3,18 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${HOME}/.cargo/bin:$PATH"
-cd "${SCRIPT_DIR}/.."
+PROJECT_DIR="${SCRIPT_DIR}/.."
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${HOME}/.cargo/bin:${PATH:-}"
+cd "$PROJECT_DIR"
 
-# Load .env for LLM API keys
-if [ -f .env ]; then
-  set -a
-  # shellcheck source=/dev/null
-  source .env
-  set +a
-fi
-
-# launchd does not inherit interactive shell variables; fall back to BASE_* from zsh.
+# The loader applies process -> secure user file -> explicit project fallback.
+# It never sources ~/.zshrc or evaluates either env file.
 # shellcheck source=scripts/load-llm-env.sh
 source "${SCRIPT_DIR}/load-llm-env.sh"
-load_refine_llm_env
+if ! load_refine_llm_env "${PROJECT_DIR}/.env"; then
+  echo "ERROR: unattended LLM credentials are unavailable; refusing to start ingest" >&2
+  exit 1
+fi
 
 QUOTA_FILE="$HOME/.refine/quota_exhausted_until"
 if [ -f "$QUOTA_FILE" ]; then
@@ -37,8 +34,7 @@ FAILED_STEPS=()
 echo "Preflight: PATH=$PATH"
 echo "Preflight: refine=$(command -v refine) mirror=$(command -v mirror)"
 echo "Preflight: cwd=$(pwd)"
-echo "Preflight: env REFINE_DB_PATH=${REFINE_DB_PATH:-<unset>} REFINE_ANTHROPIC_MODEL=${REFINE_ANTHROPIC_MODEL:-<unset>} REFINE_OPENAI_MODEL=${REFINE_OPENAI_MODEL:-<unset>} BASE_MODEL=${BASE_MODEL:-<unset>}"
-echo "Preflight: keys REFINE_ANTHROPIC_API_KEY=$([ -n "${REFINE_ANTHROPIC_API_KEY:-}" ] && echo '<set>' || echo '<unset>') REFINE_OPENAI_API_KEY=$([ -n "${REFINE_OPENAI_API_KEY:-}" ] && echo '<set>' || echo '<unset>') BASE_API_KEY=$([ -n "${BASE_API_KEY:-}" ] && echo '<set>' || echo '<unset>')"
+echo "Preflight: LLM source=${REFINE_LLM_ENV_SOURCE:-none} $(refine_llm_env_status)"
 
 # 1. Ingest new sessions (capture exit code without aborting the script)
 echo "Step 1: ingest-sessions"

--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -68,7 +68,13 @@ if [ "$DOW" = "7" ]; then
 fi
 
 echo "Step 4: wal checkpoint"
-db_path="${REFINE_DB_PATH:-$HOME/Library/Application Support/refine/refine.db}"
+if [ -n "${REFINE_DB_PATH:-}" ]; then
+  db_path="$REFINE_DB_PATH"
+elif [ "$(uname -s)" = "Darwin" ]; then
+  db_path="$HOME/Library/Application Support/refine/refine.db"
+else
+  db_path="${XDG_DATA_HOME:-$HOME/.local/share}/refine/refine.db"
+fi
 if command -v sqlite3 >/dev/null 2>&1 && [ -f "$db_path" ]; then
   if ! sqlite3 "$db_path" 'PRAGMA wal_checkpoint(TRUNCATE);' >/dev/null; then
     echo "WARN: WAL checkpoint failed: $db_path" >&2

--- a/scripts/doctor-local.sh
+++ b/scripts/doctor-local.sh
@@ -73,6 +73,23 @@ mtime_text() {
   fi
 }
 
+file_sha256() {
+  local path="$1"
+  if have_cmd shasum; then
+    shasum -a 256 "$path" | awk '{print $1}'
+  elif have_cmd sha256sum; then
+    sha256sum "$path" | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+manifest_value() {
+  local key="$1"
+  local path="$2"
+  awk -F= -v key="$key" '$1 == key {sub(/^[^=]*=/, ""); print; exit}' "$path"
+}
+
 check_cmd() {
   local cmd="$1"
   if have_cmd "$cmd"; then
@@ -144,6 +161,39 @@ check_http() {
   else
     fail "API items endpoint failed"
   fi
+}
+
+check_install_manifest() {
+  local manifest="${HOME}/.refine/install-manifest"
+  if [[ ! -f "$manifest" ]]; then
+    fail "missing install manifest: $manifest"
+    return
+  fi
+
+  local expected_root expected_commit current_commit dirty
+  expected_root="$(manifest_value source_root "$manifest")"
+  expected_commit="$(manifest_value source_commit "$manifest")"
+  dirty="$(manifest_value source_dirty "$manifest")"
+  current_commit="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+
+  if [[ "$expected_root" == "$repo_root" && "$expected_commit" == "$current_commit" && "$dirty" == "0" ]]; then
+    pass "installed source matches clean checkout: ${current_commit}"
+  else
+    fail "installed source mismatch: root=${expected_root} commit=${expected_commit} dirty=${dirty}; current=${repo_root}@${current_commit}"
+  fi
+
+  local name manifest_key binary expected_hash actual_hash
+  for name in refine mirror refine-server; do
+    binary="$(command -v "$name" 2>/dev/null || true)"
+    manifest_key="${name//-/_}_sha256"
+    expected_hash="$(manifest_value "$manifest_key" "$manifest")"
+    actual_hash="$(file_sha256 "$binary" 2>/dev/null || true)"
+    if [[ -n "$binary" && -n "$expected_hash" && "$expected_hash" == "$actual_hash" ]]; then
+      pass "installed binary hash matches: $name"
+    else
+      fail "installed binary hash mismatch: $name"
+    fi
+  done
 }
 
 check_db() {
@@ -231,6 +281,15 @@ check_ui_deps() {
   fi
 }
 
+check_ui_http() {
+  local ui_url="${REFINE_UI_URL:-http://127.0.0.1:8987}"
+  if curl -fsS --max-time 3 "$ui_url" >/dev/null 2>&1; then
+    pass "desktop UI reachable: $ui_url"
+  else
+    fail "desktop UI unreachable: $ui_url"
+  fi
+}
+
 printf 'Refine local doctor\n'
 printf 'Repo: %s\n' "$repo_root"
 printf 'Server: %s\n\n' "$server_url"
@@ -238,6 +297,7 @@ printf 'Server: %s\n\n' "$server_url"
 check_cmd refine
 check_cmd mirror
 check_cmd refine-server
+check_install_manifest
 
 check_launch_agent com.lifcc.refine-server
 check_launch_agent com.lifcc.refine-daily-ingest
@@ -254,6 +314,7 @@ check_freshness
 check_logs
 if [[ "$ui_dev_enabled" == "1" ]]; then
   check_ui_deps
+  check_ui_http
 else
   pass "desktop UI dependency check skipped"
 fi

--- a/scripts/doctor-local.sh
+++ b/scripts/doctor-local.sh
@@ -170,16 +170,25 @@ check_install_manifest() {
     return
   fi
 
-  local expected_root expected_commit current_commit dirty
+  local expected_root expected_commit current_commit installed_dirty current_status current_dirty
   expected_root="$(manifest_value source_root "$manifest")"
   expected_commit="$(manifest_value source_commit "$manifest")"
-  dirty="$(manifest_value source_dirty "$manifest")"
+  installed_dirty="$(manifest_value source_dirty "$manifest")"
   current_commit="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+  if current_status="$(git -C "$repo_root" status --porcelain 2>/dev/null)"; then
+    if [[ -z "$current_status" ]]; then
+      current_dirty=0
+    else
+      current_dirty=1
+    fi
+  else
+    current_dirty=unknown
+  fi
 
-  if [[ "$expected_root" == "$repo_root" && "$expected_commit" == "$current_commit" && "$dirty" == "0" ]]; then
+  if [[ "$expected_root" == "$repo_root" && "$expected_commit" == "$current_commit" && "$installed_dirty" == "0" && "$current_dirty" == "0" ]]; then
     pass "installed source matches clean checkout: ${current_commit}"
   else
-    fail "installed source mismatch: root=${expected_root} commit=${expected_commit} dirty=${dirty}; current=${repo_root}@${current_commit}"
+    fail "installed source mismatch: root=${expected_root} commit=${expected_commit} installed_dirty=${installed_dirty}; current=${repo_root}@${current_commit} current_dirty=${current_dirty}"
   fi
 
   local name manifest_key binary expected_hash actual_hash

--- a/scripts/doctor-local.sh
+++ b/scripts/doctor-local.sh
@@ -257,7 +257,7 @@ check_unattended_llm_env() {
   local preflight
 
   # Reproduce launchd's relevant property: no interactive/process credentials
-  # and no project .env fallback. The child prints status only, never values.
+  # while using the same project .env fallback as scheduled jobs.
   # shellcheck disable=SC2016
   if preflight="$(env -i \
     HOME="$HOME" \
@@ -266,12 +266,12 @@ check_unattended_llm_env() {
     /bin/bash -c '
       set -u
       source "$1"
-      if ! load_refine_llm_env; then
+      if ! load_refine_llm_env "$2"; then
         exit 1
       fi
       printf "source=%s " "${REFINE_LLM_ENV_SOURCE:-none}"
       refine_llm_env_status
-    ' doctor-local "$repo_root/scripts/load-llm-env.sh" 2>&1)"; then
+    ' doctor-local "$repo_root/scripts/load-llm-env.sh" "$repo_root/.env" 2>&1)"; then
     pass "unattended LLM credentials: ${preflight}"
   else
     fail "unattended LLM credential preflight failed: ${preflight}"

--- a/scripts/doctor-local.sh
+++ b/scripts/doctor-local.sh
@@ -150,6 +150,12 @@ check_http() {
     return
   fi
 
+  if grep -q '"llm_configured":true' <<<"$health"; then
+    pass "server LLM extraction configured"
+  else
+    fail "server is healthy but LLM extraction is not configured; reinstall to refresh the server wrapper"
+  fi
+
   local items
   items="$(curl -sS --max-time 3 "${server_url}/v1/items?cursor=0&limit=1" 2>/dev/null || true)"
   if grep -q '"success":true' <<<"$items"; then

--- a/scripts/doctor-local.sh
+++ b/scripts/doctor-local.sh
@@ -243,6 +243,32 @@ check_freshness() {
   fi
 }
 
+check_unattended_llm_env() {
+  local llm_env_file="${REFINE_LLM_ENV_FILE:-${HOME}/.refine/llm.env}"
+  local preflight
+
+  # Reproduce launchd's relevant property: no interactive/process credentials
+  # and no project .env fallback. The child prints status only, never values.
+  # shellcheck disable=SC2016
+  if preflight="$(env -i \
+    HOME="$HOME" \
+    PATH='/usr/bin:/bin:/usr/sbin:/sbin' \
+    REFINE_LLM_ENV_FILE="$llm_env_file" \
+    /bin/bash -c '
+      set -u
+      source "$1"
+      if ! load_refine_llm_env; then
+        exit 1
+      fi
+      printf "source=%s " "${REFINE_LLM_ENV_SOURCE:-none}"
+      refine_llm_env_status
+    ' doctor-local "$repo_root/scripts/load-llm-env.sh" 2>&1)"; then
+    pass "unattended LLM credentials: ${preflight}"
+  else
+    fail "unattended LLM credential preflight failed: ${preflight}"
+  fi
+}
+
 check_logs() {
   local log_path
   local log_paths=(
@@ -308,6 +334,7 @@ else
   pass "desktop UI dev service skipped"
 fi
 
+check_unattended_llm_env
 check_http
 check_db
 check_freshness

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -147,11 +147,10 @@ EOF
 write_server_plist() {
   local path="$1"
   local cargo_bin="$2"
-  local repo="$3"
-  local path_env="$4"
-  local repo_xml server_program_xml path_xml token_xml=""
+  local path_env="$3"
+  local home_xml server_program_xml path_xml token_xml=""
   local server_program="${cargo_bin}/refine-server"
-  repo_xml="$(printf '%s' "$repo" | xml_escape)"
+  home_xml="$(printf '%s' "$HOME" | xml_escape)"
   path_xml="$(printf '%s' "$path_env" | xml_escape)"
 
   if [[ "$auth_mode" == "token" ]]; then
@@ -179,7 +178,7 @@ write_server_plist() {
     <string>${server_program_xml}</string>
   </array>
   <key>WorkingDirectory</key>
-  <string>${repo_xml}</string>
+  <string>${home_xml}</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
@@ -210,8 +209,8 @@ write_calendar_plist() {
   local hour="$5"
   local minute="$6"
   local weekday="${7:-}"
-  local repo_xml script_xml log_xml weekday_block=""
-  repo_xml="$(printf '%s' "$repo_root" | xml_escape)"
+  local home_xml script_xml log_xml weekday_block=""
+  home_xml="$(printf '%s' "$HOME" | xml_escape)"
   script_xml="$(printf '%s' "$script_path" | xml_escape)"
   log_xml="$(printf '%s' "$log_path" | xml_escape)"
   if [[ -n "$weekday" ]]; then
@@ -232,7 +231,7 @@ write_calendar_plist() {
     <string>${script_xml}</string>
   </array>
   <key>WorkingDirectory</key>
-  <string>${repo_xml}</string>
+  <string>${home_xml}</string>
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>
@@ -255,8 +254,9 @@ write_ui_plist() {
   local bun_bin="$2"
   local path_env="$3"
   local ui_dir="${repo_root}/apps/desktop/ui"
-  local bun_xml path_xml ui_xml
+  local bun_xml home_xml path_xml ui_xml
   bun_xml="$(printf '%s' "$bun_bin" | xml_escape)"
+  home_xml="$(printf '%s' "$HOME" | xml_escape)"
   path_xml="$(printf '%s' "$path_env" | xml_escape)"
   ui_xml="$(printf '%s' "$ui_dir" | xml_escape)"
 
@@ -272,10 +272,12 @@ write_ui_plist() {
   <array>
     <string>${bun_xml}</string>
     <string>run</string>
+    <string>--cwd</string>
+    <string>${ui_xml}</string>
     <string>dev</string>
   </array>
   <key>WorkingDirectory</key>
-  <string>${ui_xml}</string>
+  <string>${home_xml}</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key>
@@ -395,7 +397,7 @@ daily_plist="${launch_agents}/com.lifcc.refine-daily-ingest.plist"
 weekly_plist="${launch_agents}/com.lifcc.refine-weekly-insights.plist"
 ui_plist="${launch_agents}/com.lifcc.refine-ui-dev.plist"
 
-write_server_plist "$server_plist" "$cargo_bin" "$repo_root" "$path_env"
+write_server_plist "$server_plist" "$cargo_bin" "$path_env"
 write_calendar_plist "$daily_plist" "com.lifcc.refine-daily-ingest" "${repo_root}/scripts/daily-refresh.sh" "${HOME}/Library/Logs/refine-daily-ingest.log" 8 0
 write_calendar_plist "$weekly_plist" "com.lifcc.refine-weekly-insights" "${repo_root}/scripts/weekly-insights.sh" "${HOME}/Library/Logs/refine-insights.log" 9 0 1
 if [[ "$ui_dev_enabled" == "1" ]]; then

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -69,6 +69,17 @@ need_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
 }
 
+file_sha256() {
+  local path="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+  else
+    die "missing shasum or sha256sum; cannot write install manifest"
+  fi
+}
+
 xml_escape() {
   sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g'
 }
@@ -179,6 +190,9 @@ write_server_plist() {
   <true/>
   <key>KeepAlive</key>
   <true/>
+  <!-- Avoid a tight loop if the server repeatedly fails at startup. -->
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
   <key>StandardOutPath</key>
   <string>${HOME}/Library/Logs/refine-server.log</string>
   <key>StandardErrorPath</key>
@@ -271,8 +285,10 @@ write_ui_plist() {
   </dict>
   <key>RunAtLoad</key>
   <true/>
-  <key>KeepAlive</key>
-  <true/>
+  <!-- A development UI is started once per login. If it exits, launchd keeps
+       the failure visible instead of entering an unbounded crash loop. -->
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
   <key>StandardOutPath</key>
   <string>${repo_root}/.run/launchd-refine-ui.out.log</string>
   <key>StandardErrorPath</key>
@@ -313,6 +329,11 @@ disable_plist() {
 need_cmd cargo
 
 log "repo root: $repo_root"
+source_commit="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+[[ "$source_commit" != "unknown" ]] || die "install source is not a Git checkout"
+[[ -z "$(git -C "$repo_root" status --porcelain 2>/dev/null || true)" ]] \
+  || die "install source must be clean; commit or stash changes first"
+
 log "installing Rust binaries"
 cargo install --path "${repo_root}/apps/cli"
 cargo install --path "${repo_root}/apps/mirror"
@@ -321,10 +342,30 @@ cargo install --path "${repo_root}/apps/server"
 cargo_bin="${CARGO_HOME:-$HOME/.cargo}/bin"
 path_env="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${cargo_bin}"
 
+write_install_manifest() {
+  [[ -z "$(git -C "$repo_root" status --porcelain 2>/dev/null || true)" ]] \
+    || die "installation changed tracked source files; refusing a clean-source manifest"
+  mkdir -p "${HOME}/.refine"
+  local install_manifest="${HOME}/.refine/install-manifest"
+  write_file "$install_manifest" <<EOF
+source_root=${repo_root}
+source_commit=${source_commit}
+source_dirty=0
+refine_sha256=$(file_sha256 "${cargo_bin}/refine")
+mirror_sha256=$(file_sha256 "${cargo_bin}/mirror")
+refine_server_sha256=$(file_sha256 "${cargo_bin}/refine-server")
+installed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+}
+
 if [[ "$ui_dev_enabled" == "1" && -d "${repo_root}/apps/desktop/ui" ]]; then
   if command -v bun >/dev/null 2>&1; then
     log "installing desktop UI dependencies"
     (cd "${repo_root}/apps/desktop/ui" && bun install)
+    [[ -x "${repo_root}/apps/desktop/ui/node_modules/.bin/vite" ]] \
+      || die "desktop UI install completed without an executable Vite binary"
+    log "verifying desktop UI build"
+    (cd "${repo_root}/apps/desktop/ui" && bun run build)
   else
     log "Bun not found; skipping desktop UI dev service"
     ui_dev_enabled=0
@@ -332,11 +373,13 @@ if [[ "$ui_dev_enabled" == "1" && -d "${repo_root}/apps/desktop/ui" ]]; then
 fi
 
 if [[ "$launchd_enabled" != "1" ]]; then
+  write_install_manifest
   log "launchd disabled; binaries installed only"
   exit 0
 fi
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
+  write_install_manifest
   log "launchd is only supported on macOS; binaries installed only"
   exit 0
 fi
@@ -345,7 +388,7 @@ need_cmd launchctl
 need_cmd plutil
 
 launch_agents="${HOME}/Library/LaunchAgents"
-mkdir -p "$launch_agents" "${HOME}/Library/Logs" "${HOME}/.refine"
+mkdir -p "$launch_agents" "${HOME}/Library/Logs"
 
 server_plist="${launch_agents}/com.lifcc.refine-server.plist"
 daily_plist="${launch_agents}/com.lifcc.refine-daily-ingest.plist"
@@ -378,5 +421,6 @@ if [[ "$start_services" == "1" ]]; then
   fi
 fi
 
+write_install_manifest
 log "done"
 log "Run scripts/doctor-local.sh to verify the local stack."

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -84,10 +84,6 @@ xml_escape() {
   sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g'
 }
 
-shell_quote() {
-  printf '%q' "$1"
-}
-
 write_file() {
   local path="$1"
   local tmp
@@ -112,59 +108,30 @@ EOF
   chmod 600 "$path"
 }
 
-write_server_token_wrapper() {
-  local path="$1"
-  local token_path="$2"
-  local server_bin="$3"
-  local token_path_sh server_bin_sh
-  token_path_sh="$(shell_quote "$token_path")"
-  server_bin_sh="$(shell_quote "$server_bin")"
-
-  write_file "$path" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-
-token_file=${token_path_sh}
-server_bin=${server_bin_sh}
-
-if [[ ! -f "\$token_file" ]]; then
-  echo "[refine-server] missing token file: \$token_file" >&2
-  exit 1
-fi
-
-IFS= read -r token < "\$token_file" || true
-if [[ -z "\$token" ]]; then
-  echo "[refine-server] token file is empty: \$token_file" >&2
-  exit 1
-fi
-
-export REFINE_API_TOKEN="\$token"
-exec "\$server_bin"
-EOF
-  chmod 700 "$path"
-}
-
 write_server_plist() {
   local path="$1"
   local cargo_bin="$2"
   local path_env="$3"
-  local home_xml server_program_xml path_xml token_xml=""
-  local server_program="${cargo_bin}/refine-server"
+  local home_xml server_bin_xml wrapper_xml project_env_xml path_xml token_xml=""
+  local server_bin="${cargo_bin}/refine-server"
+  local wrapper="${repo_root}/scripts/run-refine-server.sh"
+  local project_env="${repo_root}/.env"
   home_xml="$(printf '%s' "$HOME" | xml_escape)"
   path_xml="$(printf '%s' "$path_env" | xml_escape)"
 
   if [[ "$auth_mode" == "token" ]]; then
     local token_file="${HOME}/.refine/refine-server.token"
-    local wrapper_file="${HOME}/.refine/run-refine-server.sh"
     write_server_token_file "$token_file"
-    write_server_token_wrapper "$wrapper_file" "$token_file" "$server_program"
-    server_program="$wrapper_file"
+    token_xml="<key>REFINE_API_TOKEN_FILE</key>
+    <string>$(printf '%s' "$token_file" | xml_escape)</string>"
   else
     rm -f "${HOME}/.refine/refine-server.token" "${HOME}/.refine/run-refine-server.sh"
     token_xml="<key>REFINE_DEV_ANON</key>
     <string>1</string>"
   fi
-  server_program_xml="$(printf '%s' "$server_program" | xml_escape)"
+  server_bin_xml="$(printf '%s' "$server_bin" | xml_escape)"
+  wrapper_xml="$(printf '%s' "$wrapper" | xml_escape)"
+  project_env_xml="$(printf '%s' "$project_env" | xml_escape)"
 
   write_file "$path" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -175,7 +142,10 @@ write_server_plist() {
   <string>com.lifcc.refine-server</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${server_program_xml}</string>
+    <string>/bin/bash</string>
+    <string>${wrapper_xml}</string>
+    <string>${server_bin_xml}</string>
+    <string>${project_env_xml}</string>
   </array>
   <key>WorkingDirectory</key>
   <string>${home_xml}</string>

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -304,7 +304,8 @@ load_plist() {
   local path="$1"
   local label="$2"
   local kickstart="${3:-0}"
-  local domain="gui/$(id -u)"
+  local domain
+  domain="gui/$(id -u)"
 
   launchctl bootout "$domain" "$path" >/dev/null 2>&1 || true
   launchctl bootstrap "$domain" "$path"
@@ -316,7 +317,8 @@ load_plist() {
 disable_plist() {
   local path="$1"
   local label="$2"
-  local domain="gui/$(id -u)"
+  local domain
+  domain="gui/$(id -u)"
 
   launchctl bootout "$domain" "$path" >/dev/null 2>&1 || true
   launchctl bootout "${domain}/${label}" >/dev/null 2>&1 || true
@@ -329,6 +331,21 @@ disable_plist() {
 }
 
 need_cmd cargo
+
+refine_dir="${HOME}/.refine"
+if [[ -L "$refine_dir" ]]; then
+  die "Refine directory is a symlink and was rejected: ${refine_dir}"
+fi
+mkdir -p "$refine_dir"
+chmod 700 "$refine_dir" || die "cannot secure Refine directory: ${refine_dir}"
+
+print_llm_setup_hint() {
+  local llm_env_file="${REFINE_LLM_ENV_FILE:-${refine_dir}/llm.env}"
+  if [[ -z "${REFINE_ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}${ANTHROPIC_API_KEY:-}${REFINE_OPENAI_API_KEY:-}${OPENAI_API_KEY:-}${BASE_API_KEY:-}" && \
+    ! -f "$llm_env_file" ]]; then
+    log "LLM credentials are not configured for unattended jobs; review then run: bash ${repo_root}/scripts/configure-llm-env.sh --check"
+  fi
+}
 
 log "repo root: $repo_root"
 source_commit="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || printf 'unknown')"
@@ -376,12 +393,14 @@ fi
 
 if [[ "$launchd_enabled" != "1" ]]; then
   write_install_manifest
+  print_llm_setup_hint
   log "launchd disabled; binaries installed only"
   exit 0
 fi
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   write_install_manifest
+  print_llm_setup_hint
   log "launchd is only supported on macOS; binaries installed only"
   exit 0
 fi
@@ -424,5 +443,6 @@ if [[ "$start_services" == "1" ]]; then
 fi
 
 write_install_manifest
+print_llm_setup_hint
 log "done"
 log "Run scripts/doctor-local.sh to verify the local stack."

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -354,9 +354,9 @@ source_commit="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || printf 'unkno
   || die "install source must be clean; commit or stash changes first"
 
 log "installing Rust binaries"
-cargo install --path "${repo_root}/apps/cli"
-cargo install --path "${repo_root}/apps/mirror"
-cargo install --path "${repo_root}/apps/server"
+cargo install --locked --path "${repo_root}/apps/cli"
+cargo install --locked --path "${repo_root}/apps/mirror"
+cargo install --locked --path "${repo_root}/apps/server"
 
 cargo_bin="${CARGO_HOME:-$HOME/.cargo}/bin"
 path_env="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${cargo_bin}"
@@ -377,10 +377,21 @@ installed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
 }
 
+if [[ "$launchd_enabled" != "1" || "$(uname -s)" != "Darwin" ]]; then
+  write_install_manifest
+  print_llm_setup_hint
+  if [[ "$launchd_enabled" != "1" ]]; then
+    log "launchd disabled; binaries installed only"
+  else
+    log "launchd is only supported on macOS; binaries installed only"
+  fi
+  exit 0
+fi
+
 if [[ "$ui_dev_enabled" == "1" && -d "${repo_root}/apps/desktop/ui" ]]; then
   if command -v bun >/dev/null 2>&1; then
     log "installing desktop UI dependencies"
-    (cd "${repo_root}/apps/desktop/ui" && bun install)
+    (cd "${repo_root}/apps/desktop/ui" && bun install --frozen-lockfile)
     [[ -x "${repo_root}/apps/desktop/ui/node_modules/.bin/vite" ]] \
       || die "desktop UI install completed without an executable Vite binary"
     log "verifying desktop UI build"
@@ -389,20 +400,6 @@ if [[ "$ui_dev_enabled" == "1" && -d "${repo_root}/apps/desktop/ui" ]]; then
     log "Bun not found; skipping desktop UI dev service"
     ui_dev_enabled=0
   fi
-fi
-
-if [[ "$launchd_enabled" != "1" ]]; then
-  write_install_manifest
-  print_llm_setup_hint
-  log "launchd disabled; binaries installed only"
-  exit 0
-fi
-
-if [[ "$(uname -s)" != "Darwin" ]]; then
-  write_install_manifest
-  print_llm_setup_hint
-  log "launchd is only supported on macOS; binaries installed only"
-  exit 0
 fi
 
 need_cmd launchctl
@@ -418,7 +415,7 @@ ui_plist="${launch_agents}/com.lifcc.refine-ui-dev.plist"
 
 write_server_plist "$server_plist" "$cargo_bin" "$path_env"
 write_calendar_plist "$daily_plist" "com.lifcc.refine-daily-ingest" "${repo_root}/scripts/daily-refresh.sh" "${HOME}/Library/Logs/refine-daily-ingest.log" 8 0
-write_calendar_plist "$weekly_plist" "com.lifcc.refine-weekly-insights" "${repo_root}/scripts/weekly-insights.sh" "${HOME}/Library/Logs/refine-insights.log" 9 0 1
+write_calendar_plist "$weekly_plist" "com.lifcc.refine-weekly-insights" "${repo_root}/scripts/weekly-insights.sh" "${HOME}/Library/Logs/refine-insights.log" 9 0 0
 if [[ "$ui_dev_enabled" == "1" ]]; then
   write_ui_plist "$ui_plist" "$(command -v bun)" "$path_env"
 fi

--- a/scripts/load-llm-env.sh
+++ b/scripts/load-llm-env.sh
@@ -1,57 +1,413 @@
 #!/usr/bin/env bash
 
-load_refine_llm_env() {
-  if [[ -n "${REFINE_ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}${ANTHROPIC_API_KEY:-}${REFINE_OPENAI_API_KEY:-}${OPENAI_API_KEY:-}${BASE_API_KEY:-}" ]]; then
-    return 0
-  fi
+# Shared, non-interactive LLM environment loader.
+#
+# This file intentionally does not source any shell startup file.  It parses a
+# small allowlist itself so a scheduled job cannot execute arbitrary shell code
+# from ~/.zshrc or from an env file.
 
-  if ! command -v zsh >/dev/null 2>&1; then
-    return 0
-  fi
+# Used by configure-llm-env.sh when it imports already-exported variables.
+# shellcheck disable=SC2034
+REFINE_LLM_ENV_SUPPORTED_KEYS=(
+  REFINE_ANTHROPIC_API_KEY
+  ANTHROPIC_AUTH_TOKEN
+  ANTHROPIC_API_KEY
+  REFINE_ANTHROPIC_MODEL
+  REFINE_ANTHROPIC_BASE_URL
+  ANTHROPIC_BASE_URL
+  REFINE_OPENAI_API_KEY
+  OPENAI_API_KEY
+  REFINE_OPENAI_MODEL
+  REFINE_OPENAI_BASE_URL
+  BASE_API_KEY
+  BASE_MODEL
+  BASE_URL
+)
 
-  local line key value
-  while IFS= read -r line; do
-    case "$line" in
-      BASE_API_KEY=* | BASE_MODEL=* | BASE_URL=*)
-        key="${line%%=*}"
-        value="${line#*=}"
-        if [[ -n "$value" ]]; then
-          export "${key}=${value}"
-        fi
-        ;;
-    esac
-  done < <(probe_refine_llm_env_from_zsh)
+refine_llm_env_error() {
+  printf 'ERROR: %s\n' "$*" >&2
 }
 
-probe_refine_llm_env_from_zsh() {
-  local timeout_secs tmp pid watchdog status
-  timeout_secs="${REFINE_LLM_ENV_LOAD_TIMEOUT_SECS:-10}"
-  tmp=$(mktemp "${TMPDIR:-/tmp}/refine-llm-env.XXXXXX") || return 0
-
-  zsh -fc '
-      [[ -r "$HOME/.zshrc" ]] && source "$HOME/.zshrc" >/dev/null 2>&1
-      for key in BASE_API_KEY BASE_MODEL BASE_URL; do
-        value="${(P)key}"
-        if [[ -n "$value" ]]; then
-          print -r -- "$key=$value"
-        fi
-      done
-    ' >"$tmp" 2>/dev/null &
-  pid=$!
-
-  (
-    sleep "$timeout_secs"
-    kill "$pid" 2>/dev/null || true
-  ) &
-  watchdog=$!
-
-  wait "$pid" 2>/dev/null
-  status=$?
-  kill "$watchdog" 2>/dev/null || true
-  wait "$watchdog" 2>/dev/null || true
-
-  if [[ "$status" -eq 0 || -s "$tmp" ]]; then
-    cat "$tmp"
+refine_llm_env_file_path() {
+  if [[ -n "${REFINE_LLM_ENV_FILE:-}" ]]; then
+    printf '%s\n' "$REFINE_LLM_ENV_FILE"
+  elif [[ -n "${HOME:-}" ]]; then
+    printf '%s/.refine/llm.env\n' "$HOME"
+  else
+    return 1
   fi
-  rm -f "$tmp"
+}
+
+refine_llm_env_is_supported_key() {
+  case "$1" in
+    REFINE_ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ANTHROPIC_API_KEY|\
+    REFINE_ANTHROPIC_MODEL|REFINE_ANTHROPIC_BASE_URL|ANTHROPIC_BASE_URL|\
+    REFINE_OPENAI_API_KEY|OPENAI_API_KEY|REFINE_OPENAI_MODEL|\
+    REFINE_OPENAI_BASE_URL|BASE_API_KEY|BASE_MODEL|BASE_URL)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+refine_llm_env_is_api_key() {
+  case "$1" in
+    REFINE_ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ANTHROPIC_API_KEY|\
+    REFINE_OPENAI_API_KEY|OPENAI_API_KEY|BASE_API_KEY)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+refine_llm_env_has_api_key() {
+  [[ -n "${REFINE_ANTHROPIC_API_KEY:-}" || \
+    -n "${ANTHROPIC_AUTH_TOKEN:-}" || \
+    -n "${ANTHROPIC_API_KEY:-}" || \
+    -n "${REFINE_OPENAI_API_KEY:-}" || \
+    -n "${OPENAI_API_KEY:-}" || \
+    -n "${BASE_API_KEY:-}" ]]
+}
+
+refine_llm_env_key_group_state() {
+  case "$1" in
+    anthropic)
+      if [[ -n "${REFINE_ANTHROPIC_API_KEY:-}" || \
+        -n "${ANTHROPIC_AUTH_TOKEN:-}" || \
+        -n "${ANTHROPIC_API_KEY:-}" ]]; then
+        printf '<set>'
+      else
+        printf '<unset>'
+      fi
+      ;;
+    openai)
+      if [[ -n "${REFINE_OPENAI_API_KEY:-}" || -n "${OPENAI_API_KEY:-}" ]]; then
+        printf '<set>'
+      else
+        printf '<unset>'
+      fi
+      ;;
+    base)
+      if [[ -n "${BASE_API_KEY:-}" ]]; then
+        printf '<set>'
+      else
+        printf '<unset>'
+      fi
+      ;;
+    *)
+      printf '<unset>'
+      ;;
+  esac
+}
+
+refine_llm_env_status() {
+  printf 'anthropic_key=%s openai_key=%s base_key=%s\n' \
+    "$(refine_llm_env_key_group_state anthropic)" \
+    "$(refine_llm_env_key_group_state openai)" \
+    "$(refine_llm_env_key_group_state base)"
+}
+
+# Parse one dotenv-like assignment without eval or command substitution.
+# Return 0 for a supported assignment, 1 for an ignored line, and 2 for a
+# malformed/unsupported line in strict mode. Parsed values are returned through
+# REFINE_LLM_ENV_PARSED_KEY and REFINE_LLM_ENV_PARSED_VALUE.
+refine_llm_env_parse_assignment() {
+  local line="$1"
+  local strict="${2:-1}"
+  local key value inner
+
+  REFINE_LLM_ENV_PARSED_KEY=''
+  REFINE_LLM_ENV_PARSED_VALUE=''
+  REFINE_LLM_ENV_PARSE_ERROR=''
+
+  line="${line%$'\r'}"
+  while [[ "$line" == [[:space:]]* ]]; do
+    line="${line#?}"
+  done
+  if [[ -z "$line" || "$line" == \#* ]]; then
+    return 1
+  fi
+
+  case "$line" in
+    export[[:space:]]*)
+      line="${line#export}"
+      while [[ "$line" == [[:space:]]* ]]; do
+        line="${line#?}"
+      done
+      ;;
+  esac
+
+  if [[ "$line" != *=* ]]; then
+    if [[ "$strict" == '1' ]]; then
+      REFINE_LLM_ENV_PARSE_ERROR='malformed assignment'
+      return 2
+    fi
+    return 1
+  fi
+
+  key="${line%%=*}"
+  while [[ "$key" == *[[:space:]] ]]; do
+    key="${key%?}"
+  done
+  if [[ -z "$key" || "$key" == *[[:space:]]* ]]; then
+    REFINE_LLM_ENV_PARSE_ERROR='malformed variable name'
+    return 2
+  fi
+
+  if ! refine_llm_env_is_supported_key "$key"; then
+    if [[ "$strict" == '1' ]]; then
+      REFINE_LLM_ENV_PARSE_ERROR='unsupported variable'
+      return 2
+    fi
+    return 1
+  fi
+
+  value="${line#*=}"
+  while [[ "$value" == [[:space:]]* ]]; do
+    value="${value#?}"
+  done
+
+  case "$value" in
+    \'*)
+      case "$value" in
+        *\')
+          inner="${value:1:${#value}-2}"
+          if [[ "$inner" == *\'* ]]; then
+            REFINE_LLM_ENV_PARSE_ERROR='unsupported quoted value'
+            return 2
+          fi
+          ;;
+        *)
+          REFINE_LLM_ENV_PARSE_ERROR='unterminated quoted value'
+          return 2
+          ;;
+      esac
+      ;;
+    \"*)
+      case "$value" in
+        *\")
+          inner="${value:1:${#value}-2}"
+          case "$inner" in
+            *\\*|*\$*|*\`*|*\"*)
+              REFINE_LLM_ENV_PARSE_ERROR='unsupported quoted value'
+              return 2
+              ;;
+          esac
+          ;;
+        *)
+          REFINE_LLM_ENV_PARSE_ERROR='unterminated quoted value'
+          return 2
+          ;;
+      esac
+      ;;
+    *[[:space:]]*)
+      REFINE_LLM_ENV_PARSE_ERROR='whitespace in unquoted value'
+      return 2
+      ;;
+    *\'*|*\"*)
+      REFINE_LLM_ENV_PARSE_ERROR='malformed quoted value'
+      return 2
+      ;;
+    *\$\(*|*\`*|*\;*|*\&*|*\|*|*\<*|*\>*|*\{*|*\}*)
+      REFINE_LLM_ENV_PARSE_ERROR='unsupported shell syntax'
+      return 2
+      ;;
+    *)
+      inner="$value"
+      ;;
+  esac
+
+  REFINE_LLM_ENV_PARSED_KEY="$key"
+  REFINE_LLM_ENV_PARSED_VALUE="$inner"
+  return 0
+}
+
+refine_llm_env_validate_content() {
+  local path="$1"
+  local strict="${2:-1}"
+  local line line_number=0 parse_rc key seen_keys=' '
+
+  REFINE_LLM_ENV_FILE_HAS_API_KEY=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    if refine_llm_env_parse_assignment "$line" "$strict"; then
+      parse_rc=0
+    else
+      parse_rc=$?
+    fi
+    if [[ "$parse_rc" -eq 1 ]]; then
+      continue
+    fi
+    if [[ "$parse_rc" -ne 0 ]]; then
+      refine_llm_env_error "${path}:${line_number}: ${REFINE_LLM_ENV_PARSE_ERROR}; only supported literal LLM variables are allowed"
+      return 1
+    fi
+
+    key="$REFINE_LLM_ENV_PARSED_KEY"
+    case "$seen_keys" in
+      *" $key "*)
+        refine_llm_env_error "${path}:${line_number}: duplicate definition for ${key}"
+        return 1
+        ;;
+    esac
+    seen_keys="${seen_keys}${key} "
+    if refine_llm_env_is_api_key "$key" && [[ -n "$REFINE_LLM_ENV_PARSED_VALUE" ]]; then
+      REFINE_LLM_ENV_FILE_HAS_API_KEY=1
+    fi
+  done < "$path"
+}
+
+refine_llm_env_stat_value() {
+  local format="$1"
+  local path="$2"
+  if [[ "$(uname -s)" == 'Darwin' ]]; then
+    stat -f "$format" "$path"
+  else
+    stat -c "$format" "$path"
+  fi
+}
+
+refine_llm_env_validate_secure_file() {
+  local path="$1"
+  local owner_uid current_uid mode
+
+  if [[ -L "$path" ]]; then
+    refine_llm_env_error "secure LLM env file is a symlink and was rejected: ${path}"
+    return 1
+  fi
+  if [[ ! -f "$path" ]]; then
+    refine_llm_env_error "secure LLM env file is not a regular file: ${path}"
+    return 1
+  fi
+
+  owner_uid="$(refine_llm_env_stat_value '%u' "$path" 2>/dev/null || true)"
+  current_uid="$(id -u)"
+  if [[ -z "$owner_uid" || "$owner_uid" != "$current_uid" ]]; then
+    refine_llm_env_error "secure LLM env file has the wrong owner (expected current user): ${path}"
+    return 1
+  fi
+
+  mode="$(refine_llm_env_stat_value '%Lp' "$path" 2>/dev/null || true)"
+  case "$mode" in
+    ''|*[!0-7]*)
+      refine_llm_env_error "cannot inspect secure LLM env file permissions: ${path}"
+      return 1
+      ;;
+  esac
+  if [[ "${mode: -2}" != '00' ]]; then
+    refine_llm_env_error "secure LLM env file must have no group/other permission bits (use chmod 600): ${path}"
+    return 1
+  fi
+
+  refine_llm_env_validate_content "$path" 1
+}
+
+refine_llm_env_load_file() {
+  local path="$1"
+  local strict="${2:-1}"
+  local skip_api_keys="${3:-0}"
+  local line parse_rc key value seen_keys=' '
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if refine_llm_env_parse_assignment "$line" "$strict"; then
+      parse_rc=0
+    else
+      parse_rc=$?
+    fi
+    if [[ "$parse_rc" -eq 1 ]]; then
+      continue
+    fi
+    if [[ "$parse_rc" -ne 0 ]]; then
+      refine_llm_env_error "${path}: ${REFINE_LLM_ENV_PARSE_ERROR}; only supported literal LLM variables are allowed"
+      return 1
+    fi
+
+    key="$REFINE_LLM_ENV_PARSED_KEY"
+    case "$seen_keys" in
+      *" $key "*)
+        refine_llm_env_error "${path}: duplicate definition for ${key}"
+        return 1
+        ;;
+    esac
+    seen_keys="${seen_keys}${key} "
+    if [[ "$skip_api_keys" == '1' ]] && refine_llm_env_is_api_key "$key"; then
+      continue
+    fi
+    value="$REFINE_LLM_ENV_PARSED_VALUE"
+    if [[ -z "${!key:-}" ]]; then
+      export "$key=$value"
+    fi
+  done < "$path"
+}
+
+load_refine_llm_env() {
+  local project_file="${1:-}"
+  local secure_file secure_has_key project_has_key
+  local secure_exists=0 project_exists=0
+
+  if refine_llm_env_has_api_key; then
+    REFINE_LLM_ENV_SOURCE='process'
+    export REFINE_LLM_ENV_SOURCE
+    return 0
+  fi
+
+  if ! secure_file="$(refine_llm_env_file_path)"; then
+    refine_llm_env_error 'HOME is not set; cannot determine the secure LLM env file'
+    return 1
+  fi
+
+  secure_has_key=0
+  project_has_key=0
+  REFINE_LLM_ENV_SOURCE='none'
+
+  if [[ -L "$secure_file" || -e "$secure_file" ]]; then
+    secure_exists=1
+    if ! refine_llm_env_validate_secure_file "$secure_file"; then
+      return 1
+    fi
+    secure_has_key="$REFINE_LLM_ENV_FILE_HAS_API_KEY"
+    if ! refine_llm_env_load_file "$secure_file" 1 0; then
+      return 1
+    fi
+  fi
+
+  if [[ -n "$project_file" && -f "$project_file" ]]; then
+    project_exists=1
+    if ! refine_llm_env_validate_content "$project_file" 0; then
+      return 1
+    fi
+    project_has_key="$REFINE_LLM_ENV_FILE_HAS_API_KEY"
+    if [[ "$secure_has_key" == '1' ]]; then
+      if ! refine_llm_env_load_file "$project_file" 0 1; then
+        return 1
+      fi
+    elif ! refine_llm_env_load_file "$project_file" 0 0; then
+      return 1
+    fi
+  fi
+
+  if [[ "$secure_has_key" == '1' ]]; then
+    REFINE_LLM_ENV_SOURCE='secure-file'
+  elif [[ "$project_has_key" == '1' ]]; then
+    REFINE_LLM_ENV_SOURCE='project-env'
+  fi
+  export REFINE_LLM_ENV_SOURCE
+
+  if ! refine_llm_env_has_api_key; then
+    local project_description='disabled'
+    if [[ "$project_exists" == '1' ]]; then
+      project_description="$project_file"
+    fi
+    if [[ "$secure_exists" == '1' ]]; then
+      refine_llm_env_error "no supported LLM API key loaded; secure file was checked at ${secure_file} and project fallback was ${project_description}; run scripts/configure-llm-env.sh --check"
+    else
+      refine_llm_env_error "no supported LLM API key loaded; secure file is absent at ${secure_file} and project fallback was ${project_description}; run scripts/configure-llm-env.sh --check"
+    fi
+    return 1
+  fi
+  return 0
 }

--- a/scripts/load-llm-env.sh
+++ b/scripts/load-llm-env.sh
@@ -352,8 +352,9 @@ refine_llm_env_load_file() {
   done < "$path"
 }
 
-load_refine_llm_env() {
+load_refine_llm_env_impl() {
   local project_file="${1:-}"
+  local require_key="${2:-1}"
   local secure_file secure_has_key project_has_key
   local secure_exists=0 project_exists=0
 
@@ -406,6 +407,9 @@ load_refine_llm_env() {
   export REFINE_LLM_ENV_SOURCE
 
   if ! refine_llm_env_has_api_key; then
+    if [[ "$require_key" != '1' ]]; then
+      return 0
+    fi
     local project_description='disabled'
     if [[ "$project_exists" == '1' ]]; then
       project_description="$project_file"
@@ -418,4 +422,12 @@ load_refine_llm_env() {
     return 1
   fi
   return 0
+}
+
+load_refine_llm_env() {
+  load_refine_llm_env_impl "${1:-}" 1
+}
+
+load_refine_llm_env_optional() {
+  load_refine_llm_env_impl "${1:-}" 0
 }

--- a/scripts/load-llm-env.sh
+++ b/scripts/load-llm-env.sh
@@ -355,31 +355,35 @@ refine_llm_env_load_file() {
 load_refine_llm_env_impl() {
   local project_file="${1:-}"
   local require_key="${2:-1}"
-  local secure_file secure_has_key project_has_key
+  local secure_file secure_has_key project_has_key process_has_key
   local secure_exists=0 project_exists=0
 
   if refine_llm_env_has_api_key; then
-    REFINE_LLM_ENV_SOURCE='process'
-    export REFINE_LLM_ENV_SOURCE
-    return 0
+    process_has_key=1
+  else
+    process_has_key=0
   fi
 
   if ! secure_file="$(refine_llm_env_file_path)"; then
-    refine_llm_env_error 'HOME is not set; cannot determine the secure LLM env file'
-    return 1
+    if [[ "$process_has_key" == '1' ]]; then
+      secure_file=''
+    else
+      refine_llm_env_error 'HOME is not set; cannot determine the secure LLM env file'
+      return 1
+    fi
   fi
 
   secure_has_key=0
   project_has_key=0
   REFINE_LLM_ENV_SOURCE='none'
 
-  if [[ -L "$secure_file" || -e "$secure_file" ]]; then
+  if [[ -n "$secure_file" && ( -L "$secure_file" || -e "$secure_file" ) ]]; then
     secure_exists=1
     if ! refine_llm_env_validate_secure_file "$secure_file"; then
       return 1
     fi
     secure_has_key="$REFINE_LLM_ENV_FILE_HAS_API_KEY"
-    if ! refine_llm_env_load_file "$secure_file" 1 0; then
+    if ! refine_llm_env_load_file "$secure_file" 1 "$process_has_key"; then
       return 1
     fi
   fi
@@ -390,7 +394,7 @@ load_refine_llm_env_impl() {
       return 1
     fi
     project_has_key="$REFINE_LLM_ENV_FILE_HAS_API_KEY"
-    if [[ "$secure_has_key" == '1' ]]; then
+    if [[ "$process_has_key" == '1' || "$secure_has_key" == '1' ]]; then
       if ! refine_llm_env_load_file "$project_file" 0 1; then
         return 1
       fi
@@ -399,7 +403,9 @@ load_refine_llm_env_impl() {
     fi
   fi
 
-  if [[ "$secure_has_key" == '1' ]]; then
+  if [[ "$process_has_key" == '1' ]]; then
+    REFINE_LLM_ENV_SOURCE='process'
+  elif [[ "$secure_has_key" == '1' ]]; then
     REFINE_LLM_ENV_SOURCE='secure-file'
   elif [[ "$project_has_key" == '1' ]]; then
     REFINE_LLM_ENV_SOURCE='project-env'

--- a/scripts/load-llm-env.sh
+++ b/scripts/load-llm-env.sh
@@ -261,13 +261,21 @@ refine_llm_env_validate_content() {
   done < "$path"
 }
 
-refine_llm_env_stat_value() {
-  local format="$1"
-  local path="$2"
+refine_llm_env_stat_owner_uid() {
+  local path="$1"
   if [[ "$(uname -s)" == 'Darwin' ]]; then
-    stat -f "$format" "$path"
+    stat -f '%u' "$path"
   else
-    stat -c "$format" "$path"
+    stat -c '%u' "$path"
+  fi
+}
+
+refine_llm_env_stat_mode() {
+  local path="$1"
+  if [[ "$(uname -s)" == 'Darwin' ]]; then
+    stat -f '%Lp' "$path"
+  else
+    stat -c '%a' "$path"
   fi
 }
 
@@ -284,14 +292,14 @@ refine_llm_env_validate_secure_file() {
     return 1
   fi
 
-  owner_uid="$(refine_llm_env_stat_value '%u' "$path" 2>/dev/null || true)"
+  owner_uid="$(refine_llm_env_stat_owner_uid "$path" 2>/dev/null || true)"
   current_uid="$(id -u)"
   if [[ -z "$owner_uid" || "$owner_uid" != "$current_uid" ]]; then
     refine_llm_env_error "secure LLM env file has the wrong owner (expected current user): ${path}"
     return 1
   fi
 
-  mode="$(refine_llm_env_stat_value '%Lp' "$path" 2>/dev/null || true)"
+  mode="$(refine_llm_env_stat_mode "$path" 2>/dev/null || true)"
   case "$mode" in
     ''|*[!0-7]*)
       refine_llm_env_error "cannot inspect secure LLM env file permissions: ${path}"

--- a/scripts/load-llm-env.sh
+++ b/scripts/load-llm-env.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+load_refine_llm_env() {
+  if [[ -n "${REFINE_ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}${ANTHROPIC_API_KEY:-}${REFINE_OPENAI_API_KEY:-}${OPENAI_API_KEY:-}${BASE_API_KEY:-}" ]]; then
+    return 0
+  fi
+
+  if ! command -v zsh >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local line key value
+  while IFS= read -r line; do
+    case "$line" in
+      BASE_API_KEY=* | BASE_MODEL=* | BASE_URL=*)
+        key="${line%%=*}"
+        value="${line#*=}"
+        if [[ -n "$value" ]]; then
+          export "${key}=${value}"
+        fi
+        ;;
+    esac
+  done < <(probe_refine_llm_env_from_zsh)
+}
+
+probe_refine_llm_env_from_zsh() {
+  local timeout_secs tmp pid watchdog status
+  timeout_secs="${REFINE_LLM_ENV_LOAD_TIMEOUT_SECS:-10}"
+  tmp=$(mktemp "${TMPDIR:-/tmp}/refine-llm-env.XXXXXX") || return 0
+
+  zsh -fc '
+      [[ -r "$HOME/.zshrc" ]] && source "$HOME/.zshrc" >/dev/null 2>&1
+      for key in BASE_API_KEY BASE_MODEL BASE_URL; do
+        value="${(P)key}"
+        if [[ -n "$value" ]]; then
+          print -r -- "$key=$value"
+        fi
+      done
+    ' >"$tmp" 2>/dev/null &
+  pid=$!
+
+  (
+    sleep "$timeout_secs"
+    kill "$pid" 2>/dev/null || true
+  ) &
+  watchdog=$!
+
+  wait "$pid" 2>/dev/null
+  status=$?
+  kill "$watchdog" 2>/dev/null || true
+  wait "$watchdog" 2>/dev/null || true
+
+  if [[ "$status" -eq 0 || -s "$tmp" ]]; then
+    cat "$tmp"
+  fi
+  rm -f "$tmp"
+}

--- a/scripts/run-refine-server.sh
+++ b/scripts/run-refine-server.sh
@@ -30,7 +30,11 @@ if [[ -n "${REFINE_API_TOKEN_FILE:-}" ]]; then
     printf '[refine-server] invalid token file: %s\n' "$token_file" >&2
     exit 1
   fi
-  token_mode=$(stat -f '%Lp' "$token_file" 2>/dev/null || stat -c '%a' "$token_file" 2>/dev/null || true)
+  if [[ "$(uname -s)" == 'Darwin' ]]; then
+    token_mode=$(stat -f '%Lp' "$token_file" 2>/dev/null || true)
+  else
+    token_mode=$(stat -c '%a' "$token_file" 2>/dev/null || true)
+  fi
   if [[ -z "$token_mode" || $((8#$token_mode & 077)) -ne 0 ]]; then
     printf '[refine-server] token file must have no group/other permission bits: %s\n' "$token_file" >&2
     exit 1

--- a/scripts/run-refine-server.sh
+++ b/scripts/run-refine-server.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SERVER_BIN="${1:-${HOME}/.cargo/bin/refine-server}"
+PROJECT_ENV="${2:-${SCRIPT_DIR}/../.env}"
+
+# Mark every process boundary in both append-only launchd logs so an error from
+# an earlier server cannot be mistaken for one from the current process.
+startup="[refine-server] $(date '+%Y-%m-%d %H:%M:%S') starting pid=$$"
+printf '%s\n' "$startup"
+printf '%s\n' "$startup" >&2
+
+# shellcheck source=scripts/load-llm-env.sh
+source "${SCRIPT_DIR}/load-llm-env.sh"
+if ! load_refine_llm_env_optional "$PROJECT_ENV"; then
+  printf '[refine-server] invalid LLM credential configuration; refusing to start\n' >&2
+  exit 1
+fi
+
+if refine_llm_env_has_api_key; then
+  printf '[refine-server] LLM source=%s\n' "${REFINE_LLM_ENV_SOURCE:-process}"
+else
+  printf '[refine-server] LLM credentials unavailable; extraction is disabled\n' >&2
+fi
+
+if [[ -n "${REFINE_API_TOKEN_FILE:-}" ]]; then
+  token_file="$REFINE_API_TOKEN_FILE"
+  if [[ -L "$token_file" || ! -f "$token_file" ]]; then
+    printf '[refine-server] invalid token file: %s\n' "$token_file" >&2
+    exit 1
+  fi
+  token_mode=$(stat -f '%Lp' "$token_file" 2>/dev/null || stat -c '%a' "$token_file" 2>/dev/null || true)
+  if [[ -z "$token_mode" || $((8#$token_mode & 077)) -ne 0 ]]; then
+    printf '[refine-server] token file must have no group/other permission bits: %s\n' "$token_file" >&2
+    exit 1
+  fi
+  IFS= read -r token < "$token_file" || true
+  if [[ -z "$token" ]]; then
+    printf '[refine-server] token file is empty: %s\n' "$token_file" >&2
+    exit 1
+  fi
+  export REFINE_API_TOKEN="$token"
+fi
+
+exec "$SERVER_BIN"

--- a/scripts/test-llm-env.sh
+++ b/scripts/test-llm-env.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+LOADER="${SCRIPT_DIR}/load-llm-env.sh"
+CONFIGURE="${SCRIPT_DIR}/configure-llm-env.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/refine-llm-env-test.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT HUP INT TERM
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local text="$1"
+  local needle="$2"
+  local label="$3"
+  case "$text" in
+    *"$needle"*)
+      ;;
+    *)
+      fail "$label"
+      ;;
+  esac
+}
+
+assert_not_contains() {
+  local text="$1"
+  local needle="$2"
+  local label="$3"
+  case "$text" in
+    *"$needle"*)
+      fail "$label"
+      ;;
+    *)
+      ;;
+  esac
+}
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  [[ "$expected" == "$actual" ]] || fail "$label"
+}
+
+new_home() {
+  local name="$1"
+  local path="${TEST_ROOT}/${name}"
+  mkdir -p "${path}/.refine"
+  chmod 700 "${path}/.refine"
+  printf '%s\n' "$path"
+}
+
+write_text() {
+  local path="$1"
+  local text="$2"
+  printf '%s\n' "$text" > "$path"
+}
+
+file_mode() {
+  local path="$1"
+  if [[ "$(uname -s)" == 'Darwin' ]]; then
+    stat -f '%Lp' "$path"
+  else
+    stat -c '%a' "$path"
+  fi
+}
+
+unset_supported_command='unset REFINE_ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY REFINE_ANTHROPIC_MODEL REFINE_ANTHROPIC_BASE_URL ANTHROPIC_BASE_URL REFINE_OPENAI_API_KEY OPENAI_API_KEY REFINE_OPENAI_MODEL REFINE_OPENAI_BASE_URL BASE_API_KEY BASE_MODEL BASE_URL'
+
+run_config() {
+  local home="$1"
+  shift
+  env HOME="$home" \
+    REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" \
+    CONFIGURE_SCRIPT="$CONFIGURE" \
+    bash -c "${unset_supported_command}; bash \"\$CONFIGURE_SCRIPT\" \"\$@\"" test-config "$@"
+}
+
+printf 'Testing shared LLM env loader and migration helper\n'
+
+# Process credentials remain authoritative over an insecure secure-file and a
+# conflicting project fallback, and no credential value is printed by probe.
+home="$(new_home process-priority)"
+write_text "${home}/.refine/llm.env" "export BASE_API_KEY='secure-secret'"
+chmod 644 "${home}/.refine/llm.env"
+write_text "${home}/project.env" "export BASE_API_KEY='project-secret'"
+process_output="$(env HOME="$home" \
+  REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" \
+  REFINE_LOADER="$LOADER" \
+  REFINE_PROJECT="${home}/project.env" \
+  bash -c "${unset_supported_command}; export BASE_API_KEY='process-secret'; source \"\$REFINE_LOADER\"; load_refine_llm_env \"\$REFINE_PROJECT\"; [[ \"\$BASE_API_KEY\" == 'process-secret' && \"\$REFINE_LLM_ENV_SOURCE\" == 'process' ]]; printf 'process-priority-ok\\n'" 2>&1)" || fail 'process-priority probe failed'
+assert_contains "$process_output" 'process-priority-ok' 'process priority result missing'
+assert_not_contains "$process_output" 'process-secret' 'process secret appeared in output'
+assert_not_contains "$process_output" 'secure-secret' 'secure secret appeared in output'
+assert_not_contains "$process_output" 'project-secret' 'project secret appeared in output'
+printf 'PASS process environment priority\n'
+
+# Every supported alias is loaded as a literal assignment. This exercises the
+# allowlist through the loader rather than only inspecting its implementation.
+home="$(new_home allowlist)"
+allowlist_file="${home}/.refine/llm.env"
+write_text "$allowlist_file" "export REFINE_ANTHROPIC_API_KEY='alias-1'
+export ANTHROPIC_AUTH_TOKEN='alias-2'
+export ANTHROPIC_API_KEY='alias-3'
+export REFINE_ANTHROPIC_MODEL='alias-4'
+export REFINE_ANTHROPIC_BASE_URL='alias-5'
+export ANTHROPIC_BASE_URL='alias-6'
+export REFINE_OPENAI_API_KEY='alias-7'
+export OPENAI_API_KEY='alias-8'
+export REFINE_OPENAI_MODEL='alias-9'
+export REFINE_OPENAI_BASE_URL='alias-10'
+export BASE_API_KEY='alias-11'
+export BASE_MODEL='alias-12'
+export BASE_URL='alias-13'"
+chmod 600 "$allowlist_file"
+# shellcheck disable=SC2016
+allowlist_output="$(env -i HOME="$home" PATH="$PATH" \
+  REFINE_LLM_ENV_FILE="$allowlist_file" REFINE_LOADER="$LOADER" \
+  bash -c '
+    source "$REFINE_LOADER"
+    load_refine_llm_env
+    [[ "$REFINE_ANTHROPIC_API_KEY" == alias-1 ]]
+    [[ "$ANTHROPIC_AUTH_TOKEN" == alias-2 ]]
+    [[ "$ANTHROPIC_API_KEY" == alias-3 ]]
+    [[ "$REFINE_ANTHROPIC_MODEL" == alias-4 ]]
+    [[ "$REFINE_ANTHROPIC_BASE_URL" == alias-5 ]]
+    [[ "$ANTHROPIC_BASE_URL" == alias-6 ]]
+    [[ "$REFINE_OPENAI_API_KEY" == alias-7 ]]
+    [[ "$OPENAI_API_KEY" == alias-8 ]]
+    [[ "$REFINE_OPENAI_MODEL" == alias-9 ]]
+    [[ "$REFINE_OPENAI_BASE_URL" == alias-10 ]]
+    [[ "$BASE_API_KEY" == alias-11 ]]
+    [[ "$BASE_MODEL" == alias-12 ]]
+    [[ "$BASE_URL" == alias-13 ]]
+    [[ "$REFINE_LLM_ENV_SOURCE" == secure-file ]]
+    printf "allowlist-ok\\n"
+  ' 2>&1)" || fail 'allowlist behavioral probe failed'
+assert_contains "$allowlist_output" 'allowlist-ok' 'allowlist result missing'
+assert_not_contains "$allowlist_output" 'alias-' 'allowlist values appeared in output'
+printf 'PASS exact supported alias allowlist\n'
+
+# A private regular file is accepted and selected in a clean process.
+home="$(new_home secure-success)"
+write_text "${home}/.refine/llm.env" "export BASE_API_KEY='secure-success-secret'"
+chmod 600 "${home}/.refine/llm.env"
+secure_output="$(env HOME="$home" \
+  REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" \
+  REFINE_LOADER="$LOADER" \
+  bash -c "${unset_supported_command}; source \"\$REFINE_LOADER\"; load_refine_llm_env; [[ \"\$BASE_API_KEY\" == 'secure-success-secret' && \"\$REFINE_LLM_ENV_SOURCE\" == 'secure-file' ]]; printf 'secure-file-ok\\n'" 2>&1)" || fail 'secure file probe failed'
+assert_contains "$secure_output" 'secure-file-ok' 'secure file result missing'
+assert_not_contains "$secure_output" 'secure-success-secret' 'secure file secret appeared in output'
+assert_equal '600' "$(file_mode "${home}/.refine/llm.env")" 'secure file mode is not 0600'
+printf 'PASS secure 0600 file\n'
+
+# Group/other permissions are rejected before parsing.
+home="$(new_home insecure-mode)"
+write_text "${home}/.refine/llm.env" "export BASE_API_KEY='insecure-mode-secret'"
+chmod 644 "${home}/.refine/llm.env"
+insecure_output=''
+if insecure_output="$(env HOME="$home" \
+  REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" \
+  REFINE_LOADER="$LOADER" \
+  bash -c "${unset_supported_command}; source \"\$REFINE_LOADER\"; load_refine_llm_env" 2>&1)"; then
+  fail '0644 secure file was accepted'
+fi
+assert_contains "$insecure_output" 'permission' '0644 rejection was not actionable'
+assert_not_contains "$insecure_output" 'insecure-mode-secret' 'insecure-file secret appeared in output'
+printf 'PASS insecure 0644 rejection\n'
+
+# Symlinks are rejected even when their target has an acceptable mode.
+home="$(new_home symlink-rejection)"
+write_text "${home}/target.env" "export BASE_API_KEY='symlink-secret'"
+chmod 600 "${home}/target.env"
+ln -s "${home}/target.env" "${home}/.refine/llm.env"
+symlink_output=''
+if symlink_output="$(env HOME="$home" \
+  REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" \
+  REFINE_LOADER="$LOADER" \
+  bash -c "${unset_supported_command}; source \"\$REFINE_LOADER\"; load_refine_llm_env" 2>&1)"; then
+  fail 'secure env symlink was accepted'
+fi
+assert_contains "$symlink_output" 'symlink' 'symlink rejection was not actionable'
+assert_not_contains "$symlink_output" 'symlink-secret' 'symlink secret appeared in output'
+printf 'PASS symlink rejection\n'
+
+# An explicit project fallback is parsed without source/eval and does not
+# override a higher-priority process value.
+home="$(new_home project-fallback)"
+write_text "${home}/project.env" "# development-only fallback
+export BASE_API_KEY='project-fallback-secret'
+REFINE_DB_PATH=/tmp/refine-test.db"
+project_output="$(env HOME="$home" \
+  REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" \
+  REFINE_LOADER="$LOADER" \
+  REFINE_PROJECT="${home}/project.env" \
+  bash -c "${unset_supported_command}; source \"\$REFINE_LOADER\"; load_refine_llm_env \"\$REFINE_PROJECT\"; [[ \"\$BASE_API_KEY\" == 'project-fallback-secret' && \"\$REFINE_LLM_ENV_SOURCE\" == 'project-env' ]]; printf 'project-fallback-ok\\n'" 2>&1)" || fail 'project fallback probe failed'
+assert_contains "$project_output" 'project-fallback-ok' 'project fallback result missing'
+assert_not_contains "$project_output" 'project-fallback-secret' 'project fallback secret appeared in output'
+printf 'PASS project .env fallback\n'
+
+# No supported key is a hard failure.
+home="$(new_home missing-key)"
+missing_output=''
+if missing_output="$(env HOME="$home" \
+  REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" \
+  REFINE_LOADER="$LOADER" \
+  bash -c "${unset_supported_command}; source \"\$REFINE_LOADER\"; load_refine_llm_env" 2>&1)"; then
+  fail 'missing-key loader probe unexpectedly succeeded'
+fi
+assert_contains "$missing_output" 'no supported LLM API key' 'missing-key error was not actionable'
+printf 'PASS missing-key failure\n'
+
+# Every duplicate mode and every pair of distinct modes must be rejected.
+home="$(new_home mode-rejection)"
+mode_pairs=(
+  '--check --migrate'
+  '--migrate --check'
+  '--check --from-env'
+  '--from-env --check'
+  '--migrate --from-env'
+  '--from-env --migrate'
+  '--check --check'
+  '--migrate --migrate'
+  '--from-env --from-env'
+)
+for mode_pair in "${mode_pairs[@]}"; do
+  read -r first_mode second_mode <<< "$mode_pair"
+  mode_output=''
+  if mode_output="$(run_config "$home" "$first_mode" "$second_mode" 2>&1)"; then
+    fail "multi-mode invocation unexpectedly succeeded: ${mode_pair}"
+  fi
+  assert_contains "$mode_output" 'choose exactly one configuration mode' "mode rejection was not actionable: ${mode_pair}"
+done
+printf 'PASS duplicate and multi-mode rejection\n'
+
+# Migrate the three literal BASE_* definitions, verify the private backup and
+# one source block, then prove a repeat invocation is a no-op.
+home="$(new_home migration)"
+write_text "${home}/.zshrc" $'# unrelated interactive setup
+# export BASE_URL=commented-url
+MIMO_BASE_URL=https://mimo.example.invalid
+export MIMO_BASE_URL=https://mimo.example.invalid
+export ANTHROPIC_BASE_URL=https://anthropic.example.invalid
+export SOME_BASE_MODEL_SUFFIX=not-a-migration-key
+printf "%s" "$BASE_URL"
+echo "$BASE_API_KEY" "$BASE_MODEL"
+export PATH=/usr/bin:/bin
+  export BASE_URL = https://example.invalid/compat
+export BASE_API_KEY = migration-secret
+	 export BASE_MODEL = compat-model'
+migration_expected="${home}/zshrc.expected"
+write_text "$migration_expected" $'# unrelated interactive setup
+# export BASE_URL=commented-url
+MIMO_BASE_URL=https://mimo.example.invalid
+export MIMO_BASE_URL=https://mimo.example.invalid
+export ANTHROPIC_BASE_URL=https://anthropic.example.invalid
+export SOME_BASE_MODEL_SUFFIX=not-a-migration-key
+printf "%s" "$BASE_URL"
+echo "$BASE_API_KEY" "$BASE_MODEL"
+export PATH=/usr/bin:/bin
+
+# >>> Refine LLM env (managed) >>>
+if [ -r "${REFINE_LLM_ENV_FILE:-$HOME/.refine/llm.env}" ]; then
+  . "${REFINE_LLM_ENV_FILE:-$HOME/.refine/llm.env}"
+fi
+# <<< Refine LLM env (managed) <<<'
+migration_before_check="${home}/zshrc.before-check"
+cp "${home}/.zshrc" "$migration_before_check"
+migration_check=''
+migration_check="$(run_config "$home" --check 2>&1)" || fail 'migration check rejected valid definitions'
+assert_contains "$migration_check" 'ready for --migrate' 'migration check did not report readiness'
+assert_not_contains "$migration_check" 'migration-secret' 'migration check leaked a secret'
+cmp -s "$migration_before_check" "${home}/.zshrc" || fail 'migration check changed zshrc'
+migration_output=''
+migration_output="$(run_config "$home" --migrate 2>&1)" || fail 'migration failed for valid definitions'
+assert_contains "$migration_output" 'backup=' 'migration did not report a backup path'
+assert_not_contains "$migration_output" 'migration-secret' 'migration output leaked a secret'
+assert_equal '600' "$(file_mode "${home}/.refine/llm.env")" 'migrated env file mode is not 0600'
+cmp -s "$migration_expected" "${home}/.zshrc" || fail 'migration changed unrelated zshrc content'
+if grep -q 'export BASE_API_KEY' "${home}/.zshrc"; then
+  fail 'migrated BASE_API_KEY definition remained in zshrc'
+fi
+assert_equal '1' "$(grep -c '# >>> Refine LLM env (managed) >>>' "${home}/.zshrc" || true)" 'source block count is not one'
+assert_equal '1' "$(find "${home}/.refine/backups" -type f -name '*.bak' -print | wc -l | tr -d ' ')" 'zshrc backup count is not one'
+migrated_copy="${home}/zshrc.after-first"
+cp "${home}/.zshrc" "$migrated_copy"
+repeat_output=''
+repeat_output="$(run_config "$home" --migrate 2>&1)" || fail 'repeat migration was not safe'
+assert_not_contains "$repeat_output" 'migration-secret' 'repeat migration leaked a secret'
+cmp -s "$migrated_copy" "${home}/.zshrc" || fail 'repeat migration changed zshrc'
+assert_equal '1' "$(grep -c '# >>> Refine LLM env (managed) >>>' "${home}/.zshrc" || true)" 'repeat migration duplicated source block'
+assert_equal '1' "$(find "${home}/.refine/backups" -type f -name '*.bak' -print | wc -l | tr -d ' ')" 'repeat migration created an unexpected backup'
+migration_load=''
+migration_load="$(env HOME="$home" REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" REFINE_LOADER="$LOADER" bash -c "${unset_supported_command}; source \"\$REFINE_LOADER\"; load_refine_llm_env; [[ \"\$BASE_API_KEY\" == 'migration-secret' ]]; printf 'migration-load-ok\\n'" 2>&1)" || fail 'migrated env file did not load'
+assert_contains "$migration_load" 'migration-load-ok' 'migrated env load result missing'
+assert_not_contains "$migration_load" 'migration-secret' 'migrated secret appeared in output'
+printf 'PASS migration idempotency, backup, and source block\n'
+
+# A valid secure file with no remaining literals still gets one managed source
+# block and a private backup when the block is missing; repeating it is a no-op.
+home="$(new_home source-block-repair)"
+write_text "${home}/.refine/llm.env" "export BASE_API_KEY='source-block-secret'"
+chmod 600 "${home}/.refine/llm.env"
+write_text "${home}/.zshrc" '# unrelated interactive setup
+export PATH=/usr/bin:/bin
+'
+secure_copy="${home}/secure-before"
+cp "${home}/.refine/llm.env" "$secure_copy"
+source_block_output=''
+source_block_output="$(run_config "$home" --migrate 2>&1)" || fail 'source block repair migration failed'
+assert_contains "$source_block_output" 'added one managed source block' 'source block was not added'
+assert_contains "$source_block_output" 'backup=' 'source block repair did not report a backup'
+assert_not_contains "$source_block_output" 'source-block-secret' 'source block repair leaked a secret'
+cmp -s "$secure_copy" "${home}/.refine/llm.env" || fail 'source block repair changed the secure file'
+assert_equal '1' "$(grep -c '# >>> Refine LLM env (managed) >>>' "${home}/.zshrc" || true)" 'source block repair count is not one'
+assert_equal '1' "$(find "${home}/.refine/backups" -type f -name '*.bak' -print | wc -l | tr -d ' ')" 'source block repair backup count is not one'
+repaired_copy="${home}/zshrc.after-repair"
+cp "${home}/.zshrc" "$repaired_copy"
+repeat_output=''
+repeat_output="$(run_config "$home" --migrate 2>&1)" || fail 'source block repeat was not safe'
+assert_not_contains "$repeat_output" 'source-block-secret' 'source block repeat leaked a secret'
+cmp -s "$repaired_copy" "${home}/.zshrc" || fail 'source block repeat changed zshrc'
+assert_equal '1' "$(grep -c '# >>> Refine LLM env (managed) >>>' "${home}/.zshrc" || true)" 'source block repeat duplicated the block'
+assert_equal '1' "$(find "${home}/.refine/backups" -type f -name '*.bak' -print | wc -l | tr -d ' ')" 'source block repeat created an unexpected backup'
+printf 'PASS secure-file source block repair and no-op\n'
+
+# Malformed and duplicate definitions fail closed before either destination is
+# replaced, and diagnostics remain redacted.
+home="$(new_home malformed-migration)"
+write_text "${home}/.zshrc" "export BASE_URL=https://example.invalid/compat
+export BASE_API_KEY=\$(printf malformed-secret)
+export BASE_MODEL=compat-model"
+malformed_output=''
+if malformed_output="$(run_config "$home" --migrate 2>&1)"; then
+  fail 'malformed migration unexpectedly succeeded'
+fi
+assert_contains "$malformed_output" 'malformed' 'malformed migration error was not actionable'
+assert_not_contains "$malformed_output" 'malformed-secret' 'malformed migration leaked a secret'
+[[ ! -e "${home}/.refine/llm.env" ]] || fail 'malformed migration wrote secure env file'
+grep -q 'malformed-secret' "${home}/.zshrc" || fail 'malformed zshrc definition was unexpectedly removed'
+
+home="$(new_home duplicate-migration)"
+write_text "${home}/.zshrc" 'export BASE_URL=https://example.invalid/compat
+export BASE_API_KEY=duplicate-secret
+export BASE_MODEL=compat-model
+export BASE_MODEL=second-model'
+duplicate_output=''
+if duplicate_output="$(run_config "$home" --migrate 2>&1)"; then
+  fail 'duplicate migration unexpectedly succeeded'
+fi
+assert_contains "$duplicate_output" 'duplicate' 'duplicate migration error was not actionable'
+assert_not_contains "$duplicate_output" 'duplicate-secret' 'duplicate migration leaked a secret'
+[[ ! -e "${home}/.refine/llm.env" ]] || fail 'duplicate migration wrote secure env file'
+grep -q 'duplicate-secret' "${home}/.zshrc" || fail 'duplicate zshrc definition was unexpectedly removed'
+printf 'PASS malformed and duplicate fail-closed behavior\n'
+
+# Already-exported variables can be configured without touching ~/.zshrc.
+home="$(new_home from-env)"
+from_env_output="$(env HOME="$home" \
+  REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" \
+  CONFIGURE_SCRIPT="$CONFIGURE" \
+  bash -c "${unset_supported_command}; export REFINE_OPENAI_API_KEY='from-env-secret' REFINE_OPENAI_MODEL='from-env-model'; bash \"\$CONFIGURE_SCRIPT\" --from-env" 2>&1)" || fail 'from-env configuration failed'
+assert_contains "$from_env_output" 'FROM-ENV' 'from-env result missing'
+assert_not_contains "$from_env_output" 'from-env-secret' 'from-env leaked a secret'
+from_env_load=''
+from_env_load="$(env HOME="$home" REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" REFINE_LOADER="$LOADER" bash -c "${unset_supported_command}; source \"\$REFINE_LOADER\"; load_refine_llm_env; [[ -n \"\${REFINE_OPENAI_API_KEY:-}\" ]]; printf 'from-env-load-ok\\n'" 2>&1)" || fail 'from-env file did not load'
+assert_contains "$from_env_load" 'from-env-load-ok' 'from-env load result missing'
+assert_not_contains "$from_env_load" 'from-env-secret' 'from-env loaded secret appeared in output'
+[[ ! -e "${home}/.zshrc" ]] || fail 'from-env unexpectedly created or modified zshrc'
+printf 'PASS configuring already-exported variables\n'
+
+printf 'All LLM env tests passed\n'

--- a/scripts/test-llm-env.sh
+++ b/scripts/test-llm-env.sh
@@ -98,6 +98,19 @@ assert_not_contains "$process_output" 'secure-secret' 'secure secret appeared in
 assert_not_contains "$process_output" 'project-secret' 'project secret appeared in output'
 printf 'PASS process environment priority\n'
 
+# Server startup may run without an LLM for query-only operation, while still
+# rejecting malformed credential files.
+home="$(new_home optional-empty)"
+optional_output="$(env -i HOME="$home" PATH="$PATH" REFINE_LOADER="$LOADER" bash -c 'source "$REFINE_LOADER"; load_refine_llm_env_optional; [[ "$REFINE_LLM_ENV_SOURCE" == none ]]; printf "optional-empty-ok\n"' 2>&1)" \
+  || fail 'optional loader rejected an absent credential file'
+assert_contains "$optional_output" 'optional-empty-ok' 'optional loader result missing'
+write_text "${home}/.refine/llm.env" 'export BASE_API_KEY=$(not-literal)'
+chmod 600 "${home}/.refine/llm.env"
+if env -i HOME="$home" PATH="$PATH" REFINE_LOADER="$LOADER" bash -c 'source "$REFINE_LOADER"; load_refine_llm_env_optional' >/dev/null 2>&1; then
+  fail 'optional loader accepted malformed credentials'
+fi
+printf 'PASS optional server credential loading\n'
+
 # Every supported alias is loaded as a literal assignment. This exercises the
 # allowlist through the loader rather than only inspecting its implementation.
 home="$(new_home allowlist)"

--- a/scripts/test-llm-env.sh
+++ b/scripts/test-llm-env.sh
@@ -81,22 +81,41 @@ run_config() {
 
 printf 'Testing shared LLM env loader and migration helper\n'
 
-# Process credentials remain authoritative over an insecure secure-file and a
-# conflicting project fallback, and no credential value is printed by probe.
+# Process credentials remain authoritative while unset companion settings are
+# loaded from lower-priority files, and no credential value is printed.
 home="$(new_home process-priority)"
-write_text "${home}/.refine/llm.env" "export BASE_API_KEY='secure-secret'"
-chmod 644 "${home}/.refine/llm.env"
-write_text "${home}/project.env" "export BASE_API_KEY='project-secret'"
+write_text "${home}/.refine/llm.env" "export BASE_API_KEY='secure-secret'
+export BASE_URL='https://secure.example.invalid'"
+chmod 600 "${home}/.refine/llm.env"
+write_text "${home}/project.env" "export BASE_API_KEY='project-secret'
+export BASE_MODEL='project-model'"
 process_output="$(env HOME="$home" \
   REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" \
   REFINE_LOADER="$LOADER" \
   REFINE_PROJECT="${home}/project.env" \
-  bash -c "${unset_supported_command}; export BASE_API_KEY='process-secret'; source \"\$REFINE_LOADER\"; load_refine_llm_env \"\$REFINE_PROJECT\"; [[ \"\$BASE_API_KEY\" == 'process-secret' && \"\$REFINE_LLM_ENV_SOURCE\" == 'process' ]]; printf 'process-priority-ok\\n'" 2>&1)" || fail 'process-priority probe failed'
+  bash -c "${unset_supported_command}; export BASE_API_KEY='process-secret'; source \"\$REFINE_LOADER\"; load_refine_llm_env \"\$REFINE_PROJECT\"; [[ \"\$BASE_API_KEY\" == 'process-secret' && \"\$BASE_URL\" == 'https://secure.example.invalid' && \"\$BASE_MODEL\" == 'project-model' && \"\$REFINE_LLM_ENV_SOURCE\" == 'process' ]]; printf 'process-priority-ok\\n'" 2>&1)" || fail 'process-priority probe failed'
 assert_contains "$process_output" 'process-priority-ok' 'process priority result missing'
 assert_not_contains "$process_output" 'process-secret' 'process secret appeared in output'
 assert_not_contains "$process_output" 'secure-secret' 'secure secret appeared in output'
 assert_not_contains "$process_output" 'project-secret' 'project secret appeared in output'
 printf 'PASS process environment priority\n'
+
+# Lower-priority files are validated before their companion settings are used.
+home="$(new_home process-insecure-lower)"
+write_text "${home}/.refine/llm.env" "export BASE_URL='https://insecure.example.invalid'"
+chmod 644 "${home}/.refine/llm.env"
+if env HOME="$home" REFINE_LLM_ENV_FILE="${home}/.refine/llm.env" REFINE_LOADER="$LOADER" \
+  bash -c "${unset_supported_command}; export BASE_API_KEY='process-secret'; source \"\$REFINE_LOADER\"; load_refine_llm_env" >/dev/null 2>&1; then
+  fail 'process key accepted companion settings from an insecure file'
+fi
+printf 'PASS process companion settings remain fail-closed\n'
+
+process_only_output="$(env -i PATH="$PATH" REFINE_LOADER="$LOADER" BASE_API_KEY='process-only-secret' \
+  bash -c 'source "$REFINE_LOADER"; load_refine_llm_env; [[ "$REFINE_LLM_ENV_SOURCE" == process ]]; printf "process-only-ok\n"' 2>&1)" \
+  || fail 'process-only credentials unexpectedly required HOME'
+assert_contains "$process_only_output" 'process-only-ok' 'process-only result missing'
+assert_not_contains "$process_only_output" 'process-only-secret' 'process-only secret appeared in output'
+printf 'PASS process-only credentials without HOME\n'
 
 # Server startup may run without an LLM for query-only operation, while still
 # rejecting malformed credential files.

--- a/scripts/test-runtime-wrappers.sh
+++ b/scripts/test-runtime-wrappers.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/refine-runtime-wrapper-test.XXXXXX")
+trap 'rm -rf "$TEST_ROOT"' EXIT HUP INT TERM
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+home="${TEST_ROOT}/home"
+mkdir -p "${home}/.refine"
+chmod 700 "${home}/.refine"
+printf '%s\n' "export BASE_API_KEY='wrapper-secret'" > "${home}/.refine/llm.env"
+chmod 600 "${home}/.refine/llm.env"
+printf '%s\n' 'token-secret' > "${home}/.refine/server.token"
+chmod 600 "${home}/.refine/server.token"
+
+fake_server="${TEST_ROOT}/fake-server.sh"
+cat > "$fake_server" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${BASE_API_KEY:-}" == 'wrapper-secret' ]]
+[[ "${REFINE_API_TOKEN:-}" == 'token-secret' ]]
+printf 'fake-server-ok\n'
+EOF
+chmod 700 "$fake_server"
+
+output=$(env -i HOME="$home" PATH="/usr/bin:/bin" \
+  REFINE_API_TOKEN_FILE="${home}/.refine/server.token" \
+  bash "${SCRIPT_DIR}/run-refine-server.sh" "$fake_server" "${TEST_ROOT}/missing.env" 2>&1) \
+  || fail 'server wrapper did not load secure LLM and token files'
+[[ "$output" == *'starting pid='* ]] || fail 'server wrapper did not log a startup boundary'
+[[ "$output" == *'LLM source=secure-file'* ]] || fail 'server wrapper did not report redacted LLM source'
+[[ "$output" == *'fake-server-ok'* ]] || fail 'server wrapper did not exec the server'
+[[ "$output" != *'wrapper-secret'* ]] || fail 'server wrapper leaked the LLM secret'
+[[ "$output" != *'token-secret'* ]] || fail 'server wrapper leaked the API token'
+
+chmod 644 "${home}/.refine/server.token"
+if env -i HOME="$home" PATH="/usr/bin:/bin" \
+  REFINE_API_TOKEN_FILE="${home}/.refine/server.token" \
+  bash "${SCRIPT_DIR}/run-refine-server.sh" "$fake_server" "${TEST_ROOT}/missing.env" >/dev/null 2>&1; then
+  fail 'server wrapper accepted an insecure token file'
+fi
+chmod 600 "${home}/.refine/server.token"
+
+empty_home="${TEST_ROOT}/empty-home"
+mkdir -p "${empty_home}/.refine"
+chmod 700 "${empty_home}/.refine"
+no_llm_server="${TEST_ROOT}/no-llm-server.sh"
+cat > "$no_llm_server" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${BASE_API_KEY:-}" ]]
+printf 'no-llm-server-ok\n'
+EOF
+chmod 700 "$no_llm_server"
+output=$(env -i HOME="$empty_home" PATH="/usr/bin:/bin" \
+  bash "${SCRIPT_DIR}/run-refine-server.sh" "$no_llm_server" "${TEST_ROOT}/missing.env" 2>&1) \
+  || fail 'server wrapper should allow query-only operation without LLM credentials'
+[[ "$output" == *'extraction is disabled'* ]] || fail 'server wrapper did not explain query-only mode'
+[[ "$output" == *'no-llm-server-ok'* ]] || fail 'server wrapper did not start query-only server'
+
+printf 'All runtime wrapper tests passed\n'

--- a/scripts/weekly-insights.sh
+++ b/scripts/weekly-insights.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-REFINE_BIN="${HOME}/.cargo/bin/refine"
+REFINE_BIN="${REFINE_BIN:-${HOME}/.cargo/bin/refine}"
 PROJECT_DIR="${SCRIPT_DIR}/.."
 ENV_FILE="${PROJECT_DIR}/.env"
 LOG_PREFIX="[refine-weekly]"
+FAILED_STEPS=()
 
 log() {
   echo "${LOG_PREFIX} $(date '+%Y-%m-%d %H:%M:%S') $*"
@@ -38,22 +39,37 @@ log "Preflight: keys REFINE_ANTHROPIC_API_KEY=$([[ -n "${REFINE_ANTHROPIC_API_KE
 
 # Step 1: 增量导入新会话
 log "Step 1: ingest-sessions"
-if "$REFINE_BIN" ingest-sessions 2>&1; then
+ingest_rc=0
+"$REFINE_BIN" ingest-sessions 2>&1 || ingest_rc=$?
+if [[ "$ingest_rc" -eq 0 ]]; then
   log "Step 1: ingest-sessions completed successfully"
 else
-  log "Step 1: ingest-sessions failed with exit code $?"
+  log "ERROR: Step 1 ingest-sessions failed with exit code ${ingest_rc}"
+  FAILED_STEPS+=("ingest-sessions")
 fi
 
 # Step 2: 生成处方报告
 log "Step 2: insights --prescription"
-if "$REFINE_BIN" insights --prescription 2>&1; then
+insights_rc=0
+"$REFINE_BIN" insights --prescription 2>&1 || insights_rc=$?
+if [[ "$insights_rc" -eq 0 ]]; then
   log "Step 2: insights --prescription completed successfully"
 else
-  log "Step 2: insights --prescription failed with exit code $?"
+  log "ERROR: Step 2 insights --prescription failed with exit code ${insights_rc}"
+  FAILED_STEPS+=("insights --prescription")
 fi
 
-# Step 3: 发送 macOS 通知
+# Step 3: 发送与真实状态一致的 macOS 通知
 log "Step 3: notification"
-osascript -e 'display notification "Weekly insights 报告已生成" with title "Refine Weekly Insights"' 2>&1 || true
+if [[ ${#FAILED_STEPS[@]} -eq 0 ]]; then
+  osascript -e 'display notification "Weekly insights 报告已生成" with title "Refine Weekly Insights"' 2>&1 || true
+else
+  osascript -e "display notification \"失败步骤: ${FAILED_STEPS[*]}，详见 refine-insights.log\" with title \"Refine Weekly Insights 失败\"" 2>&1 || true
+fi
 
 log "=== Weekly Insights Run End ==="
+
+if [[ ${#FAILED_STEPS[@]} -gt 0 ]]; then
+  log "ERROR: run finished with failures: ${FAILED_STEPS[*]}"
+  exit 1
+fi

--- a/scripts/weekly-insights.sh
+++ b/scripts/weekly-insights.sh
@@ -22,13 +22,19 @@ else
   log "WARNING: env file not found: ${ENV_FILE}"
 fi
 
+# launchd does not inherit interactive shell variables; fall back to BASE_* from zsh.
+# shellcheck source=scripts/load-llm-env.sh
+source "${SCRIPT_DIR}/load-llm-env.sh"
+load_refine_llm_env
+
 log "=== Weekly Insights Run Start ==="
 
 # Preflight: environment diagnostics for troubleshooting
 log "Preflight: PATH=$PATH"
 log "Preflight: refine=$(command -v "$REFINE_BIN" 2>/dev/null && echo "$REFINE_BIN" || echo 'NOT FOUND')"
 log "Preflight: cwd=$(pwd)"
-log "Preflight: env REFINE_DB_PATH=${REFINE_DB_PATH:-<unset>} REFINE_ANTHROPIC_MODEL=${REFINE_ANTHROPIC_MODEL:-<unset>}"
+log "Preflight: env REFINE_DB_PATH=${REFINE_DB_PATH:-<unset>} REFINE_ANTHROPIC_MODEL=${REFINE_ANTHROPIC_MODEL:-<unset>} REFINE_OPENAI_MODEL=${REFINE_OPENAI_MODEL:-<unset>} BASE_MODEL=${BASE_MODEL:-<unset>}"
+log "Preflight: keys REFINE_ANTHROPIC_API_KEY=$([[ -n "${REFINE_ANTHROPIC_API_KEY:-}" ]] && echo '<set>' || echo '<unset>') REFINE_OPENAI_API_KEY=$([[ -n "${REFINE_OPENAI_API_KEY:-}" ]] && echo '<set>' || echo '<unset>') BASE_API_KEY=$([[ -n "${BASE_API_KEY:-}" ]] && echo '<set>' || echo '<unset>')"
 
 # Step 1: 增量导入新会话
 log "Step 1: ingest-sessions"

--- a/scripts/weekly-insights.sh
+++ b/scripts/weekly-insights.sh
@@ -12,21 +12,14 @@ log() {
   echo "${LOG_PREFIX} $(date '+%Y-%m-%d %H:%M:%S') $*"
 }
 
-# 加载 .env 配置（不修改文件，仅 export 到当前进程）
-if [[ -f "$ENV_FILE" ]]; then
-  log "Loading env from ${ENV_FILE}"
-  set -a
-  # shellcheck source=/dev/null
-  source "$ENV_FILE"
-  set +a
-else
-  log "WARNING: env file not found: ${ENV_FILE}"
-fi
-
-# launchd does not inherit interactive shell variables; fall back to BASE_* from zsh.
+# The loader applies process -> secure user file -> explicit project fallback.
+# It never sources ~/.zshrc or evaluates either env file.
 # shellcheck source=scripts/load-llm-env.sh
 source "${SCRIPT_DIR}/load-llm-env.sh"
-load_refine_llm_env
+if ! load_refine_llm_env "$ENV_FILE"; then
+  log "ERROR: unattended LLM credentials are unavailable; refusing to start ingest"
+  exit 1
+fi
 
 log "=== Weekly Insights Run Start ==="
 
@@ -34,8 +27,7 @@ log "=== Weekly Insights Run Start ==="
 log "Preflight: PATH=$PATH"
 log "Preflight: refine=$(command -v "$REFINE_BIN" 2>/dev/null && echo "$REFINE_BIN" || echo 'NOT FOUND')"
 log "Preflight: cwd=$(pwd)"
-log "Preflight: env REFINE_DB_PATH=${REFINE_DB_PATH:-<unset>} REFINE_ANTHROPIC_MODEL=${REFINE_ANTHROPIC_MODEL:-<unset>} REFINE_OPENAI_MODEL=${REFINE_OPENAI_MODEL:-<unset>} BASE_MODEL=${BASE_MODEL:-<unset>}"
-log "Preflight: keys REFINE_ANTHROPIC_API_KEY=$([[ -n "${REFINE_ANTHROPIC_API_KEY:-}" ]] && echo '<set>' || echo '<unset>') REFINE_OPENAI_API_KEY=$([[ -n "${REFINE_OPENAI_API_KEY:-}" ]] && echo '<set>' || echo '<unset>') BASE_API_KEY=$([[ -n "${BASE_API_KEY:-}" ]] && echo '<set>' || echo '<unset>')"
+log "Preflight: LLM source=${REFINE_LLM_ENV_SOURCE:-none} $(refine_llm_env_status)"
 
 # Step 1: 增量导入新会话
 log "Step 1: ingest-sessions"


### PR DESCRIPTION
## Summary

- harden session ingestion retries, quarantine, checkpointing, and legacy-record migration
- make remem optional while preserving strict provider behavior and adding efficient summary prefiltering
- recover the local runtime by decoupling LaunchAgents from transient working directories and tightening Doctor checks
- add deterministic, non-interactive LLM credential loading with a secure migration path for launchd jobs

## Root cause

The local runtime mixed interactive-shell configuration with unattended launchd execution, tied some services to a mutable worktree path, and treated remem/session migration edge cases too broadly. This could leave scheduled ingestion without credentials, make recovery depend on the current checkout, fetch unnecessary full sessions, or risk ambiguous legacy cleanup.

## Impact

Scheduled jobs now load credentials from a validated user-owned file without sourcing shell startup code. The installer and Doctor verify the installed commit and runtime health, remem is an optional provider rather than a hard dependency, and session ingestion resumes safely across transient failures without destructive ambiguity.

## Validation

- `cargo test -p refine-core -p refine-cli -p mirror -p refine-server` — 327 passed, 0 failed
- `bash scripts/test-llm-env.sh`
- `bash -n` and `shellcheck` for the changed shell scripts
- live local install and `scripts/doctor-local.sh` — 0 failures, 0 warnings
- real launchd daily refresh — 42 sessions processed, 384 observations generated, 0 failures, exit code 0
