### PR TITLE
Refine Mirror scoring semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ and the relevant `~/.refine` log snippet if available.
   OpenAI-compatible or Anthropic-compatible API key.
 - Browser extension support is still a developer preview and should be tested
   against the local API before relying on it for unattended capture.
-- Mirror personal baselines need enough history; before four weeks of data,
-  signal lights use fixed thresholds instead of your own baseline.
+- Mirror personal trend arrows need enough history; before enough recent daily
+  scores exist, only fixed-threshold signal lights are shown.
 - No hosted multi-user service or migration SLA is claimed by this repository.
 
 ## Mirror — Cognitive Growth Tracker
@@ -91,17 +91,17 @@ mirror profile                      # Cognitive portrait narrative (requires LLM
 
 ### What Mirror Tracks
 
-**3 Layers × 11 Indicators:**
+**3 Layers × 8 Indicators:**
 
 | Layer | Indicators | What It Measures |
 |-------|-----------|-----------------|
-| **Depth** | Dreyfus level, Decision quality, Depth output, Knowledge rate | Are you thinking at a higher level? |
+| **Depth** | Dreyfus level, Decision quality | Are you thinking at a higher level? |
 | **Breadth** | Exploration rate, Deep invest, Fragmentation | Are you investing wisely across projects? |
-| **Collaboration** | Delegation rate, Mode diversity, Bug/decision ratio, Friction density | Is your AI collaboration healthy? |
+| **Collaboration** | Delegation rate, Mode diversity, Bug/decision ratio | Is your AI collaboration healthy? |
 
 **Signal Lights:** 🟢 Green (healthy) / 🟡 Yellow (watch) / 🔴 Red (act now)
 
-**Personal Baseline:** After 4 weeks, signals are relative to your own average, not fixed thresholds.
+**Personal Baseline:** After enough recent history, arrows show change versus your 4-week average. Signal colors still use fixed targets.
 
 ### Terminal Integration
 
@@ -159,8 +159,6 @@ that path explicitly to the loader rather than sourcing it automatically.
 [targets]
 delegation_green = 0.40      # delegation < 40% = green
 exploration_green = 0.15     # exploration > 15% = green
