### PR TITLE
Make legacy database imports atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,6 +3036,7 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "filetime",
+ "fs2",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # Database
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 
 # Logging
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ reqwest = { version = "0.12", features = ["json"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
+fs2 = "0.4"
 
 # Internal
 refine-core = { path = "packages/core" }

--- a/apps/server/src/state.rs
+++ b/apps/server/src/state.rs
@@ -426,8 +426,20 @@ mod tests {
 
         assert_eq!(conversation_count, 1);
         assert_eq!(event_count, 1);
-        assert!(legacy_path.with_extension("db.migrated").exists());
-        assert!(!legacy_path.exists());
+        assert!(
+            legacy_path.exists(),
+            "live legacy DB remains discoverable for later reconciliation"
+        );
+        assert!(legacy_path.with_extension("db.pre-migration.bak").exists());
+
+        let state = runtime
+            .block_on(AppState::build())
+            .expect("rebuild app state idempotently");
+        drop(state);
+        let count_after_rebuild: i64 = conn
+            .query_row("SELECT COUNT(*) FROM conversations", [], |row| row.get(0))
+            .expect("count conversations after idempotent rebuild");
+        assert_eq!(count_after_rebuild, 1);
 
         cleanup_dir(&dir);
     }

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -18,6 +18,7 @@ reqwest.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 sha2.workspace = true
+fs2.workspace = true
 dirs = "5"
 
 [dev-dependencies]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -59,6 +59,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     crate::infra::prepare_sqlite_db(&conn)
         .map_err(|e| format!("failed to initialise target schema: {}", e))?;
     prepare_migration_state(&conn)?;
+    prepare_import_ledger(&conn)?;
 
     let mut sources = Vec::new();
     let mut total_rows = 0usize;
@@ -116,7 +117,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
             let tx = conn
                 .unchecked_transaction()
                 .map_err(|e| format!("failed to start migration transaction: {e}"))?;
-            let rows = copy_all_tables(&tx, "refine_migration_src")?;
+            let rows = copy_all_tables(&tx, "refine_migration_src", candidate)?;
             let signature_after = source_signature(candidate)?;
             if signature_after != signature_before {
                 return Err(format!(
@@ -166,6 +167,19 @@ fn prepare_migration_state(conn: &Connection) -> Result<(), String> {
         .map_err(|e| format!("failed to upgrade legacy migration state: {e}"))?;
     }
     Ok(())
+}
+
+fn prepare_import_ledger(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS refine_legacy_imported_rows (
+            source_path TEXT NOT NULL,
+            table_name TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            canonical_id TEXT NOT NULL,
+            PRIMARY KEY (source_path, table_name, source_id)
+        )",
+    )
+    .map_err(|e| format!("failed to prepare legacy import ledger: {e}"))
 }
 
 fn migration_state(conn: &Connection, source: &Path) -> Result<Option<MigrationState>, String> {
@@ -517,7 +531,7 @@ fn preserve_forensic_bundle(source: &Path) -> Result<(), String> {
     result
 }
 
-fn copy_all_tables(conn: &Connection, legacy_alias: &str) -> Result<usize, String> {
+fn copy_all_tables(conn: &Connection, legacy_alias: &str, source: &Path) -> Result<usize, String> {
     let target_tables = list_base_tables(conn, "main")?;
     let legacy_tables = list_base_tables(conn, legacy_alias)?;
     let ordered_tables = migration_copy_order(&legacy_tables);
@@ -529,7 +543,7 @@ fn copy_all_tables(conn: &Connection, legacy_alias: &str) -> Result<usize, Strin
         if !target_tables.contains(table) {
             continue;
         }
-        total += copy_table(conn, table, legacy_alias)?;
+        total += copy_table(conn, table, legacy_alias, source)?;
     }
     Ok(total)
 }
@@ -627,7 +641,12 @@ fn table_columns(conn: &Connection, db_alias: &str, table: &str) -> Result<Vec<S
     Ok(cols)
 }
 
-fn copy_table(conn: &Connection, table: &str, legacy_alias: &str) -> Result<usize, String> {
+fn copy_table(
+    conn: &Connection,
+    table: &str,
+    legacy_alias: &str,
+    source: &Path,
+) -> Result<usize, String> {
     let target_cols = table_columns(conn, "main", table)?;
     let legacy_cols = table_columns(conn, legacy_alias, table)?;
     let common: Vec<String> = legacy_cols
@@ -701,10 +720,55 @@ fn copy_table(conn: &Connection, table: &str, legacy_alias: &str) -> Result<usiz
     };
     let sql = format!(
         "INSERT INTO {table} ({col_list}) \
-         SELECT {select_list} FROM {legacy_alias}.{table} AS src {joins} WHERE true {order_by} {conflict}"
+         SELECT {select_list} FROM {legacy_alias}.{table} AS src {joins} \
+         WHERE NOT EXISTS ( \
+           SELECT 1 FROM main.refine_legacy_imported_rows AS imported \
+           WHERE imported.source_path=?1 \
+             AND imported.table_name='{table}' \
+             AND imported.source_id=src.id \
+             AND NOT EXISTS ( \
+               SELECT 1 FROM main.{table} AS current \
+               WHERE current.id=imported.canonical_id \
+             ) \
+         ) {order_by} {conflict}"
     );
-    conn.execute(&sql, [])
-        .map_err(|e| format!("failed to copy table {table}: {e}"))
+    let source_path = source.to_string_lossy();
+    let copied = conn
+        .execute(&sql, [source_path.as_ref()])
+        .map_err(|e| format!("failed to copy table {table}: {e}"))?;
+    record_imported_rows(conn, table, legacy_alias, source_path.as_ref())?;
+    Ok(copied)
+}
+
+fn record_imported_rows(
+    conn: &Connection,
+    table: &str,
+    legacy_alias: &str,
+    source_path: &str,
+) -> Result<(), String> {
+    let (canonical_id, joins) = match table {
+        "documents" => (
+            "doc_map.canonical_id",
+            "JOIN refine_document_id_map AS doc_map ON doc_map.source_id=src.id",
+        ),
+        "conversations" => (
+            "conv_map.canonical_id",
+            "JOIN refine_conversation_id_map AS conv_map ON conv_map.source_id=src.id",
+        ),
+        _ => ("src.id", ""),
+    };
+    let sql = format!(
+        "INSERT INTO main.refine_legacy_imported_rows \
+           (source_path, table_name, source_id, canonical_id) \
+         SELECT ?1, '{table}', src.id, {canonical_id} \
+         FROM {legacy_alias}.{table} AS src {joins} \
+         JOIN main.{table} AS current ON current.id={canonical_id} \
+         ON CONFLICT(source_path, table_name, source_id) DO UPDATE SET \
+           canonical_id=excluded.canonical_id"
+    );
+    conn.execute(&sql, [source_path])
+        .map(|_| ())
+        .map_err(|e| format!("failed to record imported rows for table {table}: {e}"))
 }
 
 fn document_source_order(common: &[String]) -> String {
@@ -1062,6 +1126,29 @@ mod tests {
             1
         );
         assert!(legacy.exists());
+    }
+
+    #[test]
+    fn later_source_changes_do_not_resurrect_target_deletions() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        insert_item(&lc, "deleted-in-target");
+
+        migrate_stale_dbs(&target).unwrap();
+        let tc = Connection::open(&target).unwrap();
+        tc.execute("DELETE FROM items WHERE id='deleted-in-target'", [])
+            .unwrap();
+        drop(tc);
+
+        insert_item(&lc, "late-write");
+        drop(lc);
+        migrate_stale_dbs(&target).unwrap();
+
+        let tc = Connection::open(&target).unwrap();
+        assert_eq!(item_count(&tc, "deleted-in-target"), 0);
+        assert_eq!(item_count(&tc, "late-write"), 1);
     }
 
     #[test]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -713,14 +713,26 @@ fn copy_table(
         .join(", ");
     let conflict = match table {
         "documents" if common.iter().any(|c| c == "updated_at") => document_conflict(&common),
-        "items" | "extraction_jobs" if common.iter().any(|c| c == "updated_at") => {
+        "items" if common.iter().any(|c| c == "updated_at") => {
             format!(
                 "ON CONFLICT(id) DO UPDATE SET {assignments} \
-                 WHERE julianday(excluded.updated_at) > julianday({table}.updated_at) \
-                    OR (julianday(excluded.updated_at) = julianday({table}.updated_at) \
-                        AND excluded.updated_at > {table}.updated_at)"
+                 WHERE julianday(excluded.updated_at) > julianday(items.updated_at) \
+                    OR (julianday(excluded.updated_at) = julianday(items.updated_at) \
+                        AND excluded.updated_at > items.updated_at)"
             )
         }
+        "extraction_jobs" if common.iter().any(|c| c == "updated_at") => format!(
+            "ON CONFLICT(id) DO UPDATE SET {assignments} \
+             WHERE ( \
+               julianday(excluded.updated_at) > julianday(extraction_jobs.updated_at) \
+               OR (julianday(excluded.updated_at) = julianday(extraction_jobs.updated_at) \
+                   AND excluded.updated_at > extraction_jobs.updated_at) \
+             ) AND ( \
+               extraction_jobs.status = excluded.status \
+               OR (extraction_jobs.status = 'pending' AND excluded.status IN ('running','failed')) \
+               OR (extraction_jobs.status = 'running' AND excluded.status IN ('succeeded','failed')) \
+             )"
+        ),
         "conversations" => format!(
             "ON CONFLICT(id) DO UPDATE SET {assignments} WHERE \
              (conversations.status = excluded.status) OR \
@@ -1329,6 +1341,61 @@ mod tests {
             .unwrap();
         assert_eq!(job_count, 0);
         assert_eq!(event_count, 1);
+    }
+
+    #[test]
+    fn later_legacy_job_timestamp_does_not_regress_terminal_state() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let tc = Connection::open(&target).unwrap();
+        tc.execute_batch(
+            "INSERT INTO conversations
+               (id, user_id, source, url, raw_content, captured_at, created_at,
+                status, idempotency_key, item_ids)
+             VALUES
+               ('conv-job-state', 'u', 'target', 'https://example.com/job-state', 'body',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'processed',
+                'job-state-key', '[]');
+             INSERT INTO extraction_jobs
+               (id, conversation_id, mode, status, created_at, updated_at)
+             VALUES
+               ('job-state', 'conv-job-state', 'auto', 'succeeded',
+                '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z');",
+        )
+        .unwrap();
+        drop(tc);
+
+        let legacy = tmp.path().join("server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        crate::infra::prepare_sqlite_db(&lc).unwrap();
+        lc.execute_batch(
+            "INSERT INTO conversations
+               (id, user_id, source, url, raw_content, captured_at, created_at,
+                status, idempotency_key, item_ids)
+             VALUES
+               ('conv-job-state', 'u', 'legacy', 'https://example.com/job-state', 'body',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'processed',
+                'job-state-key', '[]');
+             INSERT INTO extraction_jobs
+               (id, conversation_id, mode, status, created_at, updated_at)
+             VALUES
+               ('job-state', 'conv-job-state', 'auto', 'running',
+                '2026-01-01T00:00:00Z', '2026-01-03T00:00:00Z');",
+        )
+        .unwrap();
+        drop(lc);
+
+        migrate_stale_dbs(&target).unwrap();
+
+        let status: String = Connection::open(&target)
+            .unwrap()
+            .query_row(
+                "SELECT status FROM extraction_jobs WHERE id='job-state'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "succeeded");
     }
 
     #[test]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -71,7 +71,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
                 .map(|state| state.signature.as_str())
                 == Some(signature_before.as_str())
         {
-            archive_successful_source(candidate, &migrated_path)?;
+            archive_successful_source(candidate, &migrated_path, &signature_before)?;
             continue;
         }
         let bak_path = with_suffix(candidate, ".pre-migration.bak");
@@ -92,7 +92,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
                 == Some(content_hash.as_str())
         {
             save_migration_state(&conn, candidate, &signature_after_snapshot, &content_hash)?;
-            archive_successful_source(candidate, &migrated_path)?;
+            archive_successful_source(candidate, &migrated_path, &signature_after_snapshot)?;
             continue;
         }
 
@@ -111,7 +111,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
             return Err(format!("failed to attach {}: {}", candidate.display(), e));
         }
 
-        let result: Result<usize, String> = (|| {
+        let result: Result<(usize, String), String> = (|| {
             let tx = conn
                 .unchecked_transaction()
                 .map_err(|e| format!("failed to start migration transaction: {e}"))?;
@@ -126,12 +126,12 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
             save_migration_state(&tx, candidate, &signature_after, &content_hash)?;
             tx.commit()
                 .map_err(|e| format!("failed to commit migration transaction: {e}"))?;
-            Ok(rows)
+            Ok((rows, signature_after))
         })();
         drop(conn);
-        let rows =
+        let (rows, signature_after) =
             result.map_err(|e| format!("migration of {} failed: {}", candidate.display(), e))?;
-        archive_successful_source(candidate, &migrated_path)?;
+        archive_successful_source(candidate, &migrated_path, &signature_after)?;
 
         sources.push(candidate.clone());
         total_rows += rows;
@@ -437,8 +437,68 @@ fn ensure_archive_destinations_free(source: &Path, destination: &Path) -> Result
     Ok(())
 }
 
-fn archive_successful_source(source: &Path, destination: &Path) -> Result<(), String> {
+fn archive_successful_source(
+    source: &Path,
+    destination: &Path,
+    expected_signature: &str,
+) -> Result<(), String> {
     ensure_archive_destinations_free(source, destination)?;
+    let source_lock = lock_source_for_archive(source)?;
+    let current_signature = source_signature(source)?;
+    if current_signature != expected_signature {
+        return Err(format!(
+            "legacy DB {} changed before archival; retry migration",
+            source.display()
+        ));
+    }
+
+    // Windows cannot reliably rename an open SQLite database. The signature is
+    // checked again after the move so a writer that sneaks into the narrow
+    // unlock-to-rename gap does not disappear from the stale source path.
+    #[cfg(windows)]
+    drop(source_lock);
+
+    rename_archived_source(source, destination)?;
+
+    #[cfg(windows)]
+    {
+        let archived_signature = source_signature(destination)?;
+        if archived_signature != expected_signature {
+            restore_archived_source(source, destination)?;
+            return Err(format!(
+                "legacy DB {} changed during archival; retry migration",
+                source.display()
+            ));
+        }
+    }
+
+    #[cfg(not(windows))]
+    drop(source_lock);
+
+    Ok(())
+}
+
+fn lock_source_for_archive(source: &Path) -> Result<Connection, String> {
+    let conn = Connection::open(source).map_err(|e| {
+        format!(
+            "failed to open legacy DB {} before archive: {}",
+            source.display(),
+            e
+        )
+    })?;
+    conn.busy_timeout(Duration::from_secs(5))
+        .map_err(|e| format!("failed to configure legacy DB {}: {}", source.display(), e))?;
+    conn.execute_batch("BEGIN IMMEDIATE").map_err(|e| {
+        format!(
+            "failed to lock legacy DB {} before archive: {}",
+            source.display(),
+            e
+        )
+    })?;
+    Ok(conn)
+}
+
+fn rename_archived_source(source: &Path, destination: &Path) -> Result<(), String> {
     std::fs::rename(source, destination)
         .map_err(|e| format!("failed to rename {}: {}", source.display(), e))?;
 
@@ -450,6 +510,29 @@ fn archive_successful_source(source: &Path, destination: &Path) -> Result<(), St
         if companion.exists() {
             let _ = std::fs::rename(&companion, with_suffix(destination, suffix));
         }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn restore_archived_source(source: &Path, destination: &Path) -> Result<(), String> {
+    for suffix in ["-shm", "-wal", ""] {
+        let archived = with_suffix(destination, suffix);
+        if !archived.exists() {
+            continue;
+        }
+        let original = with_suffix(source, suffix);
+        if original.exists() {
+            continue;
+        }
+        std::fs::rename(&archived, &original).map_err(|e| {
+            format!(
+                "failed to restore archived legacy DB {} to {}: {}",
+                archived.display(),
+                original.display(),
+                e
+            )
+        })?;
     }
     Ok(())
 }
@@ -1453,6 +1536,36 @@ mod tests {
         assert_ne!(before, after);
         #[cfg(not(unix))]
         assert_eq!(before, after);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn archive_rechecks_source_signature_before_renaming() {
+        let tmp = TempDir::new().unwrap();
+        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        insert_item(&lc, "before-archive");
+        drop(lc);
+        let signature_before = source_signature(&legacy).unwrap();
+
+        let lc = Connection::open(&legacy).unwrap();
+        insert_item(&lc, "late-write");
+        drop(lc);
+        assert_ne!(signature_before, source_signature(&legacy).unwrap());
+
+        let migrated = with_suffix(&legacy, ".migrated");
+        let error = archive_successful_source(&legacy, &migrated, &signature_before).unwrap_err();
+
+        assert!(
+            error.contains("changed before archival"),
+            "unexpected error: {error}"
+        );
+        assert!(legacy.exists(), "changed source must remain retryable");
+        assert!(!migrated.exists(), "changed source must not be archived");
+        assert_eq!(
+            item_count(&Connection::open(&legacy).unwrap(), "late-write"),
+            1
+        );
     }
 
     #[test]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -63,7 +63,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     for candidate in &candidates {
         let signature_before = source_signature(candidate)?;
         let previous_state = migration_state(&conn, candidate)?;
-        let migrated_path = with_suffix(candidate, ".migrated");
+        let migrated_path = archive_destination(candidate, &signature_before)?;
         if !force_reconcile()
             && cheap_signature_is_authoritative()
             && previous_state
@@ -74,7 +74,6 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
             archive_successful_source(candidate, &migrated_path)?;
             continue;
         }
-        ensure_archive_destinations_free(candidate, &migrated_path)?;
         let bak_path = with_suffix(candidate, ".pre-migration.bak");
         let snapshot = match create_consistent_backup(candidate, &bak_path) {
             Ok(snapshot) => snapshot,
@@ -118,9 +117,13 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
                 .map_err(|e| format!("failed to start migration transaction: {e}"))?;
             let rows = copy_all_tables(&tx, "refine_migration_src")?;
             let signature_after = source_signature(candidate)?;
-            if signature_after == signature_before {
-                save_migration_state(&tx, candidate, &signature_after, &content_hash)?;
+            if signature_after != signature_before {
+                return Err(format!(
+                    "legacy DB {} changed while its migration snapshot was imported; retry migration",
+                    candidate.display()
+                ));
             }
+            save_migration_state(&tx, candidate, &signature_after, &content_hash)?;
             tx.commit()
                 .map_err(|e| format!("failed to commit migration transaction: {e}"))?;
             Ok(rows)
@@ -319,26 +322,28 @@ fn create_consistent_backup(
         }
         drop(destination_conn);
 
-        // Keep the first recovery point immutable. Later reconciliation runs
-        // import from a verified temporary snapshot and remove it on drop.
-        if destination.exists() {
-            Ok(MigrationSnapshot {
-                path: temporary.clone(),
-                remove_on_drop: true,
-            })
-        } else {
-            std::fs::rename(&temporary, destination).map_err(|e| {
-                format!(
-                    "failed to publish backup {} for {}: {}",
-                    destination.display(),
-                    source.display(),
-                    e
-                )
-            })?;
-            Ok(MigrationSnapshot {
-                path: destination.to_path_buf(),
-                remove_on_drop: false,
-            })
+        // Keep the first recovery point immutable. A hard link publishes the
+        // verified temp file without replacing another process's first backup.
+        match std::fs::hard_link(&temporary, destination) {
+            Ok(()) => {
+                let _ = std::fs::remove_file(&temporary);
+                Ok(MigrationSnapshot {
+                    path: destination.to_path_buf(),
+                    remove_on_drop: false,
+                })
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                Ok(MigrationSnapshot {
+                    path: temporary.clone(),
+                    remove_on_drop: true,
+                })
+            }
+            Err(error) => Err(format!(
+                "failed to publish backup {} for {}: {}",
+                destination.display(),
+                source.display(),
+                error
+            )),
         }
     })();
     if result.is_err() {
@@ -384,6 +389,39 @@ fn backup_stall_timeout() -> Duration {
         .unwrap_or_else(|| Duration::from_secs(30))
 }
 
+fn archive_destination(source: &Path, signature: &str) -> Result<PathBuf, String> {
+    let default = with_suffix(source, ".migrated");
+    if archive_destinations_are_free(source, &default) {
+        return Ok(default);
+    }
+
+    let digest = signature_digest(source, signature);
+    for attempt in 0..100 {
+        let suffix = if attempt == 0 {
+            format!(".migrated-{}", &digest[..16])
+        } else {
+            format!(".migrated-{}-{attempt}", &digest[..16])
+        };
+        let candidate = with_suffix(source, &suffix);
+        if archive_destinations_are_free(source, &candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    Err(format!(
+        "cannot archive {} because all generation-specific destinations are occupied",
+        source.display()
+    ))
+}
+
+fn archive_destinations_are_free(source: &Path, destination: &Path) -> bool {
+    ["", "-wal", "-shm"].into_iter().all(|suffix| {
+        let from = with_suffix(source, suffix);
+        let to = with_suffix(destination, suffix);
+        !from.exists() || !to.exists()
+    })
+}
+
 fn ensure_archive_destinations_free(source: &Path, destination: &Path) -> Result<(), String> {
     for suffix in ["", "-wal", "-shm"] {
         let from = with_suffix(source, suffix);
@@ -423,12 +461,16 @@ fn forensic_bundle_path(source: &Path) -> Result<PathBuf, String> {
         .map(|name| name.to_string_lossy().into_owned())
         .unwrap_or_else(|| "legacy.db".to_string());
     let signature = source_signature(source)?;
+    let digest = signature_digest(source, &signature);
+    Ok(parent.join(format!("{name}.pre-migration.forensic-{}", &digest[..16])))
+}
+
+fn signature_digest(source: &Path, signature: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(source.to_string_lossy().as_bytes());
     hasher.update([0]);
     hasher.update(signature.as_bytes());
-    let digest = format!("{:x}", hasher.finalize());
-    Ok(parent.join(format!("{name}.pre-migration.forensic-{}", &digest[..16])))
+    format!("{:x}", hasher.finalize())
 }
 
 fn preserve_forensic_bundle(source: &Path) -> Result<(), String> {
@@ -667,20 +709,7 @@ fn copy_table(conn: &Connection, table: &str, legacy_alias: &str) -> Result<usiz
         .collect::<Vec<_>>()
         .join(", ");
     let conflict = match table {
-        "documents" if common.iter().any(|c| c == "updated_at") => {
-            "ON CONFLICT(id) DO UPDATE SET \
-                   title=CASE \
-                     WHEN TRIM(COALESCE(excluded.title, '')) = '' THEN documents.title \
-                     ELSE excluded.title END, \
-                   raw_content=excluded.raw_content, \
-                   source_version=excluded.source_version, \
-                   captured_at=excluded.captured_at, \
-                   updated_at=excluded.updated_at \
-                 WHERE julianday(excluded.updated_at) > julianday(documents.updated_at) \
-                    OR (julianday(excluded.updated_at) = julianday(documents.updated_at) \
-                        AND excluded.updated_at > documents.updated_at)"
-                .to_string()
-        }
+        "documents" if common.iter().any(|c| c == "updated_at") => document_conflict(&common),
         "items" | "extraction_jobs" if common.iter().any(|c| c == "updated_at") => {
             format!(
                 "ON CONFLICT(id) DO UPDATE SET {assignments} \
@@ -705,6 +734,38 @@ fn copy_table(conn: &Connection, table: &str, legacy_alias: &str) -> Result<usiz
     );
     conn.execute(&sql, [])
         .map_err(|e| format!("failed to copy table {table}: {e}"))
+}
+
+fn document_conflict(common: &[String]) -> String {
+    let has_column = |name: &str| common.iter().any(|column| column == name);
+    let mut assignments = Vec::new();
+
+    if has_column("title") {
+        assignments.push(
+            "title=CASE \
+               WHEN TRIM(COALESCE(excluded.title, '')) = '' THEN documents.title \
+               ELSE excluded.title END"
+                .to_string(),
+        );
+    }
+    if has_column("raw_content") {
+        assignments.push("raw_content=excluded.raw_content".to_string());
+    }
+    if has_column("source_version") {
+        assignments.push("source_version=excluded.source_version".to_string());
+    }
+    if has_column("captured_at") {
+        assignments.push("captured_at=excluded.captured_at".to_string());
+    }
+    assignments.push("updated_at=excluded.updated_at".to_string());
+
+    format!(
+        "ON CONFLICT(id) DO UPDATE SET {} \
+         WHERE julianday(excluded.updated_at) > julianday(documents.updated_at) \
+            OR (julianday(excluded.updated_at) = julianday(documents.updated_at) \
+                AND excluded.updated_at > documents.updated_at)",
+        assignments.join(", ")
+    )
 }
 
 fn is_safe_identifier(name: &str) -> bool {
@@ -964,6 +1025,45 @@ mod tests {
     }
 
     #[test]
+    fn recreated_legacy_source_uses_generation_specific_archive() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        insert_item(&lc, "first-generation");
+        drop(lc);
+
+        migrate_stale_dbs(&target).unwrap();
+        assert!(tmp.path().join("server.db.migrated").exists());
+
+        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        insert_item(&lc, "second-generation");
+        drop(lc);
+
+        let report = migrate_stale_dbs(&target).unwrap();
+        assert!(matches!(
+            report,
+            MigrationReport::Migrated { rows_copied: 1, .. }
+        ));
+        assert_eq!(
+            item_count(&Connection::open(&target).unwrap(), "second-generation"),
+            1
+        );
+        assert!(!legacy.exists());
+        assert!(
+            std::fs::read_dir(tmp.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .any(|entry| entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("server.db.migrated-")),
+            "recreated source must not overwrite the first archive"
+        );
+    }
+
+    #[test]
     fn newer_legacy_rows_update_existing_ids_by_version_and_state() {
         let tmp = TempDir::new().unwrap();
         let target = make_target_db(tmp.path());
@@ -995,6 +1095,65 @@ mod tests {
             )
             .unwrap();
         assert_eq!(corrected, "corrected");
+    }
+
+    #[test]
+    fn document_merge_preserves_source_version_when_legacy_lacks_column() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let tc = Connection::open(&target).unwrap();
+        tc.execute_batch(
+            "INSERT INTO documents
+               (id, title, raw_content, source, url, source_version,
+                captured_at, created_at, updated_at)
+             VALUES
+               ('target-doc', 'Old title', 'old body', 'canonical',
+                'https://example.com/no-source-version', 'v-target',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                '2026-01-01T00:00:00Z');",
+        )
+        .unwrap();
+        drop(tc);
+
+        let legacy = tmp.path().join("server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        lc.execute_batch(
+            "CREATE TABLE documents (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                raw_content TEXT NOT NULL,
+                source TEXT NOT NULL,
+                url TEXT NOT NULL UNIQUE,
+                captured_at TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            INSERT INTO documents
+              (id, title, raw_content, source, url, captured_at, created_at, updated_at)
+            VALUES
+              ('legacy-doc', 'New title', 'new body', 'legacy',
+               'https://example.com/no-source-version',
+               '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z',
+               '2026-01-02T00:00:00Z');",
+        )
+        .unwrap();
+        drop(lc);
+
+        migrate_stale_dbs(&target).unwrap();
+
+        let document: (String, String, String) = Connection::open(&target)
+            .unwrap()
+            .query_row(
+                "SELECT title, raw_content, source_version
+                 FROM documents WHERE id='target-doc'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            document,
+            ("New title".into(), "new body".into(), "v-target".into())
+        );
     }
 
     #[test]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -1,5 +1,7 @@
+use fs2::FileExt;
 use rusqlite::{backup::Backup, backup::StepResult, params, Connection, OptionalExtension};
 use sha2::{Digest, Sha256};
+use std::fs::OpenOptions;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, UNIX_EPOCH};
@@ -35,12 +37,13 @@ impl Drop for MigrationSnapshot {
     }
 }
 
-/// Copies rows from any legacy databases into `target` and renames each legacy
-/// file to `<name>.migrated` after the target transaction commits.
+/// Copies rows from any legacy databases into `target`.
 ///
-/// On failure, the original legacy file and its first verified backup remain
-/// available. All target writes for the failing source are rolled back before
-/// the error is returned.
+/// Legacy files deliberately remain at their original paths: an older process
+/// may still hold a writable connection and append rows after this pass. Future
+/// starts safely reconcile those rows through table-specific upserts. Source
+/// deletions are not propagated because legacy schemas have no tombstones. On
+/// failure, all writes for the failing source are rolled back.
 pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     let candidates = stale_db_candidates(target);
     if candidates.is_empty() {
@@ -63,7 +66,6 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     for candidate in &candidates {
         let signature_before = source_signature(candidate)?;
         let previous_state = migration_state(&conn, candidate)?;
-        let migrated_path = archive_destination(candidate, &signature_before)?;
         if !force_reconcile()
             && cheap_signature_is_authoritative()
             && previous_state
@@ -71,7 +73,6 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
                 .map(|state| state.signature.as_str())
                 == Some(signature_before.as_str())
         {
-            archive_successful_source(candidate, &migrated_path, &signature_before)?;
             continue;
         }
         let bak_path = with_suffix(candidate, ".pre-migration.bak");
@@ -92,12 +93,12 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
                 == Some(content_hash.as_str())
         {
             save_migration_state(&conn, candidate, &signature_after_snapshot, &content_hash)?;
-            archive_successful_source(candidate, &migrated_path, &signature_after_snapshot)?;
             continue;
         }
 
-        // Import the exact verified snapshot; the live legacy file is archived
-        // only after the target transaction commits.
+        // Import the exact verified snapshot. Concurrent rows committed after
+        // the snapshot remain discoverable at the legacy source path and are
+        // reconciled on a later start.
         let conn = Connection::open(target)
             .map_err(|e| format!("failed to reopen target DB {}: {}", target.display(), e))?;
         crate::infra::configure_sqlite_connection(&conn)
@@ -111,7 +112,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
             return Err(format!("failed to attach {}: {}", candidate.display(), e));
         }
 
-        let result: Result<(usize, String), String> = (|| {
+        let result: Result<usize, String> = (|| {
             let tx = conn
                 .unchecked_transaction()
                 .map_err(|e| format!("failed to start migration transaction: {e}"))?;
@@ -126,12 +127,11 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
             save_migration_state(&tx, candidate, &signature_after, &content_hash)?;
             tx.commit()
                 .map_err(|e| format!("failed to commit migration transaction: {e}"))?;
-            Ok((rows, signature_after))
+            Ok(rows)
         })();
         drop(conn);
-        let (rows, signature_after) =
+        let rows =
             result.map_err(|e| format!("migration of {} failed: {}", candidate.display(), e))?;
-        archive_successful_source(candidate, &migrated_path, &signature_after)?;
 
         sources.push(candidate.clone());
         total_rows += rows;
@@ -322,34 +322,66 @@ fn create_consistent_backup(
         }
         drop(destination_conn);
 
-        // Keep the first recovery point immutable. A hard link publishes the
-        // verified temp file without replacing another process's first backup.
-        match std::fs::hard_link(&temporary, destination) {
-            Ok(()) => {
-                let _ = std::fs::remove_file(&temporary);
-                Ok(MigrationSnapshot {
-                    path: destination.to_path_buf(),
-                    remove_on_drop: false,
-                })
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                Ok(MigrationSnapshot {
-                    path: temporary.clone(),
-                    remove_on_drop: true,
-                })
-            }
-            Err(error) => Err(format!(
-                "failed to publish backup {} for {}: {}",
-                destination.display(),
-                source.display(),
-                error
-            )),
-        }
+        publish_first_backup(&temporary, destination)
     })();
     if result.is_err() {
         let _ = std::fs::remove_file(&temporary);
     }
     result
+}
+
+fn publish_first_backup(temporary: &Path, destination: &Path) -> Result<MigrationSnapshot, String> {
+    let lock_path = with_suffix(destination, ".publish.lock");
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|e| {
+            format!(
+                "failed to open backup publish lock {}: {e}",
+                lock_path.display()
+            )
+        })?;
+    lock_file.lock_exclusive().map_err(|e| {
+        format!(
+            "failed to lock backup publication {}: {e}",
+            lock_path.display()
+        )
+    })?;
+
+    let result = if destination.exists() {
+        Ok(MigrationSnapshot {
+            path: temporary.to_path_buf(),
+            remove_on_drop: true,
+        })
+    } else {
+        // Both paths are in the same directory, so rename publishes the fully
+        // verified SQLite snapshot atomically without requiring hard links.
+        std::fs::rename(temporary, destination).map_err(|e| {
+            format!(
+                "failed to publish backup {} for {}: {}",
+                destination.display(),
+                temporary.display(),
+                e
+            )
+        })?;
+        Ok(MigrationSnapshot {
+            path: destination.to_path_buf(),
+            remove_on_drop: false,
+        })
+    };
+    let unlock_result = FileExt::unlock(&lock_file).map_err(|e| {
+        format!(
+            "failed to unlock backup publication {}: {e}",
+            lock_path.display()
+        )
+    });
+    match (result, unlock_result) {
+        (Ok(snapshot), Ok(())) => Ok(snapshot),
+        (Err(error), _) | (_, Err(error)) => Err(error),
+    }
 }
 
 fn run_backup_with_deadline(
@@ -387,154 +419,6 @@ fn backup_stall_timeout() -> Duration {
         .filter(|seconds| *seconds > 0)
         .map(Duration::from_secs)
         .unwrap_or_else(|| Duration::from_secs(30))
-}
-
-fn archive_destination(source: &Path, signature: &str) -> Result<PathBuf, String> {
-    let default = with_suffix(source, ".migrated");
-    if archive_destinations_are_free(source, &default) {
-        return Ok(default);
-    }
-
-    let digest = signature_digest(source, signature);
-    for attempt in 0..100 {
-        let suffix = if attempt == 0 {
-            format!(".migrated-{}", &digest[..16])
-        } else {
-            format!(".migrated-{}-{attempt}", &digest[..16])
-        };
-        let candidate = with_suffix(source, &suffix);
-        if archive_destinations_are_free(source, &candidate) {
-            return Ok(candidate);
-        }
-    }
-
-    Err(format!(
-        "cannot archive {} because all generation-specific destinations are occupied",
-        source.display()
-    ))
-}
-
-fn archive_destinations_are_free(source: &Path, destination: &Path) -> bool {
-    ["", "-wal", "-shm"].into_iter().all(|suffix| {
-        let from = with_suffix(source, suffix);
-        let to = with_suffix(destination, suffix);
-        !from.exists() || !to.exists()
-    })
-}
-
-fn ensure_archive_destinations_free(source: &Path, destination: &Path) -> Result<(), String> {
-    for suffix in ["", "-wal", "-shm"] {
-        let from = with_suffix(source, suffix);
-        let to = with_suffix(destination, suffix);
-        if from.exists() && to.exists() {
-            return Err(format!(
-                "cannot archive {} because destination {} already exists",
-                from.display(),
-                to.display()
-            ));
-        }
-    }
-    Ok(())
-}
-
-fn archive_successful_source(
-    source: &Path,
-    destination: &Path,
-    expected_signature: &str,
-) -> Result<(), String> {
-    ensure_archive_destinations_free(source, destination)?;
-    let source_lock = lock_source_for_archive(source)?;
-    let current_signature = source_signature(source)?;
-    if current_signature != expected_signature {
-        return Err(format!(
-            "legacy DB {} changed before archival; retry migration",
-            source.display()
-        ));
-    }
-
-    // Windows cannot reliably rename an open SQLite database. The signature is
-    // checked again after the move so a writer that sneaks into the narrow
-    // unlock-to-rename gap does not disappear from the stale source path.
-    #[cfg(windows)]
-    drop(source_lock);
-
-    rename_archived_source(source, destination)?;
-
-    #[cfg(windows)]
-    {
-        let archived_signature = source_signature(destination)?;
-        if archived_signature != expected_signature {
-            restore_archived_source(source, destination)?;
-            return Err(format!(
-                "legacy DB {} changed during archival; retry migration",
-                source.display()
-            ));
-        }
-    }
-
-    #[cfg(not(windows))]
-    drop(source_lock);
-
-    Ok(())
-}
-
-fn lock_source_for_archive(source: &Path) -> Result<Connection, String> {
-    let conn = Connection::open(source).map_err(|e| {
-        format!(
-            "failed to open legacy DB {} before archive: {}",
-            source.display(),
-            e
-        )
-    })?;
-    conn.busy_timeout(Duration::from_secs(5))
-        .map_err(|e| format!("failed to configure legacy DB {}: {}", source.display(), e))?;
-    conn.execute_batch("BEGIN IMMEDIATE").map_err(|e| {
-        format!(
-            "failed to lock legacy DB {} before archive: {}",
-            source.display(),
-            e
-        )
-    })?;
-    Ok(conn)
-}
-
-fn rename_archived_source(source: &Path, destination: &Path) -> Result<(), String> {
-    std::fs::rename(source, destination)
-        .map_err(|e| format!("failed to rename {}: {}", source.display(), e))?;
-
-    // Keep companion files associated with the archived database. These are
-    // best-effort because the main database has already been archived and some
-    // platforms may not leave separate companions after close/checkpoint.
-    for suffix in ["-wal", "-shm"] {
-        let companion = with_suffix(source, suffix);
-        if companion.exists() {
-            let _ = std::fs::rename(&companion, with_suffix(destination, suffix));
-        }
-    }
-    Ok(())
-}
-
-#[cfg(windows)]
-fn restore_archived_source(source: &Path, destination: &Path) -> Result<(), String> {
-    for suffix in ["-shm", "-wal", ""] {
-        let archived = with_suffix(destination, suffix);
-        if !archived.exists() {
-            continue;
-        }
-        let original = with_suffix(source, suffix);
-        if original.exists() {
-            continue;
-        }
-        std::fs::rename(&archived, &original).map_err(|e| {
-            format!(
-                "failed to restore archived legacy DB {} to {}: {}",
-                archived.display(),
-                original.display(),
-                e
-            )
-        })?;
-    }
-    Ok(())
 }
 
 fn forensic_bundle_path(source: &Path) -> Result<PathBuf, String> {
@@ -1066,10 +950,9 @@ mod tests {
             MigrationReport::Migrated { rows_copied: 3, .. }
         ));
         assert!(
-            with_suffix(&legacy, ".migrated").exists(),
-            "legacy DB is archived after a successful commit"
+            legacy.exists(),
+            "legacy DB remains discoverable for later reconciliation"
         );
-        assert!(!legacy.exists());
 
         let tc = Connection::open(&target_path).unwrap();
         let conversation_count: i64 = tc
@@ -1158,20 +1041,15 @@ mod tests {
     }
 
     #[test]
-    fn recreated_legacy_source_uses_generation_specific_archive() {
+    fn late_writes_are_reconciled_from_the_discoverable_source() {
         let tmp = TempDir::new().unwrap();
         let target = make_target_db(tmp.path());
         let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
         let lc = Connection::open(&legacy).unwrap();
         insert_item(&lc, "first-generation");
-        drop(lc);
 
         migrate_stale_dbs(&target).unwrap();
-        assert!(tmp.path().join("server.db.migrated").exists());
-
-        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
-        let lc = Connection::open(&legacy).unwrap();
-        insert_item(&lc, "second-generation");
+        insert_item(&lc, "late-write");
         drop(lc);
 
         let report = migrate_stale_dbs(&target).unwrap();
@@ -1180,20 +1058,10 @@ mod tests {
             MigrationReport::Migrated { rows_copied: 1, .. }
         ));
         assert_eq!(
-            item_count(&Connection::open(&target).unwrap(), "second-generation"),
+            item_count(&Connection::open(&target).unwrap(), "late-write"),
             1
         );
-        assert!(!legacy.exists());
-        assert!(
-            std::fs::read_dir(tmp.path())
-                .unwrap()
-                .filter_map(Result::ok)
-                .any(|entry| entry
-                    .file_name()
-                    .to_string_lossy()
-                    .starts_with("server.db.migrated-")),
-            "recreated source must not overwrite the first archive"
-        );
+        assert!(legacy.exists());
     }
 
     #[test]
@@ -1538,36 +1406,6 @@ mod tests {
         assert_eq!(before, after);
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn archive_rechecks_source_signature_before_renaming() {
-        let tmp = TempDir::new().unwrap();
-        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
-        let lc = Connection::open(&legacy).unwrap();
-        insert_item(&lc, "before-archive");
-        drop(lc);
-        let signature_before = source_signature(&legacy).unwrap();
-
-        let lc = Connection::open(&legacy).unwrap();
-        insert_item(&lc, "late-write");
-        drop(lc);
-        assert_ne!(signature_before, source_signature(&legacy).unwrap());
-
-        let migrated = with_suffix(&legacy, ".migrated");
-        let error = archive_successful_source(&legacy, &migrated, &signature_before).unwrap_err();
-
-        assert!(
-            error.contains("changed before archival"),
-            "unexpected error: {error}"
-        );
-        assert!(legacy.exists(), "changed source must remain retryable");
-        assert!(!migrated.exists(), "changed source must not be archived");
-        assert_eq!(
-            item_count(&Connection::open(&legacy).unwrap(), "late-write"),
-            1
-        );
-    }
-
     #[test]
     fn progressing_backup_is_not_stopped_by_stall_timeout() {
         let tmp = TempDir::new().unwrap();
@@ -1596,8 +1434,7 @@ mod tests {
         migrate_stale_dbs(&target).unwrap();
 
         assert!(tmp.path().join("server.db.pre-migration.bak").exists());
-        assert!(tmp.path().join("server.db.migrated").exists());
-        assert!(!tmp.path().join("server.db").exists());
+        assert!(tmp.path().join("server.db").exists());
     }
 
     #[test]
@@ -1719,7 +1556,7 @@ mod tests {
     }
 
     #[test]
-    fn live_wal_source_is_backed_up_and_archived_after_success() {
+    fn live_wal_source_is_backed_up_and_remains_reconcilable() {
         let tmp = TempDir::new().unwrap();
         let target = make_target_db(tmp.path());
         let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
@@ -1741,11 +1578,7 @@ mod tests {
             1,
             "target import must use the verified WAL-inclusive snapshot"
         );
-        assert!(
-            with_suffix(&legacy, ".migrated").exists(),
-            "source is archived only after the WAL-inclusive import commits"
-        );
-        assert!(!legacy.exists());
+        assert!(legacy.exists(), "source remains available for later writes");
 
         let backup = Connection::open(tmp.path().join("server.db.pre-migration.bak")).unwrap();
         assert_eq!(

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -536,7 +536,7 @@ fn copy_all_tables(conn: &Connection, legacy_alias: &str, source: &Path) -> Resu
     let legacy_tables = list_base_tables(conn, legacy_alias)?;
     let ordered_tables = migration_copy_order(&legacy_tables);
 
-    create_identity_maps(conn, legacy_alias, &legacy_tables)?;
+    create_identity_maps(conn, legacy_alias, &legacy_tables, source)?;
 
     let mut total = 0usize;
     for table in &ordered_tables {
@@ -569,6 +569,7 @@ fn create_identity_maps(
     conn: &Connection,
     legacy_alias: &str,
     legacy_tables: &[String],
+    source: &Path,
 ) -> Result<(), String> {
     conn.execute_batch(
         "CREATE TEMP TABLE IF NOT EXISTS refine_document_id_map (
@@ -583,31 +584,47 @@ fn create_identity_maps(
     .map_err(|e| format!("failed to prepare legacy identity maps: {e}"))?;
 
     if legacy_tables.iter().any(|table| table == "documents") {
-        conn.execute_batch(&format!(
-            "INSERT INTO refine_document_id_map (source_id, canonical_id)
+        conn.execute(
+            &format!(
+                "INSERT INTO refine_document_id_map (source_id, canonical_id)
              SELECT src.id, COALESCE(
                target.id,
+               imported.canonical_id,
                (SELECT first.id FROM {legacy_alias}.documents AS first
                 WHERE first.url = src.url ORDER BY first.rowid LIMIT 1)
              )
              FROM {legacy_alias}.documents AS src
-             LEFT JOIN main.documents AS target ON target.url = src.url"
-        ))
+             LEFT JOIN main.documents AS target ON target.url = src.url
+             LEFT JOIN main.refine_legacy_imported_rows AS imported
+               ON imported.source_path=?1
+              AND imported.table_name='documents'
+              AND imported.source_id=src.id"
+            ),
+            [source.to_string_lossy().as_ref()],
+        )
         .map_err(|e| format!("failed to map legacy document identities: {e}"))?;
     }
     if legacy_tables.iter().any(|table| table == "conversations") {
-        conn.execute_batch(&format!(
-            "INSERT INTO refine_conversation_id_map (source_id, canonical_id)
+        conn.execute(
+            &format!(
+                "INSERT INTO refine_conversation_id_map (source_id, canonical_id)
              SELECT src.id, COALESCE(
                target.id,
+               imported.canonical_id,
                (SELECT first.id FROM {legacy_alias}.conversations AS first
                 WHERE first.idempotency_key = src.idempotency_key
                 ORDER BY first.rowid LIMIT 1)
              )
              FROM {legacy_alias}.conversations AS src
              LEFT JOIN main.conversations AS target
-               ON target.idempotency_key = src.idempotency_key"
-        ))
+               ON target.idempotency_key = src.idempotency_key
+             LEFT JOIN main.refine_legacy_imported_rows AS imported
+               ON imported.source_path=?1
+              AND imported.table_name='conversations'
+              AND imported.source_id=src.id"
+            ),
+            [source.to_string_lossy().as_ref()],
+        )
         .map_err(|e| format!("failed to map legacy conversation identities: {e}"))?;
     }
     Ok(())
@@ -718,6 +735,21 @@ fn copy_table(
         "documents" => document_source_order(&common),
         _ => String::new(),
     };
+    let parent_tombstone_guard = match table {
+        "items" if common.iter().any(|column| column == "document_id") => {
+            "AND NOT (doc_map.canonical_id IS NOT NULL AND NOT EXISTS ( \
+               SELECT 1 FROM main.documents AS parent \
+               WHERE parent.id=doc_map.canonical_id \
+             ))"
+        }
+        "extraction_jobs" if common.iter().any(|column| column == "conversation_id") => {
+            "AND NOT (conv_map.canonical_id IS NOT NULL AND NOT EXISTS ( \
+               SELECT 1 FROM main.conversations AS parent \
+               WHERE parent.id=conv_map.canonical_id \
+             ))"
+        }
+        _ => "",
+    };
     let sql = format!(
         "INSERT INTO {table} ({col_list}) \
          SELECT {select_list} FROM {legacy_alias}.{table} AS src {joins} \
@@ -730,13 +762,13 @@ fn copy_table(
                SELECT 1 FROM main.{table} AS current \
                WHERE current.id=imported.canonical_id \
              ) \
-         ) {order_by} {conflict}"
+         ) {parent_tombstone_guard} {order_by} {conflict}"
     );
     let source_path = source.to_string_lossy();
     let copied = conn
         .execute(&sql, [source_path.as_ref()])
         .map_err(|e| format!("failed to copy table {table}: {e}"))?;
-    record_imported_rows(conn, table, legacy_alias, source_path.as_ref())?;
+    record_imported_rows(conn, table, legacy_alias, source_path.as_ref(), &common)?;
     Ok(copied)
 }
 
@@ -745,24 +777,42 @@ fn record_imported_rows(
     table: &str,
     legacy_alias: &str,
     source_path: &str,
+    common: &[String],
 ) -> Result<(), String> {
-    let (canonical_id, joins) = match table {
+    let (canonical_id, joins, recordable) = match table {
         "documents" => (
             "doc_map.canonical_id",
             "JOIN refine_document_id_map AS doc_map ON doc_map.source_id=src.id",
+            "current.id IS NOT NULL",
+        ),
+        "items" if common.iter().any(|column| column == "document_id") => (
+            "src.id",
+            "LEFT JOIN refine_document_id_map AS doc_map ON doc_map.source_id=src.document_id",
+            "current.id IS NOT NULL OR (doc_map.canonical_id IS NOT NULL AND NOT EXISTS ( \
+               SELECT 1 FROM main.documents AS parent WHERE parent.id=doc_map.canonical_id \
+             ))",
         ),
         "conversations" => (
             "conv_map.canonical_id",
             "JOIN refine_conversation_id_map AS conv_map ON conv_map.source_id=src.id",
+            "current.id IS NOT NULL",
         ),
-        _ => ("src.id", ""),
+        "extraction_jobs" if common.iter().any(|column| column == "conversation_id") => (
+            "src.id",
+            "LEFT JOIN refine_conversation_id_map AS conv_map ON conv_map.source_id=src.conversation_id",
+            "current.id IS NOT NULL OR (conv_map.canonical_id IS NOT NULL AND NOT EXISTS ( \
+               SELECT 1 FROM main.conversations AS parent WHERE parent.id=conv_map.canonical_id \
+             ))",
+        ),
+        _ => ("src.id", "", "current.id IS NOT NULL"),
     };
     let sql = format!(
         "INSERT INTO main.refine_legacy_imported_rows \
            (source_path, table_name, source_id, canonical_id) \
          SELECT ?1, '{table}', src.id, {canonical_id} \
          FROM {legacy_alias}.{table} AS src {joins} \
-         JOIN main.{table} AS current ON current.id={canonical_id} \
+         LEFT JOIN main.{table} AS current ON current.id={canonical_id} \
+         WHERE {recordable} \
          ON CONFLICT(source_path, table_name, source_id) DO UPDATE SET \
            canonical_id=excluded.canonical_id"
     );
@@ -1149,6 +1199,136 @@ mod tests {
         let tc = Connection::open(&target).unwrap();
         assert_eq!(item_count(&tc, "deleted-in-target"), 0);
         assert_eq!(item_count(&tc, "late-write"), 1);
+    }
+
+    #[test]
+    fn deleted_document_tombstones_late_children_without_blocking_other_rows() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let tc = Connection::open(&target).unwrap();
+        tc.execute_batch(
+            "INSERT INTO documents
+               (id, title, raw_content, source, url, source_version,
+                captured_at, created_at, updated_at)
+             VALUES
+               ('target-doc', 'Target', 'target', 'canonical',
+                'https://example.com/tombstone-parent', 'v-target',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                '2026-01-01T00:00:00Z');",
+        )
+        .unwrap();
+        drop(tc);
+
+        let legacy = tmp.path().join("server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        crate::infra::prepare_sqlite_db(&lc).unwrap();
+        lc.execute_batch(
+            "INSERT INTO documents
+               (id, title, raw_content, source, url, source_version,
+                captured_at, created_at, updated_at)
+             VALUES
+               ('source-doc', 'Source', 'source', 'legacy',
+                'https://example.com/tombstone-parent', 'v-source',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                '2026-01-01T00:00:00Z');",
+        )
+        .unwrap();
+
+        migrate_stale_dbs(&target).unwrap();
+        let tc = Connection::open(&target).unwrap();
+        tc.execute("DELETE FROM documents WHERE id='target-doc'", [])
+            .unwrap();
+        drop(tc);
+
+        lc.execute_batch(
+            "INSERT INTO items
+               (id, item_type, title, summary, content, tags,
+                created_at, updated_at, document_id)
+             VALUES
+               ('orphaned-late-child', 'knowledge', 'T', 'S', 'C', '[]',
+                '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z', 'source-doc'),
+               ('independent-late-item', 'knowledge', 'T', 'S', 'C', '[]',
+                '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z', NULL);",
+        )
+        .unwrap();
+        drop(lc);
+
+        migrate_stale_dbs(&target).unwrap();
+        let tc = Connection::open(&target).unwrap();
+        assert_eq!(item_count(&tc, "orphaned-late-child"), 0);
+        assert_eq!(item_count(&tc, "independent-late-item"), 1);
+    }
+
+    #[test]
+    fn deleted_conversation_tombstones_late_jobs_without_blocking_events() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let tc = Connection::open(&target).unwrap();
+        tc.execute_batch(
+            "INSERT INTO conversations
+               (id, user_id, source, url, raw_content, captured_at, created_at,
+                status, idempotency_key, item_ids)
+             VALUES
+               ('target-conv', 'u', 'canonical', 'https://example.com/conv', 'target',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'captured',
+                'shared-conv-key', '[]');",
+        )
+        .unwrap();
+        drop(tc);
+
+        let legacy = tmp.path().join("server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        crate::infra::prepare_sqlite_db(&lc).unwrap();
+        lc.execute_batch(
+            "INSERT INTO conversations
+               (id, user_id, source, url, raw_content, captured_at, created_at,
+                status, idempotency_key, item_ids)
+             VALUES
+               ('source-conv', 'u', 'legacy', 'https://example.com/conv', 'source',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'captured',
+                'shared-conv-key', '[]');",
+        )
+        .unwrap();
+
+        migrate_stale_dbs(&target).unwrap();
+        let tc = Connection::open(&target).unwrap();
+        tc.execute("DELETE FROM conversations WHERE id='target-conv'", [])
+            .unwrap();
+        drop(tc);
+
+        lc.execute_batch(
+            "INSERT INTO extraction_jobs
+               (id, conversation_id, mode, status, created_at, updated_at)
+             VALUES
+               ('orphaned-late-job', 'source-conv', 'auto', 'pending',
+                '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z');
+             INSERT INTO events
+               (id, user_id, event_name, source, properties_json, created_at)
+             VALUES
+               ('independent-late-event', 'u', 'late', 'legacy', '{}',
+                '2026-01-02T00:00:00Z');",
+        )
+        .unwrap();
+        drop(lc);
+
+        migrate_stale_dbs(&target).unwrap();
+        let tc = Connection::open(&target).unwrap();
+        let job_count: i64 = tc
+            .query_row(
+                "SELECT COUNT(*) FROM extraction_jobs WHERE id='orphaned-late-job'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let event_count: i64 = tc
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE id='independent-late-event'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(job_count, 0);
+        assert_eq!(event_count, 1);
     }
 
     #[test]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -43,14 +43,19 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
 
     for candidate in &candidates {
         let bak_path = with_suffix(candidate, ".pre-migration.bak");
-        let source_conn = create_consistent_backup(candidate, &bak_path)?;
-        checkpoint_source_for_archive(&source_conn, candidate)?;
-        drop(source_conn);
-        ensure_no_live_companions(candidate)?;
+        let migrated_path = with_suffix(candidate, ".migrated");
+        ensure_archive_destinations_free(candidate, &migrated_path)?;
+        let (source_conn, snapshot_path) = match create_consistent_backup(candidate, &bak_path) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                preserve_forensic_backup(candidate, &bak_path)?;
+                return Err(error);
+            }
+        };
 
-        // Scope one target connection and one transaction to each source. When
-        // this block exits, SQLite also releases the attachment before the
-        // legacy file is renamed.
+        // Import the immutable, verified snapshot while the source write lock
+        // remains held. A legacy writer cannot race a new WAL commit between
+        // backup and archival.
         let conn = Connection::open(target)
             .map_err(|e| format!("failed to reopen target DB {}: {}", target.display(), e))?;
         crate::infra::configure_sqlite_connection(&conn)
@@ -58,29 +63,30 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
 
         let attach_sql = format!(
             "ATTACH DATABASE '{}' AS refine_migration_src",
-            candidate.to_string_lossy().replace('\'', "''")
+            snapshot_path.to_string_lossy().replace('\'', "''")
         );
         if let Err(e) = conn.execute_batch(&attach_sql) {
             return Err(format!("failed to attach {}: {}", candidate.display(), e));
         }
 
-        let result: Result<usize, String> = (|| {
-            let tx = conn
-                .unchecked_transaction()
-                .map_err(|e| format!("failed to start migration transaction: {e}"))?;
-            let rows = copy_all_tables(&tx, "refine_migration_src")?;
-            tx.commit()
-                .map_err(|e| format!("failed to commit migration transaction: {e}"))?;
-            Ok(rows)
-        })();
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| format!("failed to start migration transaction: {e}"))?;
+        let rows = copy_all_tables(&tx, "refine_migration_src")
+            .map_err(|e| format!("migration of {} failed: {}", candidate.display(), e))?;
+
+        // Archive while the source write lock and target transaction are both
+        // active. A target commit failure restores the source filenames before
+        // reporting failure, so an error never leaves only one side committed.
+        let archived = archive_locked_source(candidate, &migrated_path)?;
+        if let Err(error) = tx.commit() {
+            let restore_note = restore_archived_source(&archived);
+            return Err(format!(
+                "failed to commit migration transaction: {error}{restore_note}"
+            ));
+        }
         drop(conn);
-
-        let rows =
-            result.map_err(|e| format!("migration of {} failed: {}", candidate.display(), e))?;
-
-        let migrated_path = with_suffix(candidate, ".migrated");
-        std::fs::rename(candidate, &migrated_path)
-            .map_err(|e| format!("failed to rename {}: {}", candidate.display(), e))?;
+        drop(source_conn);
 
         sources.push(candidate.clone());
         total_rows += rows;
@@ -92,65 +98,192 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     })
 }
 
-fn create_consistent_backup(source: &Path, destination: &Path) -> Result<Connection, String> {
+fn create_consistent_backup(
+    source: &Path,
+    destination: &Path,
+) -> Result<(Connection, PathBuf), String> {
     let source_conn = Connection::open(source)
         .map_err(|e| format!("failed to open legacy DB {}: {}", source.display(), e))?;
-    let mut destination_conn = Connection::open(destination).map_err(|e| {
+    source_conn
+        .busy_timeout(Duration::from_secs(5))
+        .map_err(|e| format!("failed to configure legacy DB {}: {}", source.display(), e))?;
+    let version_before: i64 = source_conn
+        .pragma_query_value(None, "data_version", |row| row.get(0))
+        .map_err(|e| format!("failed to inspect legacy DB {}: {}", source.display(), e))?;
+    let unique = uuid::Uuid::new_v4();
+    let temporary = with_suffix(destination, &format!(".tmp-{unique}"));
+    let result = (|| {
+        let mut destination_conn = Connection::open(&temporary).map_err(|e| {
+            format!(
+                "failed to create temporary backup {} for {}: {}",
+                temporary.display(),
+                source.display(),
+                e
+            )
+        })?;
+        {
+            let backup = Backup::new(&source_conn, &mut destination_conn)
+                .map_err(|e| format!("failed to start backup of {}: {}", source.display(), e))?;
+            backup
+                .run_to_completion(128, Duration::from_millis(10), None)
+                .map_err(|e| format!("failed to backup {}: {}", source.display(), e))?;
+        }
+        let integrity: String = destination_conn
+            .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+            .map_err(|e| format!("failed to verify backup of {}: {}", source.display(), e))?;
+        if integrity != "ok" {
+            return Err(format!(
+                "backup integrity check failed for {}: {}",
+                source.display(),
+                integrity
+            ));
+        }
+        drop(destination_conn);
+
+        // Keep an earlier recovery point immutable. A retry publishes a
+        // versioned snapshot and imports from that exact verified file.
+        let published = if destination.exists() {
+            with_suffix(destination, &format!(".{unique}"))
+        } else {
+            destination.to_path_buf()
+        };
+        std::fs::rename(&temporary, &published).map_err(|e| {
+            format!(
+                "failed to publish backup {} for {}: {}",
+                published.display(),
+                source.display(),
+                e
+            )
+        })?;
+        source_conn
+            .execute_batch("BEGIN IMMEDIATE")
+            .map_err(|e| format!("failed to lock legacy DB {}: {}", source.display(), e))?;
+        let version_after: i64 = source_conn
+            .pragma_query_value(None, "data_version", |row| row.get(0))
+            .map_err(|e| format!("failed to recheck legacy DB {}: {}", source.display(), e))?;
+        if version_after != version_before {
+            return Err(format!(
+                "legacy DB {} changed while its migration snapshot was created; retry migration",
+                source.display()
+            ));
+        }
+        Ok((source_conn, published))
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+        preserve_forensic_backup(source, destination)?;
+    }
+    result
+}
+
+fn preserve_forensic_backup(source: &Path, destination: &Path) -> Result<(), String> {
+    if destination.exists() {
+        return Ok(());
+    }
+    let temporary = with_suffix(destination, &format!(".raw-tmp-{}", uuid::Uuid::new_v4()));
+    std::fs::copy(source, &temporary).map_err(|e| {
         format!(
-            "failed to create backup {} for {}: {}",
-            destination.display(),
+            "failed to preserve forensic backup of {} as {}: {}",
             source.display(),
+            destination.display(),
             e
         )
     })?;
-    {
-        let backup = Backup::new(&source_conn, &mut destination_conn)
-            .map_err(|e| format!("failed to start backup of {}: {}", source.display(), e))?;
-        backup
-            .run_to_completion(128, Duration::from_millis(10), None)
-            .map_err(|e| format!("failed to backup {}: {}", source.display(), e))?;
-    }
-    let integrity: String = destination_conn
-        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
-        .map_err(|e| format!("failed to verify backup of {}: {}", source.display(), e))?;
-    if integrity != "ok" {
+    if let Err(error) = std::fs::rename(&temporary, destination) {
+        let _ = std::fs::remove_file(&temporary);
         return Err(format!(
-            "backup integrity check failed for {}: {}",
-            source.display(),
-            integrity
-        ));
-    }
-    drop(destination_conn);
-    Ok(source_conn)
-}
-
-fn checkpoint_source_for_archive(conn: &Connection, source: &Path) -> Result<(), String> {
-    let (busy, log_frames, checkpointed_frames): (i64, i64, i64) = conn
-        .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
-            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-        })
-        .map_err(|e| format!("failed to checkpoint {}: {}", source.display(), e))?;
-    if busy != 0 || log_frames != checkpointed_frames {
-        return Err(format!(
-            "cannot archive {} while its WAL is busy ({checkpointed_frames}/{log_frames} frames checkpointed)",
-            source.display()
+            "failed to publish forensic backup {}: {}",
+            destination.display(),
+            error
         ));
     }
     Ok(())
 }
 
-fn ensure_no_live_companions(source: &Path) -> Result<(), String> {
-    for ext in ["-wal", "-shm"] {
-        let companion = with_suffix(source, ext);
-        if companion.exists() {
+fn ensure_archive_destinations_free(source: &Path, destination: &Path) -> Result<(), String> {
+    for (from, to) in archive_paths(source, destination) {
+        if from.exists() && to.exists() {
             return Err(format!(
-                "cannot archive {} while companion file {} is still active",
+                "cannot archive {} because destination {} already exists",
                 source.display(),
-                companion.display()
+                to.display()
             ));
         }
     }
     Ok(())
+}
+
+fn archive_locked_source(
+    source: &Path,
+    destination: &Path,
+) -> Result<Vec<(PathBuf, PathBuf)>, String> {
+    let paths: Vec<(PathBuf, PathBuf)> = archive_paths(source, destination)
+        .into_iter()
+        .filter(|(from, _)| from.exists())
+        .collect();
+    let mut renamed: Vec<(PathBuf, PathBuf)> = Vec::new();
+    for (from, to) in paths {
+        if let Err(error) = std::fs::rename(&from, &to) {
+            let mut rollback_errors = Vec::new();
+            for (original, archived) in renamed.iter().rev() {
+                if let Err(rollback_error) = std::fs::rename(archived, original) {
+                    rollback_errors.push(rollback_error.to_string());
+                }
+            }
+            let rollback_note = if rollback_errors.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "; archive rollback also failed: {}",
+                    rollback_errors.join(", ")
+                )
+            };
+            return Err(format!(
+                "failed to archive {} as {}: {}{}",
+                from.display(),
+                to.display(),
+                error,
+                rollback_note
+            ));
+        }
+        renamed.push((from, to));
+    }
+    Ok(renamed)
+}
+
+fn restore_archived_source(archived: &[(PathBuf, PathBuf)]) -> String {
+    let mut errors = Vec::new();
+    for (original, destination) in archived.iter().rev() {
+        if let Err(error) = std::fs::rename(destination, original) {
+            errors.push(format!(
+                "{} -> {}: {}",
+                destination.display(),
+                original.display(),
+                error
+            ));
+        }
+    }
+    if errors.is_empty() {
+        String::new()
+    } else {
+        format!("; source restore also failed: {}", errors.join(", "))
+    }
+}
+
+fn archive_paths(source: &Path, destination: &Path) -> Vec<(PathBuf, PathBuf)> {
+    ["-wal", "-shm", ""]
+        .into_iter()
+        .map(|suffix| {
+            if suffix.is_empty() {
+                (source.to_path_buf(), destination.to_path_buf())
+            } else {
+                (
+                    with_suffix(source, suffix),
+                    with_suffix(destination, suffix),
+                )
+            }
+        })
+        .collect()
 }
 
 fn copy_all_tables(conn: &Connection, legacy_alias: &str) -> Result<usize, String> {
@@ -598,7 +731,7 @@ mod tests {
     }
 
     #[test]
-    fn live_wal_source_is_backed_up_before_target_writes_and_left_retryable() {
+    fn live_wal_source_is_backed_up_and_archived_with_companions() {
         let tmp = TempDir::new().unwrap();
         let target = make_target_db(tmp.path());
         let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
@@ -610,19 +743,33 @@ mod tests {
             with_suffix(&legacy, "-wal").exists(),
             "fixture must keep committed rows in a live WAL"
         );
+        let had_wal = with_suffix(&legacy, "-wal").exists();
+        let had_shm = with_suffix(&legacy, "-shm").exists();
 
-        let result = migrate_stale_dbs(&target);
-        assert!(
-            result.is_err(),
-            "an actively held WAL must prevent source archival"
-        );
+        let result = migrate_stale_dbs(&target).unwrap();
+        assert!(matches!(
+            result,
+            MigrationReport::Migrated { rows_copied: 1, .. }
+        ));
         assert_eq!(
             item_count(&Connection::open(&target).unwrap(), "item-from-wal"),
-            0,
-            "archive preflight must fail before target writes"
+            1,
+            "target import must use the verified WAL-inclusive snapshot"
         );
-        assert!(legacy.exists(), "live source must remain retryable");
-        assert!(!tmp.path().join("server.db.migrated").exists());
+        assert!(!legacy.exists());
+        assert!(tmp.path().join("server.db.migrated").exists());
+        assert!(!with_suffix(&legacy, "-wal").exists());
+        assert!(!with_suffix(&legacy, "-shm").exists());
+        assert_eq!(
+            tmp.path().join("server.db.migrated-wal").exists(),
+            had_wal,
+            "WAL must move with the archived source when present"
+        );
+        assert_eq!(
+            tmp.path().join("server.db.migrated-shm").exists(),
+            had_shm,
+            "SHM must move with the archived source when present"
+        );
 
         let backup = Connection::open(tmp.path().join("server.db.pre-migration.bak")).unwrap();
         assert_eq!(
@@ -632,6 +779,45 @@ mod tests {
         );
         drop(backup);
         drop(lc);
+    }
+
+    #[test]
+    fn retry_keeps_existing_backup_immutable() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
+        let old_backup = tmp.path().join("server.db.pre-migration.bak");
+        let backup_conn = Connection::open(&old_backup).unwrap();
+        backup_conn
+            .execute_batch(
+                "CREATE TABLE marker (value TEXT NOT NULL); INSERT INTO marker VALUES ('old');",
+            )
+            .unwrap();
+        drop(backup_conn);
+        let original_bytes = std::fs::read(&old_backup).unwrap();
+        let lc = Connection::open(&legacy).unwrap();
+        insert_item(&lc, "retry-item");
+        drop(lc);
+
+        migrate_stale_dbs(&target).unwrap();
+
+        assert_eq!(std::fs::read(&old_backup).unwrap(), original_bytes);
+        let old_value: String = Connection::open(&old_backup)
+            .unwrap()
+            .query_row("SELECT value FROM marker", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(old_value, "old");
+        let versioned_backups = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("server.db.pre-migration.bak.")
+            })
+            .count();
+        assert_eq!(versioned_backups, 1);
     }
 
     #[test]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -35,13 +35,12 @@ impl Drop for MigrationSnapshot {
     }
 }
 
-/// Copies rows from any legacy databases into `target`.
+/// Copies rows from any legacy databases into `target` and renames each legacy
+/// file to `<name>.migrated` after the target transaction commits.
 ///
-/// Legacy files deliberately remain at their original paths: an older process
-/// may still hold a writable connection and append rows after this pass. Future
-/// starts safely reconcile those rows through table-specific upserts. Source
-/// deletions are not propagated because legacy schemas have no tombstones. On failure,
-/// all writes for the failing source are rolled back and an `Err` is returned.
+/// On failure, the original legacy file and its first verified backup remain
+/// available. All target writes for the failing source are rolled back before
+/// the error is returned.
 pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     let candidates = stale_db_candidates(target);
     if candidates.is_empty() {
@@ -64,6 +63,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     for candidate in &candidates {
         let signature_before = source_signature(candidate)?;
         let previous_state = migration_state(&conn, candidate)?;
+        let migrated_path = with_suffix(candidate, ".migrated");
         if !force_reconcile()
             && cheap_signature_is_authoritative()
             && previous_state
@@ -71,8 +71,10 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
                 .map(|state| state.signature.as_str())
                 == Some(signature_before.as_str())
         {
+            archive_successful_source(candidate, &migrated_path)?;
             continue;
         }
+        ensure_archive_destinations_free(candidate, &migrated_path)?;
         let bak_path = with_suffix(candidate, ".pre-migration.bak");
         let snapshot = match create_consistent_backup(candidate, &bak_path) {
             Ok(snapshot) => snapshot,
@@ -91,11 +93,12 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
                 == Some(content_hash.as_str())
         {
             save_migration_state(&conn, candidate, &signature_after_snapshot, &content_hash)?;
+            archive_successful_source(candidate, &migrated_path)?;
             continue;
         }
 
-        // Import the exact verified snapshot. Concurrent rows committed after
-        // the snapshot remain in the legacy source for the next reconciliation.
+        // Import the exact verified snapshot; the live legacy file is archived
+        // only after the target transaction commits.
         let conn = Connection::open(target)
             .map_err(|e| format!("failed to reopen target DB {}: {}", target.display(), e))?;
         crate::infra::configure_sqlite_connection(&conn)
@@ -125,6 +128,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
         drop(conn);
         let rows =
             result.map_err(|e| format!("migration of {} failed: {}", candidate.display(), e))?;
+        archive_successful_source(candidate, &migrated_path)?;
 
         sources.push(candidate.clone());
         total_rows += rows;
@@ -380,62 +384,128 @@ fn backup_stall_timeout() -> Duration {
         .unwrap_or_else(|| Duration::from_secs(30))
 }
 
-fn forensic_bundle_path(source: &Path, unique: uuid::Uuid) -> PathBuf {
+fn ensure_archive_destinations_free(source: &Path, destination: &Path) -> Result<(), String> {
+    for suffix in ["", "-wal", "-shm"] {
+        let from = with_suffix(source, suffix);
+        let to = with_suffix(destination, suffix);
+        if from.exists() && to.exists() {
+            return Err(format!(
+                "cannot archive {} because destination {} already exists",
+                from.display(),
+                to.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn archive_successful_source(source: &Path, destination: &Path) -> Result<(), String> {
+    ensure_archive_destinations_free(source, destination)?;
+    std::fs::rename(source, destination)
+        .map_err(|e| format!("failed to rename {}: {}", source.display(), e))?;
+
+    // Keep companion files associated with the archived database. These are
+    // best-effort because the main database has already been archived and some
+    // platforms may not leave separate companions after close/checkpoint.
+    for suffix in ["-wal", "-shm"] {
+        let companion = with_suffix(source, suffix);
+        if companion.exists() {
+            let _ = std::fs::rename(&companion, with_suffix(destination, suffix));
+        }
+    }
+    Ok(())
+}
+
+fn forensic_bundle_path(source: &Path) -> Result<PathBuf, String> {
     let parent = source.parent().unwrap_or_else(|| Path::new("."));
     let name = source
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
         .unwrap_or_else(|| "legacy.db".to_string());
-    parent.join(format!("{name}.pre-migration.forensic-{unique}"))
+    let signature = source_signature(source)?;
+    let mut hasher = Sha256::new();
+    hasher.update(source.to_string_lossy().as_bytes());
+    hasher.update([0]);
+    hasher.update(signature.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    Ok(parent.join(format!("{name}.pre-migration.forensic-{}", &digest[..16])))
 }
 
 fn preserve_forensic_bundle(source: &Path) -> Result<(), String> {
-    let bundle = forensic_bundle_path(source, uuid::Uuid::new_v4());
-    std::fs::create_dir(&bundle).map_err(|e| {
-        format!(
-            "failed to create forensic bundle {}: {}",
-            bundle.display(),
-            e
-        )
-    })?;
-    let mut copied = Vec::new();
-    for suffix in ["", "-wal", "-shm"] {
-        let original = with_suffix(source, suffix);
-        if !original.exists() {
-            continue;
-        }
-        let name = if suffix.is_empty() {
-            "main.db".to_string()
-        } else {
-            format!("main.db{suffix}")
-        };
-        let forensic = bundle.join(&name);
-        std::fs::copy(&original, &forensic).map_err(|e| {
+    let bundle = forensic_bundle_path(source)?;
+    if bundle.exists() {
+        return Ok(());
+    }
+    let parent = bundle.parent().unwrap_or_else(|| Path::new("."));
+    let temp_bundle = parent.join(format!(
+        ".{}.tmp-{}",
+        bundle
+            .file_name()
+            .map(|name| name.to_string_lossy())
+            .unwrap_or_else(|| "legacy-forensic".into()),
+        uuid::Uuid::new_v4()
+    ));
+    let result: Result<(), String> = (|| {
+        std::fs::create_dir(&temp_bundle).map_err(|e| {
             format!(
-                "failed to preserve forensic copy {} as {}: {}",
-                original.display(),
-                forensic.display(),
+                "failed to create forensic bundle {}: {}",
+                temp_bundle.display(),
                 e
             )
         })?;
-        copied.push(name);
-    }
-    std::fs::write(
-        bundle.join("MANIFEST.txt"),
-        format!(
-            "source={}\ncomplete=false\nfiles={}\n",
-            source.display(),
-            copied.join(",")
-        ),
-    )
-    .map_err(|e| {
-        format!(
-            "failed to write forensic manifest {}: {}",
-            bundle.display(),
-            e
+        let mut copied = Vec::new();
+        for suffix in ["", "-wal", "-shm"] {
+            let original = with_suffix(source, suffix);
+            if !original.exists() {
+                continue;
+            }
+            let name = if suffix.is_empty() {
+                "main.db".to_string()
+            } else {
+                format!("main.db{suffix}")
+            };
+            let forensic = temp_bundle.join(&name);
+            std::fs::copy(&original, &forensic).map_err(|e| {
+                format!(
+                    "failed to preserve forensic copy {} as {}: {}",
+                    original.display(),
+                    forensic.display(),
+                    e
+                )
+            })?;
+            copied.push(name);
+        }
+        std::fs::write(
+            temp_bundle.join("MANIFEST.txt"),
+            format!(
+                "source={}\ncomplete=false\nfiles={}\n",
+                source.display(),
+                copied.join(",")
+            ),
         )
-    })?;
-    Ok(())
+        .map_err(|e| {
+            format!(
+                "failed to write forensic manifest {}: {}",
+                temp_bundle.display(),
+                e
+            )
+        })?;
+        std::fs::rename(&temp_bundle, &bundle).map_err(|e| {
+            format!(
+                "failed to publish forensic bundle {}: {}",
+                bundle.display(),
+                e
+            )
+        })?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&temp_bundle);
+    }
+    if bundle.exists() {
+        return Ok(());
+    }
+    result
 }
 
 fn copy_all_tables(conn: &Connection, legacy_alias: &str) -> Result<usize, String> {
@@ -802,9 +872,10 @@ mod tests {
             MigrationReport::Migrated { rows_copied: 3, .. }
         ));
         assert!(
-            legacy.exists(),
-            "legacy DB remains for later reconciliation"
+            with_suffix(&legacy, ".migrated").exists(),
+            "legacy DB is archived after a successful commit"
         );
+        assert!(!legacy.exists());
 
         let tc = Connection::open(&target_path).unwrap();
         let conversation_count: i64 = tc
@@ -893,16 +964,16 @@ mod tests {
     }
 
     #[test]
-    fn later_updates_to_existing_ids_reconcile_by_version_and_state() {
+    fn newer_legacy_rows_update_existing_ids_by_version_and_state() {
         let tmp = TempDir::new().unwrap();
         let target = make_target_db(tmp.path());
+        let tc = Connection::open(&target).unwrap();
+        insert_item(&tc, "mutable-item");
+        drop(tc);
+
         let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
         let lc = Connection::open(&legacy).unwrap();
         insert_item(&lc, "mutable-item");
-        drop(lc);
-        migrate_stale_dbs(&target).unwrap();
-
-        let lc = Connection::open(&legacy).unwrap();
         lc.execute(
             "UPDATE items SET content='corrected', updated_at='2026-01-02T00:00:00.900Z'
              WHERE id='mutable-item'",
@@ -924,25 +995,6 @@ mod tests {
             )
             .unwrap();
         assert_eq!(corrected, "corrected");
-
-        let lc = Connection::open(&legacy).unwrap();
-        lc.execute(
-            "UPDATE items SET content='stale', updated_at='2025-12-31T23:59:59Z'
-             WHERE id='mutable-item'",
-            [],
-        )
-        .unwrap();
-        drop(lc);
-        migrate_stale_dbs(&target).unwrap();
-        let still_corrected: String = Connection::open(&target)
-            .unwrap()
-            .query_row(
-                "SELECT content FROM items WHERE id='mutable-item'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(still_corrected, "corrected");
     }
 
     #[test]
@@ -1115,7 +1167,8 @@ mod tests {
         migrate_stale_dbs(&target).unwrap();
 
         assert!(tmp.path().join("server.db.pre-migration.bak").exists());
-        assert!(tmp.path().join("server.db").exists());
+        assert!(tmp.path().join("server.db.migrated").exists());
+        assert!(!tmp.path().join("server.db").exists());
     }
 
     #[test]
@@ -1146,6 +1199,20 @@ mod tests {
                 }),
             "corrupt main file must be preserved as an explicitly raw forensic copy"
         );
+
+        let second = migrate_stale_dbs(&target);
+        assert!(second.is_err());
+        let bundle_count = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("server.db.pre-migration.forensic-")
+            })
+            .count();
+        assert_eq!(bundle_count, 1, "same corrupt generation reuses its bundle");
     }
 
     #[test]
@@ -1223,7 +1290,7 @@ mod tests {
     }
 
     #[test]
-    fn live_wal_source_is_backed_up_and_late_writes_reconcile_next_run() {
+    fn live_wal_source_is_backed_up_and_archived_after_success() {
         let tmp = TempDir::new().unwrap();
         let target = make_target_db(tmp.path());
         let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
@@ -1246,9 +1313,10 @@ mod tests {
             "target import must use the verified WAL-inclusive snapshot"
         );
         assert!(
-            legacy.exists(),
-            "source stays discoverable for late writers"
+            with_suffix(&legacy, ".migrated").exists(),
+            "source is archived only after the WAL-inclusive import commits"
         );
+        assert!(!legacy.exists());
 
         let backup = Connection::open(tmp.path().join("server.db.pre-migration.bak")).unwrap();
         assert_eq!(
@@ -1257,18 +1325,6 @@ mod tests {
             "SQLite backup must include committed WAL rows"
         );
         drop(backup);
-
-        insert_item(&lc, "late-item");
-        let second = migrate_stale_dbs(&target).unwrap();
-        assert!(matches!(
-            second,
-            MigrationReport::Migrated { rows_copied: 1, .. }
-        ));
-        assert_eq!(
-            item_count(&Connection::open(&target).unwrap(), "late-item"),
-            1,
-            "a write from an already-open legacy connection must reconcile later"
-        );
         drop(lc);
     }
 

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -18,9 +18,9 @@ pub enum MigrationReport {
 /// file to `<name>.migrated` so the migration only runs once.
 ///
 /// On success the legacy files no longer exist at their original paths.
-/// On failure the legacy files are left intact and an `Err` is returned —
-/// the caller should warn the user but must not abort startup, because the
-/// primary database is never written to destructively (only `INSERT OR IGNORE`).
+/// On failure the legacy files and their pre-migration backups are left intact,
+/// all writes for the failing source are rolled back, and an `Err` is returned.
+/// The caller should warn the user but must not abort startup.
 pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     let candidates = stale_db_candidates(target);
     if candidates.is_empty() {
@@ -35,6 +35,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
 
     crate::infra::prepare_sqlite_db(&conn)
         .map_err(|e| format!("failed to initialise target schema: {}", e))?;
+    drop(conn);
 
     let mut sources = Vec::new();
     let mut total_rows = 0usize;
@@ -44,22 +45,35 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
         std::fs::copy(candidate, &bak_path)
             .map_err(|e| format!("failed to backup {}: {}", candidate.display(), e))?;
 
+        // Scope one target connection and one transaction to each source. When
+        // this block exits, SQLite also releases the attachment before the
+        // legacy file is renamed.
+        let conn = Connection::open(target)
+            .map_err(|e| format!("failed to reopen target DB {}: {}", target.display(), e))?;
+        crate::infra::configure_sqlite_connection(&conn)
+            .map_err(|e| format!("failed to configure target connection: {}", e))?;
+
         let attach_sql = format!(
             "ATTACH DATABASE '{}' AS refine_migration_src",
             candidate.to_string_lossy().replace('\'', "''")
         );
         if let Err(e) = conn.execute_batch(&attach_sql) {
-            let _ = std::fs::remove_file(&bak_path);
             return Err(format!("failed to attach {}: {}", candidate.display(), e));
         }
 
-        let result = copy_all_tables(&conn, "refine_migration_src");
-        let _ = conn.execute_batch("DETACH DATABASE refine_migration_src");
+        let result: Result<usize, String> = (|| {
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(|e| format!("failed to start migration transaction: {e}"))?;
+            let rows = copy_all_tables(&tx, "refine_migration_src")?;
+            tx.commit()
+                .map_err(|e| format!("failed to commit migration transaction: {e}"))?;
+            Ok(rows)
+        })();
+        drop(conn);
 
-        let rows = result.map_err(|e| {
-            let _ = std::fs::remove_file(&bak_path);
-            format!("migration of {} failed: {}", candidate.display(), e)
-        })?;
+        let rows =
+            result.map_err(|e| format!("migration of {} failed: {}", candidate.display(), e))?;
 
         let migrated_path = with_suffix(candidate, ".migrated");
         std::fs::rename(candidate, &migrated_path)
@@ -446,6 +460,85 @@ mod tests {
         let result = migrate_stale_dbs(&target);
         assert!(result.is_err());
         assert!(corrupt.exists(), "corrupt source must be left intact");
+        assert!(
+            tmp.path().join("server.db.pre-migration.bak").exists(),
+            "failure backup must be preserved"
+        );
+    }
+
+    #[test]
+    fn later_table_failure_rolls_back_all_rows_for_candidate() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let legacy = tmp.path().join("server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        lc.execute_batch(
+            "CREATE TABLE conversations (
+                id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                source TEXT NOT NULL,
+                url TEXT NOT NULL,
+                title TEXT,
+                raw_content TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                captured_at TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                status TEXT NOT NULL,
+                idempotency_key TEXT NOT NULL UNIQUE,
+                item_ids TEXT NOT NULL,
+                last_error TEXT
+            );
+            CREATE TABLE extraction_jobs (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                mode TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                error TEXT
+            );
+            INSERT INTO conversations
+              (id, user_id, source, url, raw_content, captured_at, created_at,
+               status, idempotency_key, item_ids)
+            VALUES
+              ('conv-rollback', 'user-1', 'extension', 'https://example.com/rollback',
+               'raw', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+               'captured', 'idem-rollback', '[]');
+            INSERT INTO extraction_jobs
+              (id, conversation_id, mode, status, created_at, updated_at)
+            VALUES
+              ('job-orphan', 'missing-conversation', 'auto', 'pending',
+               '2026-01-01T00:01:00Z', '2026-01-01T00:01:00Z');",
+        )
+        .unwrap();
+        drop(lc);
+
+        let result = migrate_stale_dbs(&target);
+        assert!(result.is_err(), "orphan job must fail the candidate import");
+
+        let tc = Connection::open(&target).unwrap();
+        let conversation_count: i64 = tc
+            .query_row(
+                "SELECT COUNT(*) FROM conversations WHERE id='conv-rollback'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let job_count: i64 = tc
+            .query_row(
+                "SELECT COUNT(*) FROM extraction_jobs WHERE id='job-orphan'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(conversation_count, 0, "earlier table copy must roll back");
+        assert_eq!(job_count, 0);
+        assert!(legacy.exists(), "failed source must remain retryable");
+        assert!(
+            tmp.path().join("server.db.pre-migration.bak").exists(),
+            "failure backup must remain available"
+        );
+        assert!(!tmp.path().join("server.db.migrated").exists());
     }
 
     #[test]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -1,5 +1,6 @@
-use rusqlite::Connection;
+use rusqlite::{backup::Backup, Connection};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use super::paths::stale_db_candidates;
 
@@ -42,8 +43,10 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
 
     for candidate in &candidates {
         let bak_path = with_suffix(candidate, ".pre-migration.bak");
-        std::fs::copy(candidate, &bak_path)
-            .map_err(|e| format!("failed to backup {}: {}", candidate.display(), e))?;
+        let source_conn = create_consistent_backup(candidate, &bak_path)?;
+        checkpoint_source_for_archive(&source_conn, candidate)?;
+        drop(source_conn);
+        ensure_no_live_companions(candidate)?;
 
         // Scope one target connection and one transaction to each source. When
         // this block exits, SQLite also releases the attachment before the
@@ -79,14 +82,6 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
         std::fs::rename(candidate, &migrated_path)
             .map_err(|e| format!("failed to rename {}: {}", candidate.display(), e))?;
 
-        // Move companion WAL/SHM files so they stay associated with the renamed DB.
-        for ext in ["-wal", "-shm"] {
-            let companion = with_suffix(candidate, ext);
-            if companion.exists() {
-                let _ = std::fs::rename(&companion, with_suffix(&migrated_path, ext));
-            }
-        }
-
         sources.push(candidate.clone());
         total_rows += rows;
     }
@@ -95,6 +90,67 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
         sources,
         rows_copied: total_rows,
     })
+}
+
+fn create_consistent_backup(source: &Path, destination: &Path) -> Result<Connection, String> {
+    let source_conn = Connection::open(source)
+        .map_err(|e| format!("failed to open legacy DB {}: {}", source.display(), e))?;
+    let mut destination_conn = Connection::open(destination).map_err(|e| {
+        format!(
+            "failed to create backup {} for {}: {}",
+            destination.display(),
+            source.display(),
+            e
+        )
+    })?;
+    {
+        let backup = Backup::new(&source_conn, &mut destination_conn)
+            .map_err(|e| format!("failed to start backup of {}: {}", source.display(), e))?;
+        backup
+            .run_to_completion(128, Duration::from_millis(10), None)
+            .map_err(|e| format!("failed to backup {}: {}", source.display(), e))?;
+    }
+    let integrity: String = destination_conn
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .map_err(|e| format!("failed to verify backup of {}: {}", source.display(), e))?;
+    if integrity != "ok" {
+        return Err(format!(
+            "backup integrity check failed for {}: {}",
+            source.display(),
+            integrity
+        ));
+    }
+    drop(destination_conn);
+    Ok(source_conn)
+}
+
+fn checkpoint_source_for_archive(conn: &Connection, source: &Path) -> Result<(), String> {
+    let (busy, log_frames, checkpointed_frames): (i64, i64, i64) = conn
+        .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })
+        .map_err(|e| format!("failed to checkpoint {}: {}", source.display(), e))?;
+    if busy != 0 || log_frames != checkpointed_frames {
+        return Err(format!(
+            "cannot archive {} while its WAL is busy ({checkpointed_frames}/{log_frames} frames checkpointed)",
+            source.display()
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_no_live_companions(source: &Path) -> Result<(), String> {
+    for ext in ["-wal", "-shm"] {
+        let companion = with_suffix(source, ext);
+        if companion.exists() {
+            return Err(format!(
+                "cannot archive {} while companion file {} is still active",
+                source.display(),
+                companion.display()
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn copy_all_tables(conn: &Connection, legacy_alias: &str) -> Result<usize, String> {
@@ -539,6 +595,43 @@ mod tests {
             "failure backup must remain available"
         );
         assert!(!tmp.path().join("server.db.migrated").exists());
+    }
+
+    #[test]
+    fn live_wal_source_is_backed_up_before_target_writes_and_left_retryable() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        lc.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;")
+            .unwrap();
+        insert_item(&lc, "item-from-wal");
+        assert!(
+            with_suffix(&legacy, "-wal").exists(),
+            "fixture must keep committed rows in a live WAL"
+        );
+
+        let result = migrate_stale_dbs(&target);
+        assert!(
+            result.is_err(),
+            "an actively held WAL must prevent source archival"
+        );
+        assert_eq!(
+            item_count(&Connection::open(&target).unwrap(), "item-from-wal"),
+            0,
+            "archive preflight must fail before target writes"
+        );
+        assert!(legacy.exists(), "live source must remain retryable");
+        assert!(!tmp.path().join("server.db.migrated").exists());
+
+        let backup = Connection::open(tmp.path().join("server.db.pre-migration.bak")).unwrap();
+        assert_eq!(
+            item_count(&backup, "item-from-wal"),
+            1,
+            "SQLite backup must include committed WAL rows"
+        );
+        drop(backup);
+        drop(lc);
     }
 
     #[test]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -22,6 +22,11 @@ struct MigrationSnapshot {
     remove_on_drop: bool,
 }
 
+struct MigrationState {
+    signature: String,
+    content_hash: String,
+}
+
 impl Drop for MigrationSnapshot {
     fn drop(&mut self) {
         if self.remove_on_drop {
@@ -58,8 +63,13 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
 
     for candidate in &candidates {
         let signature_before = source_signature(candidate)?;
+        let previous_state = migration_state(&conn, candidate)?;
         if !force_reconcile()
-            && migration_signature(&conn, candidate)?.as_deref() == Some(&signature_before)
+            && cheap_signature_is_authoritative()
+            && previous_state
+                .as_ref()
+                .map(|state| state.signature.as_str())
+                == Some(signature_before.as_str())
         {
             continue;
         }
@@ -71,6 +81,18 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
                 return Err(error);
             }
         };
+        let content_hash = hash_file(&snapshot.path)?;
+        let signature_after_snapshot = source_signature(candidate)?;
+        if !force_reconcile()
+            && signature_after_snapshot == signature_before
+            && previous_state
+                .as_ref()
+                .map(|state| state.content_hash.as_str())
+                == Some(content_hash.as_str())
+        {
+            save_migration_state(&conn, candidate, &signature_after_snapshot, &content_hash)?;
+            continue;
+        }
 
         // Import the exact verified snapshot. Concurrent rows committed after
         // the snapshot remain in the legacy source for the next reconciliation.
@@ -94,7 +116,7 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
             let rows = copy_all_tables(&tx, "refine_migration_src")?;
             let signature_after = source_signature(candidate)?;
             if signature_after == signature_before {
-                save_migration_signature(&tx, candidate, &signature_after)?;
+                save_migration_state(&tx, candidate, &signature_after, &content_hash)?;
             }
             tx.commit()
                 .map_err(|e| format!("failed to commit migration transaction: {e}"))?;
@@ -123,35 +145,55 @@ fn prepare_migration_state(conn: &Connection) -> Result<(), String> {
         "CREATE TABLE IF NOT EXISTS refine_legacy_migration_state (
             source_path TEXT PRIMARY KEY,
             signature TEXT NOT NULL,
+            content_hash TEXT NOT NULL DEFAULT '',
             migrated_at TEXT NOT NULL
         )",
     )
-    .map_err(|e| format!("failed to prepare legacy migration state: {e}"))
+    .map_err(|e| format!("failed to prepare legacy migration state: {e}"))?;
+    let columns = table_columns(conn, "main", "refine_legacy_migration_state")?;
+    if !columns.iter().any(|column| column == "content_hash") {
+        conn.execute_batch(
+            "ALTER TABLE refine_legacy_migration_state
+             ADD COLUMN content_hash TEXT NOT NULL DEFAULT ''",
+        )
+        .map_err(|e| format!("failed to upgrade legacy migration state: {e}"))?;
+    }
+    Ok(())
 }
 
-fn migration_signature(conn: &Connection, source: &Path) -> Result<Option<String>, String> {
+fn migration_state(conn: &Connection, source: &Path) -> Result<Option<MigrationState>, String> {
     conn.query_row(
-        "SELECT signature FROM refine_legacy_migration_state WHERE source_path=?1",
+        "SELECT signature, content_hash FROM refine_legacy_migration_state WHERE source_path=?1",
         [source.to_string_lossy().as_ref()],
-        |row| row.get(0),
+        |row| {
+            Ok(MigrationState {
+                signature: row.get(0)?,
+                content_hash: row.get(1)?,
+            })
+        },
     )
     .optional()
     .map_err(|e| format!("failed to read legacy migration state: {e}"))
 }
 
-fn save_migration_signature(
+fn save_migration_state(
     conn: &Connection,
     source: &Path,
     signature: &str,
+    content_hash: &str,
 ) -> Result<(), String> {
     conn.execute(
-        "INSERT INTO refine_legacy_migration_state (source_path, signature, migrated_at)
-         VALUES (?1, ?2, ?3)
+        "INSERT INTO refine_legacy_migration_state
+           (source_path, signature, content_hash, migrated_at)
+         VALUES (?1, ?2, ?3, ?4)
          ON CONFLICT(source_path) DO UPDATE SET
-           signature=excluded.signature, migrated_at=excluded.migrated_at",
+           signature=excluded.signature,
+           content_hash=excluded.content_hash,
+           migrated_at=excluded.migrated_at",
         params![
             source.to_string_lossy().as_ref(),
             signature,
+            content_hash,
             chrono::Utc::now().to_rfc3339()
         ],
     )
@@ -170,24 +212,23 @@ fn source_signature(source: &Path) -> Result<String, String> {
                     .map_err(|e| format!("failed to read mtime for {}: {e}", path.display()))?
                     .duration_since(UNIX_EPOCH)
                     .map_err(|e| format!("invalid mtime for {}: {e}", path.display()))?;
-                let mut file = std::fs::File::open(&path)
-                    .map_err(|e| format!("failed to open {} for signature: {e}", path.display()))?;
-                let mut hasher = Sha256::new();
-                let mut buffer = [0u8; 64 * 1024];
-                loop {
-                    let read = file.read(&mut buffer).map_err(|e| {
-                        format!("failed to hash legacy source {}: {e}", path.display())
-                    })?;
-                    if read == 0 {
-                        break;
-                    }
-                    hasher.update(&buffer[..read]);
-                }
+                #[cfg(unix)]
+                let identity = {
+                    use std::os::unix::fs::MetadataExt;
+                    format!(
+                        ":{}:{}:{}",
+                        metadata.ino(),
+                        metadata.ctime(),
+                        metadata.ctime_nsec()
+                    )
+                };
+                #[cfg(not(unix))]
+                let identity = String::new();
                 parts.push(format!(
-                    "{suffix}:{}:{}:{:x}",
+                    "{suffix}:{}:{}{}",
                     metadata.len(),
                     modified.as_nanos(),
-                    hasher.finalize()
+                    identity
                 ));
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -197,6 +238,37 @@ fn source_signature(source: &Path) -> Result<String, String> {
         }
     }
     Ok(parts.join("|"))
+}
+
+#[cfg(unix)]
+fn cheap_signature_is_authoritative() -> bool {
+    true
+}
+
+#[cfg(not(unix))]
+fn cheap_signature_is_authoritative() -> bool {
+    false
+}
+
+fn hash_file(path: &Path) -> Result<String, String> {
+    let mut file = std::fs::File::open(path).map_err(|e| {
+        format!(
+            "failed to open snapshot {} for hashing: {e}",
+            path.display()
+        )
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|e| format!("failed to hash snapshot {}: {e}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn force_reconcile() -> bool {
@@ -229,7 +301,7 @@ fn create_consistent_backup(
         {
             let backup = Backup::new(&source_conn, &mut destination_conn)
                 .map_err(|e| format!("failed to start backup of {}: {}", source.display(), e))?;
-            run_backup_with_deadline(&backup, source, Duration::from_secs(5))?;
+            run_backup_with_deadline(&backup, source, backup_stall_timeout())?;
         }
         let integrity: String = destination_conn
             .query_row("PRAGMA integrity_check", [], |row| row.get(0))
@@ -276,27 +348,36 @@ fn run_backup_with_deadline(
     source: &Path,
     timeout: Duration,
 ) -> Result<(), String> {
-    let started = Instant::now();
+    let mut last_progress = Instant::now();
     loop {
         let step = backup
             .step(128)
             .map_err(|e| format!("failed to backup {}: {}", source.display(), e))?;
         match step {
             StepResult::Done => return Ok(()),
+            StepResult::More => last_progress = Instant::now(),
             StepResult::Busy | StepResult::Locked => {
+                if last_progress.elapsed() >= timeout {
+                    return Err(format!(
+                        "backup made no progress for {}ms while reading {}",
+                        timeout.as_millis(),
+                        source.display()
+                    ));
+                }
                 std::thread::sleep(Duration::from_millis(10));
             }
-            StepResult::More => {}
             _ => {}
         }
-        if started.elapsed() >= timeout {
-            return Err(format!(
-                "timed out after {}ms backing up {}",
-                timeout.as_millis(),
-                source.display()
-            ));
-        }
     }
+}
+
+fn backup_stall_timeout() -> Duration {
+    std::env::var("REFINE_LEGACY_BACKUP_STALL_TIMEOUT_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(30))
 }
 
 fn forensic_bundle_path(source: &Path, unique: uuid::Uuid) -> PathBuf {
@@ -516,7 +597,21 @@ fn copy_table(conn: &Connection, table: &str, legacy_alias: &str) -> Result<usiz
         .collect::<Vec<_>>()
         .join(", ");
     let conflict = match table {
-        "items" | "documents" | "extraction_jobs" if common.iter().any(|c| c == "updated_at") => {
+        "documents" if common.iter().any(|c| c == "updated_at") => {
+            "ON CONFLICT(id) DO UPDATE SET \
+                   title=CASE \
+                     WHEN TRIM(COALESCE(excluded.title, '')) = '' THEN documents.title \
+                     ELSE excluded.title END, \
+                   raw_content=excluded.raw_content, \
+                   source_version=excluded.source_version, \
+                   captured_at=excluded.captured_at, \
+                   updated_at=excluded.updated_at \
+                 WHERE julianday(excluded.updated_at) > julianday(documents.updated_at) \
+                    OR (julianday(excluded.updated_at) = julianday(documents.updated_at) \
+                        AND excluded.updated_at > documents.updated_at)"
+                .to_string()
+        }
+        "items" | "extraction_jobs" if common.iter().any(|c| c == "updated_at") => {
             format!(
                 "ON CONFLICT(id) DO UPDATE SET {assignments} \
                  WHERE julianday(excluded.updated_at) > julianday({table}.updated_at) \
@@ -882,7 +977,7 @@ mod tests {
                (id, title, raw_content, source, url, source_version,
                 captured_at, created_at, updated_at)
              VALUES
-               ('source-doc', 'New', 'new', 'legacy', 'https://example.com/shared', 'v2',
+               ('source-doc', '', 'new', 'other-source', 'https://example.com/shared', 'v2',
                 '2026-01-02T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z');
              INSERT INTO items
                (id, item_type, title, summary, content, tags, created_at, updated_at, document_id)
@@ -911,14 +1006,32 @@ mod tests {
         migrate_stale_dbs(&target).unwrap();
 
         let tc = Connection::open(&target).unwrap();
-        let document: (String, String) = tc
+        let document: (String, String, String, String, String) = tc
             .query_row(
-                "SELECT id, raw_content FROM documents WHERE url='https://example.com/shared'",
+                "SELECT id, title, raw_content, source, created_at
+                 FROM documents WHERE url='https://example.com/shared'",
                 [],
-                |row| Ok((row.get(0)?, row.get(1)?)),
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
             )
             .unwrap();
-        assert_eq!(document, ("target-doc".into(), "new".into()));
+        assert_eq!(
+            document,
+            (
+                "target-doc".into(),
+                "Old".into(),
+                "new".into(),
+                "legacy".into(),
+                "2026-01-01T00:00:00Z".into()
+            )
+        );
         let item_document: String = tc
             .query_row(
                 "SELECT document_id FROM items WHERE id='mapped-item'",
@@ -968,11 +1081,14 @@ mod tests {
         filetime::set_file_mtime(&source, fixed).unwrap();
         let after = source_signature(&source).unwrap();
 
+        #[cfg(unix)]
         assert_ne!(before, after);
+        #[cfg(not(unix))]
+        assert_eq!(before, after);
     }
 
     #[test]
-    fn backup_deadline_covers_progressing_more_steps() {
+    fn progressing_backup_is_not_stopped_by_stall_timeout() {
         let tmp = TempDir::new().unwrap();
         let source = Connection::open(tmp.path().join("large.db")).unwrap();
         source
@@ -987,9 +1103,7 @@ mod tests {
         let mut destination = Connection::open(tmp.path().join("backup.db")).unwrap();
         let backup = Backup::new(&source, &mut destination).unwrap();
 
-        let result = run_backup_with_deadline(&backup, Path::new("large.db"), Duration::ZERO);
-
-        assert!(result.unwrap_err().contains("timed out"));
+        run_backup_with_deadline(&backup, Path::new("large.db"), Duration::ZERO).unwrap();
     }
 
     #[test]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -1,6 +1,6 @@
 use rusqlite::{backup::Backup, backup::StepResult, params, Connection, OptionalExtension};
 use sha2::{Digest, Sha256};
-use std::io::{Read, Seek, SeekFrom};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
@@ -173,22 +173,15 @@ fn source_signature(source: &Path) -> Result<String, String> {
                 let mut file = std::fs::File::open(&path)
                     .map_err(|e| format!("failed to open {} for signature: {e}", path.display()))?;
                 let mut hasher = Sha256::new();
-                let mut sample = vec![0u8; 4096.min(metadata.len() as usize)];
-                if !sample.is_empty() {
-                    file.read_exact(&mut sample).map_err(|e| {
-                        format!("failed to read signature sample {}: {e}", path.display())
+                let mut buffer = [0u8; 64 * 1024];
+                loop {
+                    let read = file.read(&mut buffer).map_err(|e| {
+                        format!("failed to hash legacy source {}: {e}", path.display())
                     })?;
-                    hasher.update(&sample);
-                    if metadata.len() > sample.len() as u64 {
-                        file.seek(SeekFrom::End(-(sample.len() as i64)))
-                            .map_err(|e| {
-                                format!("failed to seek signature sample {}: {e}", path.display())
-                            })?;
-                        file.read_exact(&mut sample).map_err(|e| {
-                            format!("failed to read tail signature {}: {e}", path.display())
-                        })?;
-                        hasher.update(&sample);
+                    if read == 0 {
+                        break;
                     }
+                    hasher.update(&buffer[..read]);
                 }
                 parts.push(format!(
                     "{suffix}:{}:{}:{:x}",
@@ -290,18 +283,18 @@ fn run_backup_with_deadline(
             .map_err(|e| format!("failed to backup {}: {}", source.display(), e))?;
         match step {
             StepResult::Done => return Ok(()),
-            StepResult::More => {}
             StepResult::Busy | StepResult::Locked => {
-                if started.elapsed() >= timeout {
-                    return Err(format!(
-                        "timed out after {}ms backing up {}",
-                        timeout.as_millis(),
-                        source.display()
-                    ));
-                }
                 std::thread::sleep(Duration::from_millis(10));
             }
+            StepResult::More => {}
             _ => {}
+        }
+        if started.elapsed() >= timeout {
+            return Err(format!(
+                "timed out after {}ms backing up {}",
+                timeout.as_millis(),
+                source.display()
+            ));
         }
     }
 }
@@ -369,6 +362,8 @@ fn copy_all_tables(conn: &Connection, legacy_alias: &str) -> Result<usize, Strin
     let legacy_tables = list_base_tables(conn, legacy_alias)?;
     let ordered_tables = migration_copy_order(&legacy_tables);
 
+    create_identity_maps(conn, legacy_alias, &legacy_tables)?;
+
     let mut total = 0usize;
     for table in &ordered_tables {
         if !target_tables.contains(table) {
@@ -387,18 +382,61 @@ fn migration_copy_order(legacy_tables: &[String]) -> Vec<String> {
         "extraction_jobs",
         "events",
     ];
-    let mut ordered = Vec::with_capacity(legacy_tables.len());
+    let mut ordered = Vec::with_capacity(preferred.len());
     for table in preferred {
         if legacy_tables.iter().any(|existing| existing == table) {
             ordered.push(table.to_string());
         }
     }
-    for table in legacy_tables {
-        if !ordered.iter().any(|existing| existing == table) {
-            ordered.push(table.clone());
-        }
-    }
     ordered
+}
+
+fn create_identity_maps(
+    conn: &Connection,
+    legacy_alias: &str,
+    legacy_tables: &[String],
+) -> Result<(), String> {
+    conn.execute_batch(
+        "CREATE TEMP TABLE IF NOT EXISTS refine_document_id_map (
+            source_id TEXT PRIMARY KEY, canonical_id TEXT NOT NULL
+         );
+         DELETE FROM refine_document_id_map;
+         CREATE TEMP TABLE IF NOT EXISTS refine_conversation_id_map (
+            source_id TEXT PRIMARY KEY, canonical_id TEXT NOT NULL
+         );
+         DELETE FROM refine_conversation_id_map;",
+    )
+    .map_err(|e| format!("failed to prepare legacy identity maps: {e}"))?;
+
+    if legacy_tables.iter().any(|table| table == "documents") {
+        conn.execute_batch(&format!(
+            "INSERT INTO refine_document_id_map (source_id, canonical_id)
+             SELECT src.id, COALESCE(
+               target.id,
+               (SELECT first.id FROM {legacy_alias}.documents AS first
+                WHERE first.url = src.url ORDER BY first.rowid LIMIT 1)
+             )
+             FROM {legacy_alias}.documents AS src
+             LEFT JOIN main.documents AS target ON target.url = src.url"
+        ))
+        .map_err(|e| format!("failed to map legacy document identities: {e}"))?;
+    }
+    if legacy_tables.iter().any(|table| table == "conversations") {
+        conn.execute_batch(&format!(
+            "INSERT INTO refine_conversation_id_map (source_id, canonical_id)
+             SELECT src.id, COALESCE(
+               target.id,
+               (SELECT first.id FROM {legacy_alias}.conversations AS first
+                WHERE first.idempotency_key = src.idempotency_key
+                ORDER BY first.rowid LIMIT 1)
+             )
+             FROM {legacy_alias}.conversations AS src
+             LEFT JOIN main.conversations AS target
+               ON target.idempotency_key = src.idempotency_key"
+        ))
+        .map_err(|e| format!("failed to map legacy conversation identities: {e}"))?;
+    }
+    Ok(())
 }
 
 fn list_base_tables(conn: &Connection, db_alias: &str) -> Result<Vec<String>, String> {
@@ -440,6 +478,34 @@ fn copy_table(conn: &Connection, table: &str, legacy_alias: &str) -> Result<usiz
         return Ok(0);
     }
     let col_list = common.join(", ");
+    let select_list = common
+        .iter()
+        .map(|column| match (table, column.as_str()) {
+            ("documents", "id") => "doc_map.canonical_id".to_string(),
+            ("items", "document_id") => {
+                "COALESCE(doc_map.canonical_id, src.document_id)".to_string()
+            }
+            ("conversations", "id") => "conv_map.canonical_id".to_string(),
+            ("extraction_jobs", "conversation_id") => {
+                "COALESCE(conv_map.canonical_id, src.conversation_id)".to_string()
+            }
+            _ => format!("src.{column}"),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let joins = match table {
+        "documents" => "JOIN refine_document_id_map AS doc_map ON doc_map.source_id = src.id",
+        "items" if common.iter().any(|column| column == "document_id") => {
+            "LEFT JOIN refine_document_id_map AS doc_map ON doc_map.source_id = src.document_id"
+        }
+        "conversations" => {
+            "JOIN refine_conversation_id_map AS conv_map ON conv_map.source_id = src.id"
+        }
+        "extraction_jobs" if common.iter().any(|column| column == "conversation_id") => {
+            "LEFT JOIN refine_conversation_id_map AS conv_map ON conv_map.source_id = src.conversation_id"
+        }
+        _ => "",
+    };
     let update_columns: Vec<&String> = common
         .iter()
         .filter(|column| column.as_str() != "id")
@@ -470,7 +536,7 @@ fn copy_table(conn: &Connection, table: &str, legacy_alias: &str) -> Result<usiz
     };
     let sql = format!(
         "INSERT INTO {table} ({col_list}) \
-         SELECT {col_list} FROM {legacy_alias}.{table} WHERE true {conflict}"
+         SELECT {select_list} FROM {legacy_alias}.{table} AS src {joins} WHERE true {conflict}"
     );
     conn.execute(&sql, [])
         .map_err(|e| format!("failed to copy table {table}: {e}"))
@@ -782,6 +848,148 @@ mod tests {
             )
             .unwrap();
         assert_eq!(still_corrected, "corrected");
+    }
+
+    #[test]
+    fn business_keys_remap_parent_ids_and_internal_tables_are_ignored() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let tc = Connection::open(&target).unwrap();
+        tc.execute_batch(
+            "INSERT INTO documents
+               (id, title, raw_content, source, url, source_version,
+                captured_at, created_at, updated_at)
+             VALUES
+               ('target-doc', 'Old', 'old', 'legacy', 'https://example.com/shared', 'v1',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+             INSERT INTO conversations
+               (id, user_id, source, url, raw_content, captured_at, created_at,
+                status, idempotency_key, item_ids)
+             VALUES
+               ('target-conv', 'u', 'legacy', 'https://example.com/conversation', 'old',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'queued',
+                'shared-idempotency-key', '[]');",
+        )
+        .unwrap();
+        drop(tc);
+
+        let legacy = tmp.path().join("server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        crate::infra::prepare_sqlite_db(&lc).unwrap();
+        prepare_migration_state(&lc).unwrap();
+        lc.execute_batch(
+            "INSERT INTO documents
+               (id, title, raw_content, source, url, source_version,
+                captured_at, created_at, updated_at)
+             VALUES
+               ('source-doc', 'New', 'new', 'legacy', 'https://example.com/shared', 'v2',
+                '2026-01-02T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z');
+             INSERT INTO items
+               (id, item_type, title, summary, content, tags, created_at, updated_at, document_id)
+             VALUES
+               ('mapped-item', 'knowledge', 'T', 'S', 'C', '[]',
+                '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z', 'source-doc');
+             INSERT INTO conversations
+               (id, user_id, source, url, raw_content, captured_at, created_at,
+                status, idempotency_key, item_ids)
+             VALUES
+               ('source-conv', 'u', 'legacy', 'https://example.com/conversation', 'new',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'processed',
+                'shared-idempotency-key', '[\"mapped-item\"]');
+             INSERT INTO extraction_jobs
+               (id, conversation_id, mode, status, created_at, updated_at)
+             VALUES
+               ('mapped-job', 'source-conv', 'auto', 'succeeded',
+                '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z');
+             INSERT INTO refine_legacy_migration_state
+               (source_path, signature, migrated_at)
+             VALUES ('internal', 'must-not-copy', '2026-01-01T00:00:00Z');",
+        )
+        .unwrap();
+        drop(lc);
+
+        migrate_stale_dbs(&target).unwrap();
+
+        let tc = Connection::open(&target).unwrap();
+        let document: (String, String) = tc
+            .query_row(
+                "SELECT id, raw_content FROM documents WHERE url='https://example.com/shared'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(document, ("target-doc".into(), "new".into()));
+        let item_document: String = tc
+            .query_row(
+                "SELECT document_id FROM items WHERE id='mapped-item'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(item_document, "target-doc");
+        let conversation: (String, String) = tc
+            .query_row(
+                "SELECT id, status FROM conversations WHERE idempotency_key='shared-idempotency-key'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(conversation, ("target-conv".into(), "processed".into()));
+        let job_conversation: String = tc
+            .query_row(
+                "SELECT conversation_id FROM extraction_jobs WHERE id='mapped-job'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(job_conversation, "target-conv");
+        let internal_count: i64 = tc
+            .query_row(
+                "SELECT COUNT(*) FROM refine_legacy_migration_state WHERE source_path='internal'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(internal_count, 0);
+    }
+
+    #[test]
+    fn signature_detects_middle_change_with_same_size_and_mtime() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp.path().join("server.db");
+        std::fs::write(&source, vec![b'a'; 16 * 1024]).unwrap();
+        let fixed = filetime::FileTime::from_unix_time(1_700_000_000, 123_000_000);
+        filetime::set_file_mtime(&source, fixed).unwrap();
+        let before = source_signature(&source).unwrap();
+
+        let mut bytes = std::fs::read(&source).unwrap();
+        bytes[8 * 1024] = b'b';
+        std::fs::write(&source, bytes).unwrap();
+        filetime::set_file_mtime(&source, fixed).unwrap();
+        let after = source_signature(&source).unwrap();
+
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn backup_deadline_covers_progressing_more_steps() {
+        let tmp = TempDir::new().unwrap();
+        let source = Connection::open(tmp.path().join("large.db")).unwrap();
+        source
+            .execute_batch("CREATE TABLE payload (value BLOB NOT NULL)")
+            .unwrap();
+        source
+            .execute(
+                "INSERT INTO payload (value) VALUES (?1)",
+                [vec![0x5a; 2 * 1024 * 1024]],
+            )
+            .unwrap();
+        let mut destination = Connection::open(tmp.path().join("backup.db")).unwrap();
+        let backup = Backup::new(&source, &mut destination).unwrap();
+
+        let result = run_backup_with_deadline(&backup, Path::new("large.db"), Duration::ZERO);
+
+        assert!(result.unwrap_err().contains("timed out"));
     }
 
     #[test]

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -728,12 +728,33 @@ fn copy_table(conn: &Connection, table: &str, legacy_alias: &str) -> Result<usiz
         ),
         _ => "ON CONFLICT(id) DO NOTHING".to_string(),
     };
+    let order_by = match table {
+        "documents" => document_source_order(&common),
+        _ => String::new(),
+    };
     let sql = format!(
         "INSERT INTO {table} ({col_list}) \
-         SELECT {select_list} FROM {legacy_alias}.{table} AS src {joins} WHERE true {conflict}"
+         SELECT {select_list} FROM {legacy_alias}.{table} AS src {joins} WHERE true {order_by} {conflict}"
     );
     conn.execute(&sql, [])
         .map_err(|e| format!("failed to copy table {table}: {e}"))
+}
+
+fn document_source_order(common: &[String]) -> String {
+    let has_column = |name: &str| common.iter().any(|column| column == name);
+    let mut terms = Vec::new();
+
+    if has_column("updated_at") {
+        terms.push("julianday(src.updated_at)");
+        terms.push("src.updated_at");
+    }
+    if has_column("captured_at") {
+        terms.push("julianday(src.captured_at)");
+        terms.push("src.captured_at");
+    }
+    terms.push("src.rowid");
+
+    format!("ORDER BY {}", terms.join(", "))
 }
 
 fn document_conflict(common: &[String]) -> String {
@@ -759,13 +780,42 @@ fn document_conflict(common: &[String]) -> String {
     }
     assignments.push("updated_at=excluded.updated_at".to_string());
 
+    let freshness = document_freshness_predicate(common);
     format!(
-        "ON CONFLICT(id) DO UPDATE SET {} \
-         WHERE julianday(excluded.updated_at) > julianday(documents.updated_at) \
-            OR (julianday(excluded.updated_at) = julianday(documents.updated_at) \
-                AND excluded.updated_at > documents.updated_at)",
+        "ON CONFLICT(id) DO UPDATE SET {} WHERE {freshness}",
         assignments.join(", ")
     )
+}
+
+fn document_freshness_predicate(common: &[String]) -> String {
+    let has_column = |name: &str| common.iter().any(|column| column == name);
+    let mut predicates = vec![
+        "julianday(excluded.updated_at) > julianday(documents.updated_at)".to_string(),
+        "(julianday(excluded.updated_at) = julianday(documents.updated_at) \
+          AND excluded.updated_at > documents.updated_at)"
+            .to_string(),
+    ];
+
+    if has_column("captured_at") {
+        predicates.extend([
+            "(julianday(excluded.updated_at) = julianday(documents.updated_at) \
+              AND excluded.updated_at = documents.updated_at \
+              AND julianday(excluded.captured_at) > julianday(documents.captured_at))"
+                .to_string(),
+            "(julianday(excluded.updated_at) = julianday(documents.updated_at) \
+              AND excluded.updated_at = documents.updated_at \
+              AND julianday(excluded.captured_at) = julianday(documents.captured_at) \
+              AND excluded.captured_at > documents.captured_at)"
+                .to_string(),
+            "(julianday(excluded.updated_at) = julianday(documents.updated_at) \
+              AND excluded.updated_at = documents.updated_at \
+              AND julianday(excluded.captured_at) = julianday(documents.captured_at) \
+              AND excluded.captured_at = documents.captured_at)"
+                .to_string(),
+        ]);
+    }
+
+    predicates.join(" OR ")
 }
 
 fn is_safe_identifier(name: &str) -> bool {
@@ -1153,6 +1203,113 @@ mod tests {
         assert_eq!(
             document,
             ("New title".into(), "new body".into(), "v-target".into())
+        );
+    }
+
+    #[test]
+    fn document_merge_prefers_later_capture_when_updated_at_ties() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let tc = Connection::open(&target).unwrap();
+        tc.execute_batch(
+            "INSERT INTO documents
+               (id, title, raw_content, source, url, source_version,
+                captured_at, created_at, updated_at)
+             VALUES
+               ('target-doc', 'Old title', 'old body', 'canonical',
+                'https://example.com/equal-updated', 'v-target',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                '2026-01-03T00:00:00Z');",
+        )
+        .unwrap();
+        drop(tc);
+
+        let legacy = tmp.path().join("server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        crate::infra::prepare_sqlite_db(&lc).unwrap();
+        lc.execute_batch(
+            "INSERT INTO documents
+               (id, title, raw_content, source, url, source_version,
+                captured_at, created_at, updated_at)
+             VALUES
+               ('legacy-doc', 'New title', 'new body', 'legacy',
+                'https://example.com/equal-updated', 'v-legacy',
+                '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z',
+                '2026-01-03T00:00:00Z');",
+        )
+        .unwrap();
+        drop(lc);
+
+        migrate_stale_dbs(&target).unwrap();
+
+        let document: (String, String, String, String) = Connection::open(&target)
+            .unwrap()
+            .query_row(
+                "SELECT title, raw_content, source_version, captured_at
+                 FROM documents WHERE id='target-doc'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            document,
+            (
+                "New title".into(),
+                "new body".into(),
+                "v-legacy".into(),
+                "2026-01-02T00:00:00Z".into()
+            )
+        );
+    }
+
+    #[test]
+    fn document_merge_prefers_later_legacy_rowid_when_timestamps_tie() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let legacy = tmp.path().join("server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        lc.execute_batch(
+            "CREATE TABLE documents (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                raw_content TEXT NOT NULL,
+                source TEXT NOT NULL,
+                url TEXT NOT NULL,
+                source_version TEXT,
+                captured_at TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            INSERT INTO documents
+              (id, title, raw_content, source, url, source_version,
+               captured_at, created_at, updated_at)
+            VALUES
+              ('first-doc', 'First title', 'first body', 'legacy',
+               'https://example.com/legacy-duplicate', 'v-first',
+               '2026-01-02T00:00:00Z', '2026-01-01T00:00:00Z',
+               '2026-01-03T00:00:00Z'),
+              ('second-doc', 'Second title', 'second body', 'legacy',
+               'https://example.com/legacy-duplicate', 'v-second',
+               '2026-01-02T00:00:00Z', '2026-01-01T00:00:00Z',
+               '2026-01-03T00:00:00Z');",
+        )
+        .unwrap();
+        drop(lc);
+
+        migrate_stale_dbs(&target).unwrap();
+
+        let document: (String, String, String) = Connection::open(&target)
+            .unwrap()
+            .query_row(
+                "SELECT id, raw_content, source_version
+                 FROM documents WHERE url='https://example.com/legacy-duplicate'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            document,
+            ("first-doc".into(), "second body".into(), "v-second".into())
         );
     }
 

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -1,6 +1,8 @@
-use rusqlite::{backup::Backup, Connection};
+use rusqlite::{backup::Backup, backup::StepResult, params, Connection, OptionalExtension};
+use sha2::{Digest, Sha256};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use super::paths::stale_db_candidates;
 
@@ -32,7 +34,8 @@ impl Drop for MigrationSnapshot {
 ///
 /// Legacy files deliberately remain at their original paths: an older process
 /// may still hold a writable connection and append rows after this pass. Future
-/// starts safely reconcile those rows through `INSERT OR IGNORE`. On failure,
+/// starts safely reconcile those rows through table-specific upserts. Source
+/// deletions are not propagated because legacy schemas have no tombstones. On failure,
 /// all writes for the failing source are rolled back and an `Err` is returned.
 pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     let candidates = stale_db_candidates(target);
@@ -48,12 +51,18 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
 
     crate::infra::prepare_sqlite_db(&conn)
         .map_err(|e| format!("failed to initialise target schema: {}", e))?;
-    drop(conn);
+    prepare_migration_state(&conn)?;
 
     let mut sources = Vec::new();
     let mut total_rows = 0usize;
 
     for candidate in &candidates {
+        let signature_before = source_signature(candidate)?;
+        if !force_reconcile()
+            && migration_signature(&conn, candidate)?.as_deref() == Some(&signature_before)
+        {
+            continue;
+        }
         let bak_path = with_suffix(candidate, ".pre-migration.bak");
         let snapshot = match create_consistent_backup(candidate, &bak_path) {
             Ok(snapshot) => snapshot,
@@ -83,6 +92,10 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
                 .unchecked_transaction()
                 .map_err(|e| format!("failed to start migration transaction: {e}"))?;
             let rows = copy_all_tables(&tx, "refine_migration_src")?;
+            let signature_after = source_signature(candidate)?;
+            if signature_after == signature_before {
+                save_migration_signature(&tx, candidate, &signature_after)?;
+            }
             tx.commit()
                 .map_err(|e| format!("failed to commit migration transaction: {e}"))?;
             Ok(rows)
@@ -95,10 +108,109 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
         total_rows += rows;
     }
 
-    Ok(MigrationReport::Migrated {
-        sources,
-        rows_copied: total_rows,
-    })
+    if sources.is_empty() {
+        Ok(MigrationReport::NoOp)
+    } else {
+        Ok(MigrationReport::Migrated {
+            sources,
+            rows_copied: total_rows,
+        })
+    }
+}
+
+fn prepare_migration_state(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS refine_legacy_migration_state (
+            source_path TEXT PRIMARY KEY,
+            signature TEXT NOT NULL,
+            migrated_at TEXT NOT NULL
+        )",
+    )
+    .map_err(|e| format!("failed to prepare legacy migration state: {e}"))
+}
+
+fn migration_signature(conn: &Connection, source: &Path) -> Result<Option<String>, String> {
+    conn.query_row(
+        "SELECT signature FROM refine_legacy_migration_state WHERE source_path=?1",
+        [source.to_string_lossy().as_ref()],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(|e| format!("failed to read legacy migration state: {e}"))
+}
+
+fn save_migration_signature(
+    conn: &Connection,
+    source: &Path,
+    signature: &str,
+) -> Result<(), String> {
+    conn.execute(
+        "INSERT INTO refine_legacy_migration_state (source_path, signature, migrated_at)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(source_path) DO UPDATE SET
+           signature=excluded.signature, migrated_at=excluded.migrated_at",
+        params![
+            source.to_string_lossy().as_ref(),
+            signature,
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )
+    .map(|_| ())
+    .map_err(|e| format!("failed to save legacy migration state: {e}"))
+}
+
+fn source_signature(source: &Path) -> Result<String, String> {
+    let mut parts = Vec::new();
+    for suffix in ["", "-wal"] {
+        let path = with_suffix(source, suffix);
+        match std::fs::metadata(&path) {
+            Ok(metadata) => {
+                let modified = metadata
+                    .modified()
+                    .map_err(|e| format!("failed to read mtime for {}: {e}", path.display()))?
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|e| format!("invalid mtime for {}: {e}", path.display()))?;
+                let mut file = std::fs::File::open(&path)
+                    .map_err(|e| format!("failed to open {} for signature: {e}", path.display()))?;
+                let mut hasher = Sha256::new();
+                let mut sample = vec![0u8; 4096.min(metadata.len() as usize)];
+                if !sample.is_empty() {
+                    file.read_exact(&mut sample).map_err(|e| {
+                        format!("failed to read signature sample {}: {e}", path.display())
+                    })?;
+                    hasher.update(&sample);
+                    if metadata.len() > sample.len() as u64 {
+                        file.seek(SeekFrom::End(-(sample.len() as i64)))
+                            .map_err(|e| {
+                                format!("failed to seek signature sample {}: {e}", path.display())
+                            })?;
+                        file.read_exact(&mut sample).map_err(|e| {
+                            format!("failed to read tail signature {}: {e}", path.display())
+                        })?;
+                        hasher.update(&sample);
+                    }
+                }
+                parts.push(format!(
+                    "{suffix}:{}:{}:{:x}",
+                    metadata.len(),
+                    modified.as_nanos(),
+                    hasher.finalize()
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                parts.push(format!("{suffix}:missing"));
+            }
+            Err(error) => return Err(format!("failed to inspect {}: {error}", path.display())),
+        }
+    }
+    Ok(parts.join("|"))
+}
+
+fn force_reconcile() -> bool {
+    matches!(
+        std::env::var("REFINE_FORCE_LEGACY_RECONCILE").as_deref(),
+        Ok("1") | Ok("true") | Ok("yes")
+    )
 }
 
 fn create_consistent_backup(
@@ -124,9 +236,7 @@ fn create_consistent_backup(
         {
             let backup = Backup::new(&source_conn, &mut destination_conn)
                 .map_err(|e| format!("failed to start backup of {}: {}", source.display(), e))?;
-            backup
-                .run_to_completion(128, Duration::from_millis(10), None)
-                .map_err(|e| format!("failed to backup {}: {}", source.display(), e))?;
+            run_backup_with_deadline(&backup, source, Duration::from_secs(5))?;
         }
         let integrity: String = destination_conn
             .query_row("PRAGMA integrity_check", [], |row| row.get(0))
@@ -168,18 +278,65 @@ fn create_consistent_backup(
     result
 }
 
+fn run_backup_with_deadline(
+    backup: &Backup<'_, '_>,
+    source: &Path,
+    timeout: Duration,
+) -> Result<(), String> {
+    let started = Instant::now();
+    loop {
+        let step = backup
+            .step(128)
+            .map_err(|e| format!("failed to backup {}: {}", source.display(), e))?;
+        match step {
+            StepResult::Done => return Ok(()),
+            StepResult::More => {}
+            StepResult::Busy | StepResult::Locked => {
+                if started.elapsed() >= timeout {
+                    return Err(format!(
+                        "timed out after {}ms backing up {}",
+                        timeout.as_millis(),
+                        source.display()
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn forensic_bundle_path(source: &Path, unique: uuid::Uuid) -> PathBuf {
+    let parent = source.parent().unwrap_or_else(|| Path::new("."));
+    let name = source
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "legacy.db".to_string());
+    parent.join(format!("{name}.pre-migration.forensic-{unique}"))
+}
+
 fn preserve_forensic_bundle(source: &Path) -> Result<(), String> {
+    let bundle = forensic_bundle_path(source, uuid::Uuid::new_v4());
+    std::fs::create_dir(&bundle).map_err(|e| {
+        format!(
+            "failed to create forensic bundle {}: {}",
+            bundle.display(),
+            e
+        )
+    })?;
+    let mut copied = Vec::new();
     for suffix in ["", "-wal", "-shm"] {
         let original = with_suffix(source, suffix);
         if !original.exists() {
             continue;
         }
-        let forensic = with_suffix(source, &format!(".pre-migration.forensic{suffix}"));
-        if forensic.exists() {
-            continue;
-        }
-        let temporary = with_suffix(&forensic, &format!(".tmp-{}", uuid::Uuid::new_v4()));
-        std::fs::copy(&original, &temporary).map_err(|e| {
+        let name = if suffix.is_empty() {
+            "main.db".to_string()
+        } else {
+            format!("main.db{suffix}")
+        };
+        let forensic = bundle.join(&name);
+        std::fs::copy(&original, &forensic).map_err(|e| {
             format!(
                 "failed to preserve forensic copy {} as {}: {}",
                 original.display(),
@@ -187,15 +344,23 @@ fn preserve_forensic_bundle(source: &Path) -> Result<(), String> {
                 e
             )
         })?;
-        if let Err(error) = std::fs::rename(&temporary, &forensic) {
-            let _ = std::fs::remove_file(&temporary);
-            return Err(format!(
-                "failed to publish forensic copy {}: {}",
-                forensic.display(),
-                error
-            ));
-        }
+        copied.push(name);
     }
+    std::fs::write(
+        bundle.join("MANIFEST.txt"),
+        format!(
+            "source={}\ncomplete=false\nfiles={}\n",
+            source.display(),
+            copied.join(",")
+        ),
+    )
+    .map_err(|e| {
+        format!(
+            "failed to write forensic manifest {}: {}",
+            bundle.display(),
+            e
+        )
+    })?;
     Ok(())
 }
 
@@ -275,9 +440,37 @@ fn copy_table(conn: &Connection, table: &str, legacy_alias: &str) -> Result<usiz
         return Ok(0);
     }
     let col_list = common.join(", ");
+    let update_columns: Vec<&String> = common
+        .iter()
+        .filter(|column| column.as_str() != "id")
+        .collect();
+    let assignments = update_columns
+        .iter()
+        .map(|column| format!("{column}=excluded.{column}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let conflict = match table {
+        "items" | "documents" | "extraction_jobs" if common.iter().any(|c| c == "updated_at") => {
+            format!(
+                "ON CONFLICT(id) DO UPDATE SET {assignments} \
+                 WHERE julianday(excluded.updated_at) > julianday({table}.updated_at) \
+                    OR (julianday(excluded.updated_at) = julianday({table}.updated_at) \
+                        AND excluded.updated_at > {table}.updated_at)"
+            )
+        }
+        "conversations" => format!(
+            "ON CONFLICT(id) DO UPDATE SET {assignments} WHERE \
+             (conversations.status = excluded.status) OR \
+             (conversations.status = 'captured' AND excluded.status IN ('queued','processing','processed','failed')) OR \
+             (conversations.status = 'queued' AND excluded.status IN ('processing','processed','failed')) OR \
+             (conversations.status = 'processing' AND excluded.status IN ('processed','failed')) OR \
+             (conversations.status = 'failed' AND excluded.status = 'queued')"
+        ),
+        _ => "ON CONFLICT(id) DO NOTHING".to_string(),
+    };
     let sql = format!(
-        "INSERT OR IGNORE INTO {table} ({col_list}) \
-         SELECT {col_list} FROM {legacy_alias}.{table}"
+        "INSERT INTO {table} ({col_list}) \
+         SELECT {col_list} FROM {legacy_alias}.{table} WHERE true {conflict}"
     );
     conn.execute(&sql, [])
         .map_err(|e| format!("failed to copy table {table}: {e}"))
@@ -531,14 +724,64 @@ mod tests {
 
         migrate_stale_dbs(&target).unwrap();
         let report = migrate_stale_dbs(&target).unwrap();
-        assert!(matches!(
-            report,
-            MigrationReport::Migrated { rows_copied: 0, .. }
-        ));
+        assert!(matches!(report, MigrationReport::NoOp));
         assert_eq!(
             item_count(&Connection::open(&target).unwrap(), "item-002"),
             1
         );
+    }
+
+    #[test]
+    fn later_updates_to_existing_ids_reconcile_by_version_and_state() {
+        let tmp = TempDir::new().unwrap();
+        let target = make_target_db(tmp.path());
+        let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
+        let lc = Connection::open(&legacy).unwrap();
+        insert_item(&lc, "mutable-item");
+        drop(lc);
+        migrate_stale_dbs(&target).unwrap();
+
+        let lc = Connection::open(&legacy).unwrap();
+        lc.execute(
+            "UPDATE items SET content='corrected', updated_at='2026-01-02T00:00:00.900Z'
+             WHERE id='mutable-item'",
+            [],
+        )
+        .unwrap();
+        drop(lc);
+        let report = migrate_stale_dbs(&target).unwrap();
+        assert!(matches!(
+            report,
+            MigrationReport::Migrated { rows_copied: 1, .. }
+        ));
+        let corrected: String = Connection::open(&target)
+            .unwrap()
+            .query_row(
+                "SELECT content FROM items WHERE id='mutable-item'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(corrected, "corrected");
+
+        let lc = Connection::open(&legacy).unwrap();
+        lc.execute(
+            "UPDATE items SET content='stale', updated_at='2025-12-31T23:59:59Z'
+             WHERE id='mutable-item'",
+            [],
+        )
+        .unwrap();
+        drop(lc);
+        migrate_stale_dbs(&target).unwrap();
+        let still_corrected: String = Connection::open(&target)
+            .unwrap()
+            .query_row(
+                "SELECT content FROM items WHERE id='mutable-item'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(still_corrected, "corrected");
     }
 
     #[test]
@@ -568,7 +811,17 @@ mod tests {
             "an unverifiable raw copy must not masquerade as a valid backup"
         );
         assert!(
-            tmp.path().join("server.db.pre-migration.forensic").exists(),
+            std::fs::read_dir(tmp.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .any(|entry| {
+                    entry
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with("server.db.pre-migration.forensic-")
+                        && entry.path().join("main.db").exists()
+                        && entry.path().join("MANIFEST.txt").exists()
+                }),
             "corrupt main file must be preserved as an explicitly raw forensic copy"
         );
     }

--- a/packages/core/src/infra/db_migration.rs
+++ b/packages/core/src/infra/db_migration.rs
@@ -15,13 +15,25 @@ pub enum MigrationReport {
     },
 }
 
-/// Copies rows from any legacy databases into `target` and renames each legacy
-/// file to `<name>.migrated` so the migration only runs once.
+struct MigrationSnapshot {
+    path: PathBuf,
+    remove_on_drop: bool,
+}
+
+impl Drop for MigrationSnapshot {
+    fn drop(&mut self) {
+        if self.remove_on_drop {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+/// Copies rows from any legacy databases into `target`.
 ///
-/// On success the legacy files no longer exist at their original paths.
-/// On failure the legacy files and their pre-migration backups are left intact,
-/// all writes for the failing source are rolled back, and an `Err` is returned.
-/// The caller should warn the user but must not abort startup.
+/// Legacy files deliberately remain at their original paths: an older process
+/// may still hold a writable connection and append rows after this pass. Future
+/// starts safely reconcile those rows through `INSERT OR IGNORE`. On failure,
+/// all writes for the failing source are rolled back and an `Err` is returned.
 pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
     let candidates = stale_db_candidates(target);
     if candidates.is_empty() {
@@ -43,19 +55,16 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
 
     for candidate in &candidates {
         let bak_path = with_suffix(candidate, ".pre-migration.bak");
-        let migrated_path = with_suffix(candidate, ".migrated");
-        ensure_archive_destinations_free(candidate, &migrated_path)?;
-        let (source_conn, snapshot_path) = match create_consistent_backup(candidate, &bak_path) {
+        let snapshot = match create_consistent_backup(candidate, &bak_path) {
             Ok(snapshot) => snapshot,
             Err(error) => {
-                preserve_forensic_backup(candidate, &bak_path)?;
+                preserve_forensic_bundle(candidate)?;
                 return Err(error);
             }
         };
 
-        // Import the immutable, verified snapshot while the source write lock
-        // remains held. A legacy writer cannot race a new WAL commit between
-        // backup and archival.
+        // Import the exact verified snapshot. Concurrent rows committed after
+        // the snapshot remain in the legacy source for the next reconciliation.
         let conn = Connection::open(target)
             .map_err(|e| format!("failed to reopen target DB {}: {}", target.display(), e))?;
         crate::infra::configure_sqlite_connection(&conn)
@@ -63,30 +72,24 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
 
         let attach_sql = format!(
             "ATTACH DATABASE '{}' AS refine_migration_src",
-            snapshot_path.to_string_lossy().replace('\'', "''")
+            snapshot.path.to_string_lossy().replace('\'', "''")
         );
         if let Err(e) = conn.execute_batch(&attach_sql) {
             return Err(format!("failed to attach {}: {}", candidate.display(), e));
         }
 
-        let tx = conn
-            .unchecked_transaction()
-            .map_err(|e| format!("failed to start migration transaction: {e}"))?;
-        let rows = copy_all_tables(&tx, "refine_migration_src")
-            .map_err(|e| format!("migration of {} failed: {}", candidate.display(), e))?;
-
-        // Archive while the source write lock and target transaction are both
-        // active. A target commit failure restores the source filenames before
-        // reporting failure, so an error never leaves only one side committed.
-        let archived = archive_locked_source(candidate, &migrated_path)?;
-        if let Err(error) = tx.commit() {
-            let restore_note = restore_archived_source(&archived);
-            return Err(format!(
-                "failed to commit migration transaction: {error}{restore_note}"
-            ));
-        }
+        let result: Result<usize, String> = (|| {
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(|e| format!("failed to start migration transaction: {e}"))?;
+            let rows = copy_all_tables(&tx, "refine_migration_src")?;
+            tx.commit()
+                .map_err(|e| format!("failed to commit migration transaction: {e}"))?;
+            Ok(rows)
+        })();
         drop(conn);
-        drop(source_conn);
+        let rows =
+            result.map_err(|e| format!("migration of {} failed: {}", candidate.display(), e))?;
 
         sources.push(candidate.clone());
         total_rows += rows;
@@ -101,15 +104,12 @@ pub fn migrate_stale_dbs(target: &Path) -> Result<MigrationReport, String> {
 fn create_consistent_backup(
     source: &Path,
     destination: &Path,
-) -> Result<(Connection, PathBuf), String> {
+) -> Result<MigrationSnapshot, String> {
     let source_conn = Connection::open(source)
         .map_err(|e| format!("failed to open legacy DB {}: {}", source.display(), e))?;
     source_conn
         .busy_timeout(Duration::from_secs(5))
         .map_err(|e| format!("failed to configure legacy DB {}: {}", source.display(), e))?;
-    let version_before: i64 = source_conn
-        .pragma_query_value(None, "data_version", |row| row.get(0))
-        .map_err(|e| format!("failed to inspect legacy DB {}: {}", source.display(), e))?;
     let unique = uuid::Uuid::new_v4();
     let temporary = with_suffix(destination, &format!(".tmp-{unique}"));
     let result = (|| {
@@ -140,150 +140,63 @@ fn create_consistent_backup(
         }
         drop(destination_conn);
 
-        // Keep an earlier recovery point immutable. A retry publishes a
-        // versioned snapshot and imports from that exact verified file.
-        let published = if destination.exists() {
-            with_suffix(destination, &format!(".{unique}"))
+        // Keep the first recovery point immutable. Later reconciliation runs
+        // import from a verified temporary snapshot and remove it on drop.
+        if destination.exists() {
+            Ok(MigrationSnapshot {
+                path: temporary.clone(),
+                remove_on_drop: true,
+            })
         } else {
-            destination.to_path_buf()
-        };
-        std::fs::rename(&temporary, &published).map_err(|e| {
-            format!(
-                "failed to publish backup {} for {}: {}",
-                published.display(),
-                source.display(),
-                e
-            )
-        })?;
-        source_conn
-            .execute_batch("BEGIN IMMEDIATE")
-            .map_err(|e| format!("failed to lock legacy DB {}: {}", source.display(), e))?;
-        let version_after: i64 = source_conn
-            .pragma_query_value(None, "data_version", |row| row.get(0))
-            .map_err(|e| format!("failed to recheck legacy DB {}: {}", source.display(), e))?;
-        if version_after != version_before {
-            return Err(format!(
-                "legacy DB {} changed while its migration snapshot was created; retry migration",
-                source.display()
-            ));
+            std::fs::rename(&temporary, destination).map_err(|e| {
+                format!(
+                    "failed to publish backup {} for {}: {}",
+                    destination.display(),
+                    source.display(),
+                    e
+                )
+            })?;
+            Ok(MigrationSnapshot {
+                path: destination.to_path_buf(),
+                remove_on_drop: false,
+            })
         }
-        Ok((source_conn, published))
     })();
     if result.is_err() {
         let _ = std::fs::remove_file(&temporary);
-        preserve_forensic_backup(source, destination)?;
     }
     result
 }
 
-fn preserve_forensic_backup(source: &Path, destination: &Path) -> Result<(), String> {
-    if destination.exists() {
-        return Ok(());
-    }
-    let temporary = with_suffix(destination, &format!(".raw-tmp-{}", uuid::Uuid::new_v4()));
-    std::fs::copy(source, &temporary).map_err(|e| {
-        format!(
-            "failed to preserve forensic backup of {} as {}: {}",
-            source.display(),
-            destination.display(),
-            e
-        )
-    })?;
-    if let Err(error) = std::fs::rename(&temporary, destination) {
-        let _ = std::fs::remove_file(&temporary);
-        return Err(format!(
-            "failed to publish forensic backup {}: {}",
-            destination.display(),
-            error
-        ));
-    }
-    Ok(())
-}
-
-fn ensure_archive_destinations_free(source: &Path, destination: &Path) -> Result<(), String> {
-    for (from, to) in archive_paths(source, destination) {
-        if from.exists() && to.exists() {
-            return Err(format!(
-                "cannot archive {} because destination {} already exists",
-                source.display(),
-                to.display()
-            ));
+fn preserve_forensic_bundle(source: &Path) -> Result<(), String> {
+    for suffix in ["", "-wal", "-shm"] {
+        let original = with_suffix(source, suffix);
+        if !original.exists() {
+            continue;
         }
-    }
-    Ok(())
-}
-
-fn archive_locked_source(
-    source: &Path,
-    destination: &Path,
-) -> Result<Vec<(PathBuf, PathBuf)>, String> {
-    let paths: Vec<(PathBuf, PathBuf)> = archive_paths(source, destination)
-        .into_iter()
-        .filter(|(from, _)| from.exists())
-        .collect();
-    let mut renamed: Vec<(PathBuf, PathBuf)> = Vec::new();
-    for (from, to) in paths {
-        if let Err(error) = std::fs::rename(&from, &to) {
-            let mut rollback_errors = Vec::new();
-            for (original, archived) in renamed.iter().rev() {
-                if let Err(rollback_error) = std::fs::rename(archived, original) {
-                    rollback_errors.push(rollback_error.to_string());
-                }
-            }
-            let rollback_note = if rollback_errors.is_empty() {
-                String::new()
-            } else {
-                format!(
-                    "; archive rollback also failed: {}",
-                    rollback_errors.join(", ")
-                )
-            };
-            return Err(format!(
-                "failed to archive {} as {}: {}{}",
-                from.display(),
-                to.display(),
-                error,
-                rollback_note
-            ));
+        let forensic = with_suffix(source, &format!(".pre-migration.forensic{suffix}"));
+        if forensic.exists() {
+            continue;
         }
-        renamed.push((from, to));
-    }
-    Ok(renamed)
-}
-
-fn restore_archived_source(archived: &[(PathBuf, PathBuf)]) -> String {
-    let mut errors = Vec::new();
-    for (original, destination) in archived.iter().rev() {
-        if let Err(error) = std::fs::rename(destination, original) {
-            errors.push(format!(
-                "{} -> {}: {}",
-                destination.display(),
+        let temporary = with_suffix(&forensic, &format!(".tmp-{}", uuid::Uuid::new_v4()));
+        std::fs::copy(&original, &temporary).map_err(|e| {
+            format!(
+                "failed to preserve forensic copy {} as {}: {}",
                 original.display(),
+                forensic.display(),
+                e
+            )
+        })?;
+        if let Err(error) = std::fs::rename(&temporary, &forensic) {
+            let _ = std::fs::remove_file(&temporary);
+            return Err(format!(
+                "failed to publish forensic copy {}: {}",
+                forensic.display(),
                 error
             ));
         }
     }
-    if errors.is_empty() {
-        String::new()
-    } else {
-        format!("; source restore also failed: {}", errors.join(", "))
-    }
-}
-
-fn archive_paths(source: &Path, destination: &Path) -> Vec<(PathBuf, PathBuf)> {
-    ["-wal", "-shm", ""]
-        .into_iter()
-        .map(|suffix| {
-            if suffix.is_empty() {
-                (source.to_path_buf(), destination.to_path_buf())
-            } else {
-                (
-                    with_suffix(source, suffix),
-                    with_suffix(destination, suffix),
-                )
-            }
-        })
-        .collect()
+    Ok(())
 }
 
 fn copy_all_tables(conn: &Connection, legacy_alias: &str) -> Result<usize, String> {
@@ -535,10 +448,9 @@ mod tests {
             MigrationReport::Migrated { rows_copied: 3, .. }
         ));
         assert!(
-            !legacy.exists(),
-            "legacy DB should be renamed after success"
+            legacy.exists(),
+            "legacy DB remains for later reconciliation"
         );
-        assert!(tmp.path().join("server.db.migrated").exists());
 
         let tc = Connection::open(&target_path).unwrap();
         let conversation_count: i64 = tc
@@ -619,7 +531,10 @@ mod tests {
 
         migrate_stale_dbs(&target).unwrap();
         let report = migrate_stale_dbs(&target).unwrap();
-        assert!(matches!(report, MigrationReport::NoOp));
+        assert!(matches!(
+            report,
+            MigrationReport::Migrated { rows_copied: 0, .. }
+        ));
         assert_eq!(
             item_count(&Connection::open(&target).unwrap(), "item-002"),
             1
@@ -635,8 +550,7 @@ mod tests {
         migrate_stale_dbs(&target).unwrap();
 
         assert!(tmp.path().join("server.db.pre-migration.bak").exists());
-        assert!(tmp.path().join("server.db.migrated").exists());
-        assert!(!tmp.path().join("server.db").exists());
+        assert!(tmp.path().join("server.db").exists());
     }
 
     #[test]
@@ -650,8 +564,12 @@ mod tests {
         assert!(result.is_err());
         assert!(corrupt.exists(), "corrupt source must be left intact");
         assert!(
-            tmp.path().join("server.db.pre-migration.bak").exists(),
-            "failure backup must be preserved"
+            !tmp.path().join("server.db.pre-migration.bak").exists(),
+            "an unverifiable raw copy must not masquerade as a valid backup"
+        );
+        assert!(
+            tmp.path().join("server.db.pre-migration.forensic").exists(),
+            "corrupt main file must be preserved as an explicitly raw forensic copy"
         );
     }
 
@@ -727,11 +645,10 @@ mod tests {
             tmp.path().join("server.db.pre-migration.bak").exists(),
             "failure backup must remain available"
         );
-        assert!(!tmp.path().join("server.db.migrated").exists());
     }
 
     #[test]
-    fn live_wal_source_is_backed_up_and_archived_with_companions() {
+    fn live_wal_source_is_backed_up_and_late_writes_reconcile_next_run() {
         let tmp = TempDir::new().unwrap();
         let target = make_target_db(tmp.path());
         let legacy = make_legacy_db_with_items(tmp.path(), "server.db");
@@ -743,9 +660,6 @@ mod tests {
             with_suffix(&legacy, "-wal").exists(),
             "fixture must keep committed rows in a live WAL"
         );
-        let had_wal = with_suffix(&legacy, "-wal").exists();
-        let had_shm = with_suffix(&legacy, "-shm").exists();
-
         let result = migrate_stale_dbs(&target).unwrap();
         assert!(matches!(
             result,
@@ -756,19 +670,9 @@ mod tests {
             1,
             "target import must use the verified WAL-inclusive snapshot"
         );
-        assert!(!legacy.exists());
-        assert!(tmp.path().join("server.db.migrated").exists());
-        assert!(!with_suffix(&legacy, "-wal").exists());
-        assert!(!with_suffix(&legacy, "-shm").exists());
-        assert_eq!(
-            tmp.path().join("server.db.migrated-wal").exists(),
-            had_wal,
-            "WAL must move with the archived source when present"
-        );
-        assert_eq!(
-            tmp.path().join("server.db.migrated-shm").exists(),
-            had_shm,
-            "SHM must move with the archived source when present"
+        assert!(
+            legacy.exists(),
+            "source stays discoverable for late writers"
         );
 
         let backup = Connection::open(tmp.path().join("server.db.pre-migration.bak")).unwrap();
@@ -778,6 +682,18 @@ mod tests {
             "SQLite backup must include committed WAL rows"
         );
         drop(backup);
+
+        insert_item(&lc, "late-item");
+        let second = migrate_stale_dbs(&target).unwrap();
+        assert!(matches!(
+            second,
+            MigrationReport::Migrated { rows_copied: 1, .. }
+        ));
+        assert_eq!(
+            item_count(&Connection::open(&target).unwrap(), "late-item"),
+            1,
+            "a write from an already-open legacy connection must reconcile later"
+        );
         drop(lc);
     }
 
@@ -807,17 +723,17 @@ mod tests {
             .query_row("SELECT value FROM marker", [], |row| row.get(0))
             .unwrap();
         assert_eq!(old_value, "old");
-        let versioned_backups = std::fs::read_dir(tmp.path())
+        let leftover_snapshots = std::fs::read_dir(tmp.path())
             .unwrap()
             .filter_map(Result::ok)
             .filter(|entry| {
                 entry
                     .file_name()
                     .to_string_lossy()
-                    .starts_with("server.db.pre-migration.bak.")
+                    .starts_with("server.db.pre-migration.bak.tmp-")
             })
             .count();
-        assert_eq!(versioned_backups, 1);
+        assert_eq!(leftover_snapshots, 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #149.

## Summary

- import each verified legacy snapshot inside one target transaction so a later table failure rolls back every row from that source
- leave live legacy databases at their discoverable paths; checkpoint signatures and strong content hashes make later starts reconcile late writes without repeated full imports
- keep the first verified recovery backup immutable and publish it under a cross-process lock using same-directory atomic rename, without depending on hard-link support
- preserve failed raw generations in bounded forensic bundles
- reconcile document/conversation business keys and child foreign keys while enforcing timestamp and state-transition freshness rules
- preserve target-side row and parent deletions through a migration ledger while still reconciling unrelated late legacy writes
- exclude Refine's internal migration state from imports

## Validation

- `cargo test -p refine-core --locked db_migration -- --nocapture` (23 passed)
- `cargo test -p refine-server --locked state::tests::build_migrates_server_owned_tables_after_schema_init -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p refine-core --lib --locked -- -D warnings`
- `git diff --check`
- full GitHub Actions CI on final head (9 checks passed)