-knowledge_green = 0.5        # knowledge rate > 0.5/session = green
-friction_green = 1.0         # friction < 1.0/session = green
 ```
 
 ### Data Flow
@@ -236,7 +234,7 @@ refine/
 ├── apps/
 │   ├── cli/                # refine command (ingest, insights, search, growth)
 │   ├── mirror/             # mirror command (score, motd, dashboard, weekly, profile)
-│   │   └── src/score/      # Signal light engine (11 indicators, personal baseline)
+│   │   └── src/score/      # Signal light engine (8 indicators, personal trends)
 │   ├── server/             # API server (Axum)
 │   ├── desktop/            # Desktop app (Tauri)
 │   └── extension/          # Browser extension (Plasmo)

--- a/apps/mirror/src/advice.rs
+++ b/apps/mirror/src/advice.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 const ADVICE_CACHE_VERSION: &str = "advice-v2";
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
+const ADVICE_STALE_AFTER_HOURS: i64 = 72;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CachedAdvice {
@@ -23,6 +24,12 @@ pub struct CachedAdvice {
     pub cache_key: String,
     #[serde(default)]
     pub model_identity: String,
+}
+
+impl CachedAdvice {
+    pub fn is_stale(&self) -> bool {
+        (Utc::now() - self.generated_at).num_hours() >= ADVICE_STALE_AFTER_HOURS
+    }
 }
 
 pub fn load_cached() -> Result<Option<CachedAdvice>> {
@@ -61,12 +68,10 @@ fn load_cached_matching_key(
     if expected_key.is_some_and(|key| cached.cache_key != key) {
         return Ok(None);
     }
-    let age = Utc::now() - cached.generated_at;
-    if age.num_hours() < 72 {
-        Ok(Some(cached))
-    } else {
-        Ok(None)
+    if expected_key.is_some() && cached.is_stale() {
+        return Ok(None);
     }
+    Ok(Some(cached))
 }
 
 fn save_cached(advice: &str, short: &str, cache_key: &str, model_identity: &str) -> Result<()> {
@@ -251,13 +256,27 @@ mod tests {
     }
 
     #[test]
-    fn test_load_cached_returns_none_for_stale_cache() {
+    fn test_load_cached_returns_stale_cache_for_display_callers() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("advice.json");
         let cached = cached_advice("stale", Utc::now() - Duration::hours(80));
         std::fs::write(&path, serde_json::to_string(&cached).unwrap()).unwrap();
 
-        let loaded = load_cached_from_path(&path).unwrap();
+        let loaded = load_cached_from_path(&path)
+            .unwrap()
+            .expect("display callers need stale cache visibility");
+        assert!(loaded.is_stale());
+        assert_eq!(loaded.advice, "stale");
+    }
+
+    #[test]
+    fn test_load_cached_for_generation_ignores_stale_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("advice.json");
+        let cached = cached_advice("stale", Utc::now() - Duration::hours(80));
+        std::fs::write(&path, serde_json::to_string(&cached).unwrap()).unwrap();
+
+        let loaded = load_cached_for_key_from_path(&path, "cache-key").unwrap();
         assert!(loaded.is_none());
     }
 

--- a/apps/mirror/src/cli.rs
+++ b/apps/mirror/src/cli.rs
@@ -19,7 +19,7 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Compute 3-layer signal lights + 9 indicators + tension analysis
+    /// Compute 3-layer signal lights + 8 indicators + tension analysis
     Score {
         /// Filter observations since date (YYYY-MM-DD), default: last 90 days
         #[arg(long)]

--- a/apps/mirror/src/config.rs
+++ b/apps/mirror/src/config.rs
@@ -11,8 +11,6 @@ pub struct Targets {
     pub dreyfus_yellow: f64,
     pub decision_quality_green: f64,
     pub decision_quality_yellow: f64,
-    pub depth_output_green: f64,
-    pub depth_output_yellow: f64,
     // 层2 战略广度
     pub exploration_green: f64,
     pub exploration_yellow: f64,
@@ -22,9 +20,6 @@ pub struct Targets {
     pub deep_invest_yellow_hi: f64,
     pub fragmentation_green: f64,
     pub fragmentation_yellow: f64,
-    // 层1 知识获取率
-    pub knowledge_green: f64,
-    pub knowledge_yellow: f64,
     // 层3 协作效能
     pub delegation_green: f64,
     pub delegation_yellow: f64,
@@ -32,8 +27,6 @@ pub struct Targets {
     pub mode_diversity_yellow: usize,
     pub bug_decision_green: f64,
     pub bug_decision_yellow: f64,
-    pub friction_green: f64,
-    pub friction_yellow: f64,
 }
 
 impl Default for Targets {
@@ -43,10 +36,6 @@ impl Default for Targets {
             dreyfus_yellow: 2.5,
             decision_quality_green: 0.60,
             decision_quality_yellow: 0.40,
-            depth_output_green: 0.10,
-            depth_output_yellow: 0.0,
-            knowledge_green: 0.5,
-            knowledge_yellow: 0.2,
             exploration_green: 0.15,
             exploration_yellow: 0.08,
             deep_invest_green_lo: 0.15,
@@ -61,8 +50,6 @@ impl Default for Targets {
             mode_diversity_yellow: 2,
             bug_decision_green: 0.60,
             bug_decision_yellow: 0.80,
-            friction_green: 1.0,
-            friction_yellow: 2.0,
         }
     }
 }

--- a/apps/mirror/src/motd.rs
+++ b/apps/mirror/src/motd.rs
@@ -272,11 +272,11 @@ pub fn handle_motd() -> Result<()> {
         .map(|(d, _, _)| d)
         .unwrap_or_else(|| "general".to_string());
 
-    // Prefer LLM-generated advice if cached, fallback to static tips
+    let mut advice_stale = false;
     let tip = match crate::advice::load_cached() {
-        Ok(Some(cached)) => cached.advice,
-        Err(e) => {
-            tracing::warn!("failed to load cached advice: {}", e);
+        Ok(Some(cached)) if !cached.is_stale() => cached.advice,
+        Ok(Some(_)) => {
+            advice_stale = true;
             let tips = ensure_tips()?;
             select_tip(&tips, &dim)
         }
@@ -284,6 +284,16 @@ pub fn handle_motd() -> Result<()> {
             let tips = ensure_tips()?;
             select_tip(&tips, &dim)
         }
+        Err(e) => {
+            eprintln!("[mirror] error: failed to load cached advice: {}", e);
+            let tips = ensure_tips()?;
+            select_tip(&tips, &dim)
+        }
+    };
+    let advice_stale_suffix = if advice_stale {
+        t!(" ⚠️ advice stale", " ⚠️ 建议已过期")
+    } else {
+        ""
     };
 
     // Check data freshness: warn if latest score is older than 48 hours
@@ -304,7 +314,7 @@ pub fn handle_motd() -> Result<()> {
         .unwrap_or_default();
 
     println!(
-        "🪞 {d}{de}{dt} {b}{be}{bt} {c}{ce}{ct}{streak} | {tip}{stale}",
+        "🪞 {d}{de}{dt} {b}{be}{bt} {c}{ce}{ct}{streak} | {tip}{advice_stale}{stale}",
         d = t!("Depth", "深度"),
         de = depth_e,
         dt = depth_t,
@@ -316,6 +326,7 @@ pub fn handle_motd() -> Result<()> {
         ct = collab_t,
         streak = streak_suffix,
         tip = tip,
+        advice_stale = advice_stale_suffix,
         stale = stale_suffix,
     );
     if let Some(milestone) = crate::score::streak::milestone_message(streak) {

--- a/apps/mirror/src/profile.rs
+++ b/apps/mirror/src/profile.rs
@@ -319,7 +319,7 @@ pub async fn handle_profile(
 mod tests {
     use super::*;
     use refine_core::session::{ClusterResult, GlobalStats, ProjectCluster};
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     fn make_cluster() -> ClusterResult {
         let mut projects = HashMap::new();
@@ -337,6 +337,7 @@ mod tests {
             ProjectCluster {
                 project_name: "proj-a".to_string(),
                 session_count: 50,
+                doc_ids: HashSet::new(),
                 summary_excerpts: vec!["s1".into(); 40],
                 decision_titles: vec!["d1".into(); 5],
                 bugfix_titles: vec!["b1".into(); 5],
@@ -366,6 +367,7 @@ mod tests {
             ProjectCluster {
                 project_name: "proj-b".to_string(),
                 session_count: 20,
+                doc_ids: HashSet::new(),
                 summary_excerpts: vec!["s2".into(); 15],
                 decision_titles: vec!["d2".into(); 3],
                 bugfix_titles: vec!["b2".into(); 2],

--- a/apps/mirror/src/profile.rs
+++ b/apps/mirror/src/profile.rs
@@ -38,6 +38,14 @@ fn extract_profile_data(
 ) -> ProfileData {
     let total_sessions = cluster.global_stats.total_sessions;
     let total_projects = cluster.projects.len();
+    // A source document may legitimately contribute to more than one project.
+    // Use the same assignment-weighted denominator as breadth scoring so these
+    // project shares remain comparable and sum to 100%.
+    let project_session_assignments: usize = cluster
+        .projects
+        .values()
+        .map(|project| project.session_count)
+        .sum();
 
     let mut stats: Vec<ProjectStat> = cluster
         .projects
@@ -60,10 +68,10 @@ fn extract_profile_data(
                 deleg as f64 / collab_total as f64 * 100.0
             };
 
-            let pct = if total_sessions == 0 {
+            let pct = if project_session_assignments == 0 {
                 0.0
             } else {
-                p.session_count as f64 / total_sessions as f64 * 100.0
+                p.session_count as f64 / project_session_assignments as f64 * 100.0
             };
 
             ProjectStat {
@@ -433,6 +441,29 @@ mod tests {
         assert!((data.project_stats[0].delegation_pct - 60.0).abs() < f64::EPSILON);
 
         assert_eq!(data.project_stats[1].name, "proj-b");
+    }
+
+    #[test]
+    fn project_shares_use_project_assignment_denominator() {
+        let mut cluster = make_cluster();
+        cluster.global_stats.total_sessions = 2;
+        cluster.projects.get_mut("proj-a").unwrap().session_count = 1;
+        cluster.projects.get_mut("proj-b").unwrap().session_count = 2;
+
+        let data = extract_profile_data(&cluster, "G", &[]);
+        let proj_a = data
+            .project_stats
+            .iter()
+            .find(|project| project.name == "proj-a")
+            .unwrap();
+        let proj_b = data
+            .project_stats
+            .iter()
+            .find(|project| project.name == "proj-b")
+            .unwrap();
+
+        assert!((proj_a.pct - 100.0 / 3.0).abs() < 0.001);
+        assert!((proj_b.pct - 200.0 / 3.0).abs() < 0.001);
     }
 
     #[test]

--- a/apps/mirror/src/score.rs
+++ b/apps/mirror/src/score.rs
@@ -34,9 +34,7 @@ use baseline::{trend_from_personal, PersonalBaseline};
 use types::Trend;
 
 #[cfg(test)]
-use compute::{
-    analyze_tension, dreyfus_weighted, friction_density, knowledge_rate, layer1, layer3,
-};
+use compute::{analyze_tension, dreyfus_weighted, layer1, layer3};
 
 #[cfg(test)]
 use persistence::load_recent_scores_from_path;

--- a/apps/mirror/src/score/compute.rs
+++ b/apps/mirror/src/score/compute.rs
@@ -53,45 +53,9 @@ fn decision_quality_rate(cluster: &ClusterResult) -> f64 {
     with_reason as f64 / total as f64
 }
 
-fn depth_output_ratio(stats: &GlobalStats) -> f64 {
-    let deep_total = *stats.collaboration_modes.get("deep_inquiry").unwrap_or(&0);
-    let deleg_total = *stats.collaboration_modes.get("delegation").unwrap_or(&0);
-    if deep_total + deleg_total == 0 {
-        return 0.0;
-    }
-    let expert_count = *stats.cognitive_levels.get("expert").unwrap_or(&0);
-    let deep_expert_rate = if deep_total == 0 {
-        0.0
-    } else {
-        expert_count as f64 / deep_total as f64
-    };
-    let deleg_expert_rate = if deleg_total == 0 {
-        0.0
-    } else {
-        expert_count as f64 / deleg_total as f64
-    };
-    deep_expert_rate - deleg_expert_rate
-}
-
-pub(super) fn knowledge_rate(cluster: &ClusterResult) -> f64 {
-    let total_knowledge: usize = cluster
-        .projects
-        .values()
-        .map(|p| p.knowledge_gained.len())
-        .sum();
-    let total_sessions = cluster.global_stats.total_sessions;
-    if total_sessions == 0 {
-        0.0
-    } else {
-        total_knowledge as f64 / total_sessions as f64
-    }
-}
-
 pub(super) fn layer1(cluster: &ClusterResult, t: &Targets) -> LayerScore {
     let dw = dreyfus_weighted(&cluster.global_stats);
     let dq = decision_quality_rate(cluster);
-    let dor = depth_output_ratio(&cluster.global_stats);
-    let kr = knowledge_rate(cluster);
 
     let sig_dw = if dw > t.dreyfus_green {
         Signal::Green
@@ -103,20 +67,6 @@ pub(super) fn layer1(cluster: &ClusterResult, t: &Targets) -> LayerScore {
     let sig_dq = if dq > t.decision_quality_green {
         Signal::Green
     } else if dq >= t.decision_quality_yellow {
-        Signal::Yellow
-    } else {
-        Signal::Red
-    };
-    let sig_dor = if dor > t.depth_output_green {
-        Signal::Green
-    } else if dor >= t.depth_output_yellow {
-        Signal::Yellow
-    } else {
-        Signal::Red
-    };
-    let sig_kr = if kr >= t.knowledge_green {
-        Signal::Green
-    } else if kr >= t.knowledge_yellow {
         Signal::Yellow
     } else {
         Signal::Red
@@ -135,23 +85,11 @@ pub(super) fn layer1(cluster: &ClusterResult, t: &Targets) -> LayerScore {
             target: format!(">{}%", (t.decision_quality_green * 100.0) as u32),
             signal: sig_dq,
         },
-        Indicator {
-            name: "depth_output".into(),
-            actual: dor * 100.0,
-            target: format!(">{}%", (t.depth_output_green * 100.0) as u32),
-            signal: sig_dor,
-        },
-        Indicator {
-            name: "knowledge_rate".into(),
-            actual: kr,
-            target: format!(">{:.1}", t.knowledge_green),
-            signal: sig_kr,
-        },
     ];
 
     LayerScore {
         name: "depth".into(),
-        signal: worst(&[sig_dw, sig_dq, sig_dor, sig_kr]),
+        signal: worst(&[sig_dw, sig_dq]),
         indicators,
     }
 }
@@ -171,26 +109,26 @@ fn layer2(cluster: &ClusterResult, t: &Targets) -> LayerScore {
         exploration as f64 / collab_total as f64
     };
 
-    let total_projects = cluster.projects.len();
-    let deep_projects = cluster
+    let total_sessions: usize = cluster.projects.values().map(|p| p.session_count).sum();
+    let deep_sessions: usize = cluster
         .projects
         .values()
         .filter(|p| p.session_count >= 20)
-        .count();
-    let frag_projects = cluster
+        .map(|p| p.session_count)
+        .sum();
+    let frag_sessions: usize = cluster
         .projects
         .values()
         .filter(|p| p.session_count == 1)
-        .count();
-    let deep_rate = if total_projects == 0 {
-        0.0
+        .map(|p| p.session_count)
+        .sum();
+    let (deep_rate, frag_rate) = if total_sessions == 0 {
+        (0.0, 0.0)
     } else {
-        deep_projects as f64 / total_projects as f64
-    };
-    let frag_rate = if total_projects == 0 {
-        0.0
-    } else {
-        frag_projects as f64 / total_projects as f64
+        (
+            deep_sessions as f64 / total_sessions as f64,
+            frag_sessions as f64 / total_sessions as f64,
+        )
     };
 
     let sig_exp = if exploration_rate > t.exploration_green {
@@ -249,16 +187,6 @@ fn layer2(cluster: &ClusterResult, t: &Targets) -> LayerScore {
 
 // ── Layer 3: Collaboration ──
 
-pub(super) fn friction_density(cluster: &ClusterResult) -> f64 {
-    let total_frictions: usize = cluster.projects.values().map(|p| p.frictions.len()).sum();
-    let total_sessions = cluster.global_stats.total_sessions;
-    if total_sessions == 0 {
-        0.0
-    } else {
-        total_frictions as f64 / total_sessions as f64
-    }
-}
-
 pub(super) fn layer3(cluster: &ClusterResult, t: &Targets) -> LayerScore {
     let collab_total: usize = cluster.global_stats.collaboration_modes.values().sum();
     let delegation = *cluster
@@ -307,16 +235,6 @@ pub(super) fn layer3(cluster: &ClusterResult, t: &Targets) -> LayerScore {
         Signal::Red
     };
 
-    let fd = friction_density(cluster);
-    // friction_density: lower is better
-    let sig_fd = if fd < t.friction_green {
-        Signal::Green
-    } else if fd <= t.friction_yellow {
-        Signal::Yellow
-    } else {
-        Signal::Red
-    };
-
     let indicators = vec![
         Indicator {
             name: "delegation".into(),
@@ -336,17 +254,11 @@ pub(super) fn layer3(cluster: &ClusterResult, t: &Targets) -> LayerScore {
             target: format!("<{}", t.bug_decision_green),
             signal: sig_bug,
         },
-        Indicator {
-            name: "friction_density".into(),
-            actual: fd,
-            target: format!("<{:.1}", t.friction_green),
-            signal: sig_fd,
-        },
     ];
 
     LayerScore {
         name: "collaboration".into(),
-        signal: worst(&[sig_del, sig_div, sig_bug, sig_fd]),
+        signal: worst(&[sig_del, sig_div, sig_bug]),
         indicators,
     }
 }

--- a/apps/mirror/src/score/indicators.rs
+++ b/apps/mirror/src/score/indicators.rs
@@ -38,7 +38,7 @@ impl IndicatorSpec {
     }
 }
 
-const INDICATOR_SPECS: [IndicatorSpec; 11] = [
+const INDICATOR_SPECS: [IndicatorSpec; 8] = [
     IndicatorSpec {
         key: "dreyfus",
         format: IndicatorFormat::Fixed1,
@@ -54,22 +54,6 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
         aliases: &["Decision Quality", "决策质量"],
         display_en: "Decision Quality",
         display_zh: "决策质量",
-    },
-    IndicatorSpec {
-        key: "depth_output",
-        format: IndicatorFormat::Percent0,
-        direction: Direction::HigherBetter,
-        aliases: &["Depth Output", "深度产出比"],
-        display_en: "Depth Output",
-        display_zh: "深度产出比",
-    },
-    IndicatorSpec {
-        key: "knowledge_rate",
-        format: IndicatorFormat::Fixed1,
-        direction: Direction::HigherBetter,
-        aliases: &["Knowledge", "知识获取"],
-        display_en: "Knowledge",
-        display_zh: "知识获取",
     },
     IndicatorSpec {
         key: "exploration",
@@ -118,14 +102,6 @@ const INDICATOR_SPECS: [IndicatorSpec; 11] = [
         aliases: &["Bug/Decision", "bug/decision", "bug/决策"],
         display_en: "bug/decision",
         display_zh: "bug/决策",
-    },
-    IndicatorSpec {
-        key: "friction_density",
-        format: IndicatorFormat::Fixed1,
-        direction: Direction::LowerBetter,
-        aliases: &["Friction", "摩擦密度"],
-        display_en: "Friction",
-        display_zh: "摩擦密度",
     },
 ];
 

--- a/apps/mirror/src/score/statusline.rs
+++ b/apps/mirror/src/score/statusline.rs
@@ -58,6 +58,9 @@ pub fn write_statusline(
     trends: Option<&PersonalTrends>,
 ) -> Result<()> {
     let short = match crate::advice::load_cached() {
+        Ok(Some(cached)) if cached.is_stale() => {
+            crate::lang::t!("⚠️ advice stale", "⚠️ 建议已过期").to_string()
+        }
         Ok(cached) => cached
             .map(|c| c.short)
             .filter(|s: &String| !s.is_empty())

--- a/apps/mirror/src/score/tests/baseline.rs
+++ b/apps/mirror/src/score/tests/baseline.rs
@@ -34,15 +34,15 @@ fn test_personal_baseline_calculation() {
     let bl = baseline.unwrap();
     assert!((bl.average("dreyfus").unwrap() - 3.5).abs() < f64::EPSILON);
     assert!((bl.average("decision_quality").unwrap() - 60.0).abs() < f64::EPSILON);
-    assert!((bl.average("depth_output").unwrap() - 10.0).abs() < f64::EPSILON);
     assert!((bl.average("exploration").unwrap() - 20.0).abs() < f64::EPSILON);
     assert!((bl.average("deep_invest").unwrap() - 25.0).abs() < f64::EPSILON);
     assert!((bl.average("fragmentation").unwrap() - 15.0).abs() < f64::EPSILON);
     assert!((bl.average("delegation").unwrap() - 30.0).abs() < f64::EPSILON);
     assert!((bl.average("mode_diversity").unwrap() - 4.0).abs() < f64::EPSILON);
     assert!((bl.average("bug_decision").unwrap() - 0.20).abs() < f64::EPSILON);
-    assert!((bl.average("knowledge_rate").unwrap() - 0.5).abs() < f64::EPSILON);
-    assert!((bl.average("friction_density").unwrap() - 0.8).abs() < f64::EPSILON);
+    assert!(bl.average("depth_output").is_none());
+    assert!(bl.average("knowledge_rate").is_none());
+    assert!(bl.average("friction_density").is_none());
 }
 
 #[test]
@@ -254,15 +254,12 @@ fn test_personal_baseline_mixed_legacy_schema_repro() {
         bl.average("decision_quality").unwrap()
     );
     assert!(
-        (bl.average("knowledge_rate").unwrap() - 0.9).abs() < f64::EPSILON,
-        "missing legacy entries should not dilute knowledge_rate avg, got {}",
-        bl.average("knowledge_rate").unwrap()
+        (bl.average("bug_decision").unwrap() - 0.10).abs() < f64::EPSILON,
+        "legacy aliases should still populate bug_decision, got {}",
+        bl.average("bug_decision").unwrap()
     );
-    assert!(
-        (bl.average("friction_density").unwrap() - 0.7).abs() < f64::EPSILON,
-        "missing legacy entries should not dilute friction_density avg, got {}",
-        bl.average("friction_density").unwrap()
-    );
+    assert!(bl.average("knowledge_rate").is_none());
+    assert!(bl.average("friction_density").is_none());
 }
 
 #[test]

--- a/apps/mirror/src/score/tests/compute.rs
+++ b/apps/mirror/src/score/tests/compute.rs
@@ -1,164 +1,17 @@
 use super::*;
 use std::collections::HashMap;
 
-#[test]
-fn test_knowledge_rate_green() {
-    let t = crate::config::Targets::default();
-    // 10 sessions, 6 knowledge items -> rate = 0.6 >= 0.5 -> green
-    let cluster = make_cluster_with_data(
-        HashMap::new(),
-        HashMap::new(),
-        0,
-        0,
-        vec![
-            (
-                "proj-a",
-                5,
-                vec![],
-                vec![],
-                vec!["learned Rust", "learned SQL", "learned async"],
-            ),
-            (
-                "proj-b",
-                5,
-                vec![],
-                vec![],
-                vec!["learned Docker", "learned K8s", "learned Nix"],
-            ),
-        ],
-    );
-    let kr = knowledge_rate(&cluster);
-    assert!((kr - 0.6).abs() < f64::EPSILON);
-    let l1 = layer1(&cluster, &t);
-    let kr_ind = l1
+fn indicator<'a>(layer: &'a LayerScore, name: &str) -> &'a Indicator {
+    layer
         .indicators
         .iter()
-        .find(|i| i.name == "knowledge_rate")
-        .unwrap();
-    assert_eq!(kr_ind.signal, Signal::Green);
+        .find(|indicator| indicator.name == name)
+        .expect("indicator should exist")
 }
 
 #[test]
-fn test_knowledge_rate_red() {
-    let t = crate::config::Targets::default();
-    // 10 sessions, 1 knowledge item -> rate = 0.1 < 0.2 -> red
-    let cluster = make_cluster_with_data(
-        HashMap::new(),
-        HashMap::new(),
-        0,
-        0,
-        vec![
-            ("proj-a", 5, vec![], vec![], vec!["learned Rust"]),
-            ("proj-b", 5, vec![], vec![], vec![]),
-        ],
-    );
-    let kr = knowledge_rate(&cluster);
-    assert!((kr - 0.1).abs() < f64::EPSILON);
-    let l1 = layer1(&cluster, &t);
-    let kr_ind = l1
-        .indicators
-        .iter()
-        .find(|i| i.name == "knowledge_rate")
-        .unwrap();
-    assert_eq!(kr_ind.signal, Signal::Red);
-}
-
-#[test]
-fn test_friction_density_green() {
-    let t = crate::config::Targets::default();
-    // 10 sessions, 5 frictions -> density = 0.5 < 1.0 -> green
-    let cluster = make_cluster_with_data(
-        HashMap::new(),
-        {
-            let mut m = HashMap::new();
-            m.insert("delegation".into(), 5);
-            m.insert("exploration".into(), 5);
-            m.insert("pair_programming".into(), 5);
-            m.insert("review".into(), 5);
-            m
-        },
-        10,
-        2,
-        vec![
-            (
-                "proj-a",
-                5,
-                vec![],
-                vec!["slow build", "confusing API"],
-                vec![],
-            ),
-            (
-                "proj-b",
-                5,
-                vec![],
-                vec!["flaky test", "bad docs", "timeout"],
-                vec![],
-            ),
-        ],
-    );
-    let fd = friction_density(&cluster);
-    assert!((fd - 0.5).abs() < f64::EPSILON);
-    let l3 = layer3(&cluster, &t);
-    let fd_ind = l3
-        .indicators
-        .iter()
-        .find(|i| i.name == "friction_density")
-        .unwrap();
-    assert_eq!(fd_ind.signal, Signal::Green);
-}
-
-#[test]
-fn test_friction_density_red() {
-    let t = crate::config::Targets::default();
-    // 10 sessions, 25 frictions -> density = 2.5 > 2.0 -> red
-    let cluster = make_cluster_with_data(
-        HashMap::new(),
-        {
-            let mut m = HashMap::new();
-            m.insert("delegation".into(), 5);
-            m.insert("exploration".into(), 5);
-            m.insert("pair_programming".into(), 5);
-            m.insert("review".into(), 5);
-            m
-        },
-        10,
-        2,
-        vec![
-            (
-                "proj-a",
-                5,
-                vec![],
-                vec![
-                    "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
-                    "f13",
-                ],
-                vec![],
-            ),
-            (
-                "proj-b",
-                5,
-                vec![],
-                vec![
-                    "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
-                ],
-                vec![],
-            ),
-        ],
-    );
-    let fd = friction_density(&cluster);
-    assert!(fd > 2.0);
-    let l3 = layer3(&cluster, &t);
-    let fd_ind = l3
-        .indicators
-        .iter()
-        .find(|i| i.name == "friction_density")
-        .unwrap();
-    assert_eq!(fd_ind.signal, Signal::Red);
-}
-
-#[test]
-fn test_layer1_has_4_indicators() {
-    let t = crate::config::Targets::default();
+fn test_layer1_has_2_indicators() {
+    let targets = crate::config::Targets::default();
     let cluster = make_cluster(
         HashMap::new(),
         HashMap::new(),
@@ -166,14 +19,39 @@ fn test_layer1_has_4_indicators() {
         0,
         vec![("proj-a", 5, vec![])],
     );
-    let l1 = layer1(&cluster, &t);
-    assert_eq!(l1.indicators.len(), 4);
-    assert_eq!(l1.indicators[3].name, "knowledge_rate");
+    let layer = layer1(&cluster, &targets);
+    assert_eq!(layer.indicators.len(), 2);
+    assert_eq!(layer.indicators[0].name, "dreyfus");
+    assert_eq!(layer.indicators[1].name, "decision_quality");
 }
 
 #[test]
-fn test_layer3_has_4_indicators() {
-    let t = crate::config::Targets::default();
+fn test_layer2_uses_session_weighted_project_rates() {
+    let targets = crate::config::Targets::default();
+    let cluster = make_cluster(
+        HashMap::new(),
+        HashMap::new(),
+        0,
+        0,
+        vec![
+            ("solo-a", 1, vec![]),
+            ("solo-b", 1, vec![]),
+            ("deep-a", 20, vec![]),
+        ],
+    );
+
+    let score = compute(&cluster, &targets);
+    let breadth = &score.layers[1];
+    let deep_invest = indicator(breadth, "deep_invest");
+    let fragmentation = indicator(breadth, "fragmentation");
+
+    assert!((deep_invest.actual - (20.0 / 22.0 * 100.0)).abs() < 0.0001);
+    assert!((fragmentation.actual - (2.0 / 22.0 * 100.0)).abs() < 0.0001);
+}
+
+#[test]
+fn test_layer3_has_3_indicators() {
+    let targets = crate::config::Targets::default();
     let cluster = make_cluster(
         HashMap::new(),
         HashMap::new(),
@@ -181,7 +59,9 @@ fn test_layer3_has_4_indicators() {
         0,
         vec![("proj-a", 5, vec![])],
     );
-    let l3 = layer3(&cluster, &t);
-    assert_eq!(l3.indicators.len(), 4);
-    assert_eq!(l3.indicators[3].name, "friction_density");
+    let layer = layer3(&cluster, &targets);
+    assert_eq!(layer.indicators.len(), 3);
+    assert_eq!(layer.indicators[0].name, "delegation");
+    assert_eq!(layer.indicators[1].name, "mode_diversity");
+    assert_eq!(layer.indicators[2].name, "bug_decision");
 }

--- a/apps/mirror/src/score/tests/mod.rs
+++ b/apps/mirror/src/score/tests/mod.rs
@@ -33,6 +33,7 @@ pub(super) fn make_cluster(
             ProjectCluster {
                 project_name: name.to_string(),
                 session_count: *sessions,
+                doc_ids: std::collections::HashSet::new(),
                 summary_excerpts: Vec::new(),
                 decision_titles: dec_titles.iter().map(|s| s.to_string()).collect(),
                 bugfix_titles: Vec::new(),
@@ -81,6 +82,7 @@ pub(super) fn make_cluster_with_data(
             ProjectCluster {
                 project_name: name.to_string(),
                 session_count: *sessions,
+                doc_ids: std::collections::HashSet::new(),
                 summary_excerpts: Vec::new(),
                 decision_titles: dec_titles.iter().map(|s| s.to_string()).collect(),
                 bugfix_titles: Vec::new(),

--- a/apps/mirror/src/weekly.rs
+++ b/apps/mirror/src/weekly.rs
@@ -446,8 +446,8 @@ mod tests {
     use super::*;
     use crate::score::{Indicator, Signal};
     use refine_core::knowledge::{Item, ItemId, ItemType, RestoreParams, Tag};
-    use refine_core::session::GlobalStats;
-    use std::collections::HashMap;
+    use refine_core::session::{GlobalStats, ProjectCluster};
+    use std::collections::{HashMap, HashSet};
 
     fn make_weekly_record(seed: usize) -> WeeklyRecord {
         WeeklyRecord {
@@ -512,6 +512,46 @@ mod tests {
                 collaboration_modes: HashMap::new(),
                 tool_frequency: HashMap::new(),
                 project_ranking: Vec::new(),
+            },
+            untagged_count: 0,
+        }
+    }
+
+    fn cluster_with_project_evidence() -> ClusterResult {
+        let mut projects = HashMap::new();
+        projects.insert(
+            "codex-tool".to_string(),
+            ProjectCluster {
+                project_name: "codex-tool".to_string(),
+                session_count: 1,
+                doc_ids: HashSet::new(),
+                summary_excerpts: Vec::new(),
+                decision_titles: Vec::new(),
+                bugfix_titles: Vec::new(),
+                cognitive_levels: HashMap::new(),
+                collaboration_modes: HashMap::new(),
+                tools: Vec::new(),
+                frictions: Vec::new(),
+                architectures: Vec::new(),
+                knowledge_gained: Vec::new(),
+                patterns: Vec::new(),
+                progress_items: Vec::new(),
+                question_items: vec!["validate Codex session attribution".to_string()],
+                code_artifacts: Vec::new(),
+            },
+        );
+
+        ClusterResult {
+            projects,
+            global_stats: GlobalStats {
+                total_sessions: 1,
+                total_decisions: 0,
+                total_bugfixes: 0,
+                total_summaries: 1,
+                cognitive_levels: HashMap::new(),
+                collaboration_modes: HashMap::new(),
+                tool_frequency: HashMap::new(),
+                project_ranking: vec![("codex-tool".to_string(), 1)],
             },
             untagged_count: 0,
         }
@@ -611,6 +651,56 @@ mod tests {
             "indicator values must appear in report"
         );
         assert!(report.contains("tension") || report.contains("张力"));
+    }
+
+    #[test]
+    fn test_build_weekly_report_includes_action_card_from_same_cluster() {
+        let score = ScoreResult {
+            layers: [
+                LayerScore {
+                    name: "depth".into(),
+                    signal: Signal::Green,
+                    indicators: Vec::new(),
+                },
+                LayerScore {
+                    name: "breadth".into(),
+                    signal: Signal::Red,
+                    indicators: vec![
+                        Indicator {
+                            name: "exploration".into(),
+                            actual: 5.2,
+                            target: ">15%".into(),
+                            signal: Signal::Red,
+                        },
+                        Indicator {
+                            name: "deep_invest".into(),
+                            actual: 19.0,
+                            target: "15-30%".into(),
+                            signal: Signal::Yellow,
+                        },
+                        Indicator {
+                            name: "fragmentation".into(),
+                            actual: 26.0,
+                            target: "<20%".into(),
+                            signal: Signal::Red,
+                        },
+                    ],
+                },
+                LayerScore {
+                    name: "collaboration".into(),
+                    signal: Signal::Green,
+                    indicators: Vec::new(),
+                },
+            ],
+            tension: None,
+            timestamp: Utc::now(),
+        };
+
+        let report = build_weekly_report(&score, None, &cluster_with_project_evidence());
+
+        assert!(report.contains("Weekly Action Card"));
+        assert!(report.contains("codex-tool"));
+        assert!(report.contains("validate Codex session attribution"));
     }
 
     #[test]

--- a/apps/mirror/src/weekly/action_card.rs
+++ b/apps/mirror/src/weekly/action_card.rs
@@ -316,6 +316,7 @@ mod tests {
         ProjectCluster {
             project_name: name.to_string(),
             session_count,
+            doc_ids: std::collections::HashSet::new(),
             summary_excerpts: Vec::new(),
             decision_titles: Vec::new(),
             bugfix_titles: Vec::new(),

--- a/docs/SPEC-codex-session-ingestion-for-mirror-weekly.md
+++ b/docs/SPEC-codex-session-ingestion-for-mirror-weekly.md
@@ -1,0 +1,169 @@
+# SPEC: Mirror Scoring and Codex Weekly Semantics
+
+Date: 2026-08-12
+Status: Accepted for issue #145
+
+## Goal
+
+Re-evaluate the remaining Mirror scoring experiment from PR #141 commit
+`544bf8187256b85678d2a5d1fa726febf2b51278` on top of current `main`.
+The implementation must keep the ingestion, data-safety, and scheduler fixes
+that were already merged through PRs #142, #143, and #144.
+
+## Current Main Comparison
+
+The old PR mixed independent work streams. Current `main` already contains
+these parts, so this issue must not replay them:
+
+| Area from PR #141 | Current `main` state | Decision |
+| --- | --- | --- |
+| Codex transcript parser | Current `response_item.payload.type = "message"` schema, roles, text types, metadata, and timestamp extraction are already implemented in `packages/core/src/session/parser.rs`. | Do not edit parser transport. |
+| Codex project attribution | `apps/cli/src/ingest_sessions.rs` already falls back from discovery project to `session.meta.project` before `facets_to_items`. | Do not replay ingest changes. |
+| Event-time storage | Session documents have `captured_at`; session ingestion sets it from `SessionMeta.started_at` or file mtime. | Preserve. |
+| Weekly event-time window | `mirror weekly` already uses `find_observations_by_event_range`. | Preserve. |
+| Score/dashboard event-time window | `mirror score` and dashboard already use the same event-time query for default and `--since` windows. | Preserve. |
+| Scheduled workflow hardening | PR #143 made daily/weekly automation locked, serialized, and failure-visible. | Do not edit scheduler scripts. |
+| Cognitive portrait archive | PR #144 extracted generated reports and scheduling. | Do not add generated reports. |
+
+The remaining portable work is therefore limited to scoring semantics,
+statusline/advice visibility, weekly action cards, clustering input stability,
+and this specification.
+
+## Event-Time Window Semantics
+
+Mirror windows are based on when the session happened, not when it was
+ingested.
+
+| Command | Default window | Override | Time source |
+| --- | --- | --- | --- |
+| `mirror score` | Rolling 90 days | `--since YYYY-MM-DD`, `--all` | `Document.captured_at`, falling back to `Item.created_at` for unlinked legacy observations |
+| `mirror dashboard` | Rolling 90 days | `--since YYYY-MM-DD`, `--all` | Same event-time query |
+| `mirror weekly` | Rolling 7 days vs prior 7 days | None | Same event-time query |
+
+This avoids a historical Codex or Claude backfill appearing as current-week
+work merely because the observations were inserted today.
+
+## Scoring Semantics
+
+Signals and trends are separate:
+
+- `Signal` color answers: does the current score meet the fixed target?
+- `Trend` arrow answers: is the current score better than the user's recent
+  4-week average?
+- Personal trends never rewrite indicator or layer signals.
+- Band metrics, currently `deep_invest`, do not get personal trend arrows
+  because "higher than average" is not necessarily better.
+
+Mirror now scores three layers with eight live indicators:
+
+| Layer | Indicator | Direction | Target source |
+| --- | --- | --- | --- |
+| Depth | `dreyfus` | Higher is better | Weighted cognitive level average |
+| Depth | `decision_quality` | Higher is better | Decision titles with explicit reason keywords |
+| Breadth | `exploration` | Higher is better | Exploration observations over all collaboration-mode observations |
+| Breadth | `deep_invest` | Band | Session-weighted share of projects with at least 20 sessions |
+| Breadth | `fragmentation` | Lower is better | Session-weighted share of single-session projects |
+| Collaboration | `delegation` | Lower is better | Delegation observations over all collaboration-mode observations |
+| Collaboration | `mode_diversity` | Higher is better | Count of observed collaboration modes |
+| Collaboration | `bug_decision` | Lower is better | Bugfix count over decision count |
+
+The experiment drops three noisy live indicators:
+
+- `depth_output`, because it mixed deep-inquiry observations with expert-level
+  observations and did not reliably describe output quality.
+- `knowledge_rate`, because extracted knowledge-item volume was sensitive to
+  extraction style and could contradict its target text.
+- `friction_density`, because friction item granularity was not stable enough
+  to be a color-bearing collaboration metric.
+
+Historical `scores.jsonl` entries that contain those old indicators remain
+deserializable. The baseline registry simply stops computing personal averages
+for removed live indicators.
+
+## Breadth Weighting
+
+`deep_invest` and `fragmentation` are session-weighted, not bucket-weighted.
+A one-session side project should not have the same weight as a deeply worked
+project. For example:
+
+```text
+solo-a: 1 session
+solo-b: 1 session
+deep-a: 20 sessions
+```
+
+The resulting rates are:
+
+- `deep_invest = 20 / 22 = 90.9%`
+- `fragmentation = 2 / 22 = 9.1%`
+
+The old bucket-weighted interpretation would have produced `33.3%` and
+`66.7%`, overstating fragmentation.
+
+## Statusline and Advice Cache
+
+`~/.mirror/statusline.txt` is written by `mirror score` so shell prompts can
+read one short line cheaply.
+
+Format:
+
+```text
+mirror-marker + depth/breadth/collab lights + optional trend arrow + optional streak + advice
+```
+
+The three lights are absolute target signals. The optional arrow is the
+overall personal trend. Advice cache handling is deliberately visible:
+
+- Generation only reuses a fresh cache entry for the exact score/model key.
+- Display callers can still load stale cache entries so they can show
+  `advice stale` instead of silently showing nothing.
+- MOTD falls back to static tips when cached advice is stale, and marks that
+  fallback.
+
+## Weekly Action Card
+
+`mirror weekly` builds one cluster for this week, computes this week's score
+from that cluster, and passes the same cluster into the action-card builder.
+
+Action cards only trigger from non-green breadth indicators:
+
+- `exploration`
+- `deep_invest`
+- `fragmentation`
+
+Project choice must be deterministic and evidence-backed:
+
+- exploration or fragmentation risk selects the least-worked real project;
+- deep-invest risk selects the main current project;
+- evidence comes from questions, progress, patterns, knowledge, architecture,
+  summary excerpts, decisions, or bugfixes in the same weekly cluster.
+
+## Clustering Stability
+
+Project clustering must not let ingestion artifacts distort breadth metrics:
+
+- `tool` and `tools` path segments are both generic and are removed during
+  project normalization.
+- `agent_<hex>` session identifiers are not project names.
+- `session_count` is deduplicated per project, while `global_stats.total_sessions`
+  remains globally deduplicated.
+
+The per-project dedupe matters when observations from one source document
+carry different project tags. Each affected project should count that source
+document once; the old global-only set made the result depend on observation
+iteration order.
+
+## Validation Scope
+
+Focused validation for this issue:
+
+```bash
+cargo fmt --all --check
+cargo test -p mirror
+cargo test -p refine-core session::clustering
+git diff --check
+```
+
+Broader workspace tests are useful before release, but this issue intentionally
+does not change parser transport, LLM ingest, SQLite migrations, or scheduler
+scripts.

--- a/docs/SPEC-codex-session-ingestion-for-mirror-weekly.md
+++ b/docs/SPEC-codex-session-ingestion-for-mirror-weekly.md
@@ -147,6 +147,9 @@ Project clustering must not let ingestion artifacts distort breadth metrics:
 - `agent_<hex>` session identifiers are not project names.
 - `session_count` is deduplicated per project, while `global_stats.total_sessions`
   remains globally deduplicated.
+- Profile project shares use the sum of per-project session assignments as
+  their denominator, matching breadth scoring when one session belongs to
+  multiple projects.
 
 The per-project dedupe matters when observations from one source document
 carry different project tags. Each affected project should count that source

--- a/packages/core/src/session/clustering.rs
+++ b/packages/core/src/session/clustering.rs
@@ -29,6 +29,7 @@ const GENERIC_PATH_SEGMENTS: &[&str] = &[
     "code",
     "ai",
     "tools",
+    "tool",
     "agent",
     "work",
     "life",
@@ -41,6 +42,7 @@ const GENERIC_PATH_SEGMENTS: &[&str] = &[
 pub struct ProjectCluster {
     pub project_name: String,
     pub session_count: usize,
+    pub doc_ids: HashSet<String>,
     pub summary_excerpts: Vec<String>,
     pub decision_titles: Vec<String>,
     pub bugfix_titles: Vec<String>,
@@ -131,6 +133,7 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
             .or_insert_with(|| ProjectCluster {
                 project_name: project_name.clone(),
                 session_count: 0,
+                doc_ids: HashSet::new(),
                 summary_excerpts: Vec::new(),
                 decision_titles: Vec::new(),
                 bugfix_titles: Vec::new(),
@@ -146,10 +149,12 @@ pub fn cluster_observations(items: &[Item]) -> ClusterResult {
                 code_artifacts: Vec::new(),
             });
 
-        // 跟踪 session 数
+        // Count sessions per project, while still keeping a global unique
+        // session count for the overall denominator.
         if let Some(doc_id) = item.document_id() {
             let id_str = doc_id.as_str().to_string();
-            if all_doc_ids.insert(id_str.clone()) {
+            all_doc_ids.insert(id_str.clone());
+            if cluster.doc_ids.insert(id_str) {
                 cluster.session_count += 1;
             }
         }
@@ -250,10 +255,16 @@ fn extract_project_from_tags(tags: &[&str]) -> Option<String> {
         .max_by_key(|s| s.len())
 }
 
+fn is_session_id(segment: &str) -> bool {
+    segment
+        .strip_prefix("agent_")
+        .is_some_and(|rest| rest.len() >= 16 && rest.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
 pub fn normalize_project_name(raw: &str) -> Option<String> {
     let segments: Vec<&str> = raw
         .split('-')
-        .filter(|s| !s.is_empty() && !GENERIC_PATH_SEGMENTS.contains(s))
+        .filter(|s| !s.is_empty() && !GENERIC_PATH_SEGMENTS.contains(s) && !is_session_id(s))
         .collect();
     match segments.len() {
         0 => None,
@@ -321,6 +332,26 @@ fn is_collab_mode(tag: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::knowledge::{DocumentId, ItemId, RestoreParams, Tag};
+    use chrono::Utc;
+
+    fn observation(id: &str, doc_id: &str, tags: &[&str]) -> Item {
+        let now = Utc::now();
+        Item::restore(RestoreParams {
+            id: ItemId::from(id),
+            item_type: ItemType::Observation,
+            title: id.to_string(),
+            summary: String::new(),
+            content: "进展:\n- shipped one step\n\n问题:\n- what next?".to_string(),
+            tags: tags.iter().map(|tag| Tag::new(tag).unwrap()).collect(),
+            source: None,
+            document_id: Some(DocumentId::from(doc_id)),
+            excerpt: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .unwrap()
+    }
 
     #[test]
     fn normalize_project_name_extracts_meaningful_segments() {
@@ -345,6 +376,28 @@ mod tests {
         assert_eq!(
             normalize_project_name("-users-lifcc-desktop-code-work-life"),
             None
+        );
+        assert_eq!(
+            normalize_project_name("-users-lifcc-desktop-code-ai-tool-argus"),
+            Some("argus".into())
+        );
+        assert_eq!(
+            normalize_project_name("-users-lifcc-desktop-code-ai-tool-argus"),
+            normalize_project_name("-users-lifcc-desktop-code-ai-tools-argus")
+        );
+        assert_eq!(
+            normalize_project_name("agent_019ec96be5fe7f53a6cca93bb6201c26"),
+            None
+        );
+        assert_eq!(
+            normalize_project_name(
+                "-users-lifcc-desktop-code-ai-tools-refine-agent_019ec96be5fe7f53a6cca93bb6201c26"
+            ),
+            Some("refine".into())
+        );
+        assert_eq!(
+            normalize_project_name("agent_harness"),
+            Some("agent_harness".into())
         );
     }
 
@@ -380,5 +433,18 @@ mod tests {
         assert_eq!(progress, vec!["step1", "step2"]);
         assert_eq!(questions, vec!["如何优化？"]);
         assert_eq!(artifacts, vec!["main.rs"]);
+    }
+
+    #[test]
+    fn cluster_observations_counts_sessions_per_project() {
+        let cluster = cluster_observations(&[
+            observation("a1", "doc-1", &["project-a"]),
+            observation("b1", "doc-1", &["project-b"]),
+            observation("b2", "doc-2", &["project-b"]),
+        ]);
+
+        assert_eq!(cluster.global_stats.total_sessions, 2);
+        assert_eq!(cluster.projects["project-a"].session_count, 1);
+        assert_eq!(cluster.projects["project-b"].session_count, 2);
     }
 }

--- a/packages/core/src/session/clustering.rs
+++ b/packages/core/src/session/clustering.rs
@@ -262,9 +262,14 @@ fn is_session_id(segment: &str) -> bool {
 }
 
 pub fn normalize_project_name(raw: &str) -> Option<String> {
-    let segments: Vec<&str> = raw
-        .split('-')
-        .filter(|s| !s.is_empty() && !GENERIC_PATH_SEGMENTS.contains(s) && !is_session_id(s))
+    let segments: Vec<&str> = raw.split('-').filter(|s| !s.is_empty()).collect();
+    let first_project_segment = segments
+        .iter()
+        .position(|segment| !GENERIC_PATH_SEGMENTS.contains(segment))?;
+    let segments: Vec<&str> = segments[first_project_segment..]
+        .iter()
+        .copied()
+        .filter(|segment| !is_session_id(segment))
         .collect();
     match segments.len() {
         0 => None,
@@ -385,6 +390,11 @@ mod tests {
             normalize_project_name("-users-lifcc-desktop-code-ai-tool-argus"),
             normalize_project_name("-users-lifcc-desktop-code-ai-tools-argus")
         );
+        assert_eq!(
+            normalize_project_name("-users-lifcc-desktop-code-ai-tools-codex-tool"),
+            Some("codex-tool".into())
+        );
+        assert_eq!(normalize_project_name("my-tool"), Some("my-tool".into()));
         assert_eq!(
             normalize_project_name("agent_019ec96be5fe7f53a6cca93bb6201c26"),
             None


### PR DESCRIPTION
## Summary

- port the remaining Mirror scoring experiment from PR #141 onto current main: 8 live indicators, session-weighted breadth scoring, and absolute-signal plus personal-trend separation
- preserve the superseding ingest/runtime work from #142-#144 by leaving parser transport, captured-at ingestion, SQLite migrations, and scheduler scripts untouched
- make stale advice visible in statusline/MOTD, stabilize project clustering session counts, and add focused score/statusline/weekly/clustering tests
- document the current-main comparison, scoring semantics, and event-time window contract in `docs/SPEC-codex-session-ingestion-for-mirror-weekly.md`

## Scope guard

- Base: `origin/main`
- Files changed: 17 / 30
- Lines added: 448 / 1500

## Validation

- `cargo fmt --all --check`
- `cargo test -p mirror`
- `cargo test -p refine-core session::clustering`
- `git diff --check`
- `git diff --cached --check`

Closes #145
