### PR TITLE
fix: make installed UI pass the server CORS boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           bash scripts/test-cognitive-portrait.sh
           bash scripts/test-llm-env.sh
           bash scripts/test-runtime-wrappers.sh
+          bash scripts/test-local-ui-contract.sh
 
   msrv:
     runs-on: ubuntu-latest

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -445,7 +445,7 @@ mod tests {
 
     #[tokio::test]
     async fn trusted_origin_receives_cors_headers_when_configured() {
-        let trusted_origin = "https://trusted.example";
+        let trusted_origin = "http://127.0.0.1:8987";
         let (_tmp, app) = test_app(
             AuthConfig {
                 api_token: None,
@@ -463,7 +463,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
-            Some(&HeaderValue::from_static("https://trusted.example"))
+            Some(&HeaderValue::from_static("http://127.0.0.1:8987"))
         );
         assert!(response
             .headers()

--- a/scripts/doctor-local.sh
+++ b/scripts/doctor-local.sh
@@ -14,7 +14,11 @@ EOF
 }
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/local-ui-contract.sh
+source "${repo_root}/scripts/local-ui-contract.sh"
 server_url="${REFINE_SERVER_URL:-http://127.0.0.1:21567}"
+ui_url="${REFINE_UI_URL:-$REFINE_INSTALLED_UI_ORIGIN}"
+ui_origin="${REFINE_UI_ORIGIN:-${ui_url%/}}"
 failures=0
 warnings=0
 ui_dev_enabled=1
@@ -323,11 +327,24 @@ check_ui_deps() {
 }
 
 check_ui_http() {
-  local ui_url="${REFINE_UI_URL:-http://127.0.0.1:8987}"
   if curl -fsS --max-time 3 "$ui_url" >/dev/null 2>&1; then
     pass "desktop UI reachable: $ui_url"
   else
     fail "desktop UI unreachable: $ui_url"
+  fi
+}
+
+check_ui_cors() {
+  local headers
+  headers="$(curl -sS --max-time 3 -D - -o /dev/null \
+    -X OPTIONS \
+    -H "Origin: ${ui_origin}" \
+    -H 'Access-Control-Request-Method: GET' \
+    "${server_url}/v1/items" 2>/dev/null || true)"
+  if refine_cors_response_allows_origin "$headers" "$ui_origin"; then
+    pass "server permits desktop UI origin: $ui_origin"
+  else
+    fail "server CORS blocks desktop UI origin: $ui_origin"
   fi
 }
 
@@ -361,6 +378,7 @@ check_logs
 if [[ "$ui_dev_enabled" == "1" ]]; then
   check_ui_deps
   check_ui_http
+  check_ui_cors
 else
   pass "desktop UI dependency check skipped"
 fi

--- a/scripts/doctor-local.sh
+++ b/scripts/doctor-local.sh
@@ -18,7 +18,11 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${repo_root}/scripts/local-ui-contract.sh"
 server_url="${REFINE_SERVER_URL:-http://127.0.0.1:21567}"
 ui_url="${REFINE_UI_URL:-$REFINE_INSTALLED_UI_ORIGIN}"
-ui_origin="${REFINE_UI_ORIGIN:-${ui_url%/}}"
+ui_origin=""
+ui_origin_error=""
+if ! ui_origin="$(refine_url_origin "$ui_url")"; then
+  ui_origin_error="invalid desktop UI URL: $ui_url"
+fi
 failures=0
 warnings=0
 ui_dev_enabled=1
@@ -336,12 +340,19 @@ check_ui_http() {
 
 check_ui_cors() {
   local headers
-  headers="$(curl -sS --max-time 3 -D - -o /dev/null \
+  if [[ -n "$ui_origin_error" ]]; then
+    fail "$ui_origin_error"
+    return
+  fi
+  if ! headers="$(curl -sS --max-time 3 -D - -o /dev/null \
     -X OPTIONS \
     -H "Origin: ${ui_origin}" \
     -H 'Access-Control-Request-Method: GET' \
-    "${server_url}/v1/items" 2>/dev/null || true)"
-  if refine_cors_response_allows_origin "$headers" "$ui_origin"; then
+    "${server_url}/v1/items" 2>/dev/null)"; then
+    fail "server CORS preflight request failed: ${server_url}/v1/items"
+    return
+  fi
+  if refine_cors_preflight_succeeds "$headers" "$ui_origin" GET; then
     pass "server permits desktop UI origin: $ui_origin"
   else
     fail "server CORS blocks desktop UI origin: $ui_origin"

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -30,6 +30,8 @@ EOF
 }
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/local-ui-contract.sh
+source "${repo_root}/scripts/local-ui-contract.sh"
 launchd_enabled=1
 start_services=1
 ui_dev_enabled=1
@@ -125,7 +127,7 @@ write_server_plist() {
   local path="$1"
   local cargo_bin="$2"
   local path_env="$3"
-  local home_xml server_bin_xml wrapper_xml project_env_xml path_xml token_xml=""
+  local home_xml server_bin_xml wrapper_xml project_env_xml path_xml token_xml="" cors_xml=""
   local server_bin="${cargo_bin}/refine-server"
   local wrapper="${repo_root}/scripts/run-refine-server.sh"
   local project_env="${repo_root}/.env"
@@ -142,6 +144,7 @@ write_server_plist() {
     token_xml="<key>REFINE_DEV_ANON</key>
     <string>1</string>"
   fi
+  cors_xml="$(refine_server_trusted_origins_xml "$ui_dev_enabled")"
   server_bin_xml="$(printf '%s' "$server_bin" | xml_escape)"
   wrapper_xml="$(printf '%s' "$wrapper" | xml_escape)"
   project_env_xml="$(printf '%s' "$project_env" | xml_escape)"
@@ -167,6 +170,7 @@ write_server_plist() {
     <key>PATH</key>
     <string>${path_xml}</string>
     ${token_xml}
+${cors_xml}
   </dict>
   <key>RunAtLoad</key>
   <true/>

--- a/scripts/local-ui-contract.sh
+++ b/scripts/local-ui-contract.sh
@@ -13,18 +13,71 @@ refine_server_trusted_origins_xml() {
   fi
 }
 
-refine_cors_response_allows_origin() {
+refine_url_origin() {
+  local url="$1"
+  local scheme authority host port=""
+
+  if [[ "$url" =~ ^([Hh][Tt][Tt][Pp][Ss]?)://([^/?#]+)(/[^?#]*)?(\?[^#]*)?(#.*)?$ ]]; then
+    scheme="$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')"
+    authority="${BASH_REMATCH[2]}"
+  else
+    return 1
+  fi
+  [[ "$authority" != *'@'* && "$authority" != *[$'\t\r\n ']* ]] || return 1
+
+  if [[ "$authority" =~ ^(\[[0-9A-Fa-f:.]+\])(:([0-9]+))?$ ]]; then
+    host="${BASH_REMATCH[1]}"
+    port="${BASH_REMATCH[3]:-}"
+  elif [[ "$authority" =~ ^([A-Za-z0-9._-]+)(:([0-9]+))?$ ]]; then
+    host="${BASH_REMATCH[1]}"
+    port="${BASH_REMATCH[3]:-}"
+  else
+    return 1
+  fi
+  host="$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$scheme" == "http" && "$port" == "80" ]] \
+    || [[ "$scheme" == "https" && "$port" == "443" ]]; then
+    port=""
+  fi
+
+  printf '%s://%s' "$scheme" "$host"
+  [[ -z "$port" ]] || printf ':%s' "$port"
+  printf '\n'
+}
+
+refine_cors_preflight_succeeds() {
   local headers="$1"
   local expected_origin="$2"
-  local actual_origin
-  actual_origin="$(printf '%s\n' "$headers" | awk '
-    tolower($1) == "access-control-allow-origin:" {
-      $1 = ""
-      sub(/^ /, "")
-      sub(/\r$/, "")
-      print
-      exit
-    }
-  ')"
-  [[ "$actual_origin" == "$expected_origin" ]]
+  local expected_method="$3"
+  local line status="" actual_origin="" allowed_methods="" name value token
+
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+    if [[ "$line" =~ ^HTTP/[0-9.]+[[:space:]]+([0-9]{3})([[:space:]]|$) ]]; then
+      # Only the final response block is authoritative (for example after an
+      # intermediary's 100 Continue response).
+      status="${BASH_REMATCH[1]}"
+      actual_origin=""
+      allowed_methods=""
+      continue
+    fi
+    [[ "$line" == *:* ]] || continue
+    name="$(printf '%s' "${line%%:*}" | tr '[:upper:]' '[:lower:]')"
+    value="${line#*:}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    case "$name" in
+      access-control-allow-origin) actual_origin="$value" ;;
+      access-control-allow-methods) allowed_methods="${allowed_methods:+${allowed_methods},}${value}" ;;
+    esac
+  done <<< "$headers"
+
+  [[ "$status" == 2[0-9][0-9] && "$actual_origin" == "$expected_origin" ]] || return 1
+  while IFS= read -r token; do
+    token="${token#"${token%%[![:space:]]*}"}"
+    token="${token%"${token##*[![:space:]]}"}"
+    [[ "$(printf '%s' "$token" | tr '[:lower:]' '[:upper:]')" == "$expected_method" ]] \
+      && return 0
+  done < <(printf '%s' "$allowed_methods" | tr ',' '\n')
+  return 1
 }

--- a/scripts/local-ui-contract.sh
+++ b/scripts/local-ui-contract.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Shared browser boundary for the locally installed Vite UI. Keep the
+# installer and doctor on the same exact origin so a healthy UI cannot be
+# silently blocked by the server's CORS policy.
+REFINE_INSTALLED_UI_ORIGIN="http://127.0.0.1:8987"
+
+refine_server_trusted_origins_xml() {
+  local ui_dev_enabled="$1"
+  if [[ "$ui_dev_enabled" == "1" ]]; then
+    printf '    <key>REFINE_TRUSTED_ORIGINS</key>\n    <string>%s</string>\n' \
+      "$REFINE_INSTALLED_UI_ORIGIN"
+  fi
+}
+
+refine_cors_response_allows_origin() {
+  local headers="$1"
+  local expected_origin="$2"
+  local actual_origin
+  actual_origin="$(printf '%s\n' "$headers" | awk '
+    tolower($1) == "access-control-allow-origin:" {
+      $1 = ""
+      sub(/^ /, "")
+      sub(/\r$/, "")
+      print
+      exit
+    }
+  ')"
+  [[ "$actual_origin" == "$expected_origin" ]]
+}

--- a/scripts/test-local-ui-contract.sh
+++ b/scripts/test-local-ui-contract.sh
@@ -20,17 +20,37 @@ disabled_xml="$(refine_server_trusted_origins_xml 0)"
 [[ -z "$disabled_xml" ]] \
   || fail '--no-ui-dev server plist still emitted a trusted UI origin'
 
-trusted_headers=$'HTTP/1.1 200 OK\r\naccess-control-allow-origin: http://127.0.0.1:8987\r\n\r\n'
-refine_cors_response_allows_origin "$trusted_headers" "$REFINE_INSTALLED_UI_ORIGIN" \
+[[ "$(refine_url_origin 'http://127.0.0.1:8987/dashboard/?tab=all#top')" == "$REFINE_INSTALLED_UI_ORIGIN" ]] \
+  || fail 'URL path/query/fragment leaked into the browser origin'
+[[ "$(refine_url_origin 'HTTP://LOCALHOST:80/')" == 'http://localhost' ]] \
+  || fail 'URL origin did not normalize scheme, host, and default port'
+[[ "$(refine_url_origin 'http://[::1]:8987/items')" == 'http://[::1]:8987' ]] \
+  || fail 'URL origin did not preserve an IPv6 authority'
+if refine_url_origin 'http://user@example.test/' >/dev/null; then
+  fail 'URL origin accepted credentials'
+fi
+
+trusted_headers=$'HTTP/1.1 200 OK\r\naccess-control-allow-origin:http://127.0.0.1:8987\r\naccess-control-allow-methods: POST, GET, OPTIONS\r\n\r\n'
+refine_cors_preflight_succeeds "$trusted_headers" "$REFINE_INSTALLED_UI_ORIGIN" GET \
   || fail 'doctor rejected the configured CORS origin'
 
-untrusted_headers=$'HTTP/1.1 200 OK\r\naccess-control-allow-origin: http://evil.invalid\r\n\r\n'
-if refine_cors_response_allows_origin "$untrusted_headers" "$REFINE_INSTALLED_UI_ORIGIN"; then
+untrusted_headers=$'HTTP/1.1 200 OK\r\naccess-control-allow-origin: http://evil.invalid\r\naccess-control-allow-methods: GET\r\n\r\n'
+if refine_cors_preflight_succeeds "$untrusted_headers" "$REFINE_INSTALLED_UI_ORIGIN" GET; then
   fail 'doctor accepted a different CORS origin'
 fi
 
-if refine_cors_response_allows_origin $'HTTP/1.1 200 OK\r\n\r\n' "$REFINE_INSTALLED_UI_ORIGIN"; then
-  fail 'doctor accepted a response without a CORS allow-origin header'
+for invalid_headers in \
+  $'HTTP/1.1 403 Forbidden\r\naccess-control-allow-origin: http://127.0.0.1:8987\r\naccess-control-allow-methods: GET\r\n\r\n' \
+  $'HTTP/1.1 200 OK\r\naccess-control-allow-origin: http://127.0.0.1:8987\r\n\r\n' \
+  $'HTTP/1.1 200 OK\r\naccess-control-allow-methods: GET\r\n\r\n'; do
+  if refine_cors_preflight_succeeds "$invalid_headers" "$REFINE_INSTALLED_UI_ORIGIN" GET; then
+    fail 'doctor accepted an incomplete or unsuccessful preflight response'
+  fi
+done
+
+multiple_blocks=$'HTTP/1.1 200 OK\r\naccess-control-allow-origin: http://127.0.0.1:8987\r\naccess-control-allow-methods: GET\r\n\r\nHTTP/1.1 403 Forbidden\r\n\r\n'
+if refine_cors_preflight_succeeds "$multiple_blocks" "$REFINE_INSTALLED_UI_ORIGIN" GET; then
+  fail 'doctor accepted headers from a non-final response block'
 fi
 
 printf 'All local UI contract tests passed\n'

--- a/scripts/test-local-ui-contract.sh
+++ b/scripts/test-local-ui-contract.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/local-ui-contract.sh
+source "${SCRIPT_DIR}/local-ui-contract.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+enabled_xml="$(refine_server_trusted_origins_xml 1)"
+[[ "$enabled_xml" == *'<key>REFINE_TRUSTED_ORIGINS</key>'* ]] \
+  || fail 'UI-enabled server plist omitted REFINE_TRUSTED_ORIGINS'
+[[ "$enabled_xml" == *"<string>${REFINE_INSTALLED_UI_ORIGIN}</string>"* ]] \
+  || fail 'UI-enabled server plist used the wrong trusted origin'
+
+disabled_xml="$(refine_server_trusted_origins_xml 0)"
+[[ -z "$disabled_xml" ]] \
+  || fail '--no-ui-dev server plist still emitted a trusted UI origin'
+
+trusted_headers=$'HTTP/1.1 200 OK\r\naccess-control-allow-origin: http://127.0.0.1:8987\r\n\r\n'
+refine_cors_response_allows_origin "$trusted_headers" "$REFINE_INSTALLED_UI_ORIGIN" \
+  || fail 'doctor rejected the configured CORS origin'
+
+untrusted_headers=$'HTTP/1.1 200 OK\r\naccess-control-allow-origin: http://evil.invalid\r\n\r\n'
+if refine_cors_response_allows_origin "$untrusted_headers" "$REFINE_INSTALLED_UI_ORIGIN"; then
+  fail 'doctor accepted a different CORS origin'
+fi
+
+if refine_cors_response_allows_origin $'HTTP/1.1 200 OK\r\n\r\n' "$REFINE_INSTALLED_UI_ORIGIN"; then
+  fail 'doctor accepted a response without a CORS allow-origin header'
+fi
+
+printf 'All local UI contract tests passed\n'


### PR DESCRIPTION
Closes #153

## Summary
- share the installed Vite UI origin between installer and doctor
- configure the server LaunchAgent to trust that exact origin only when UI dev mode is enabled
- add an Origin-bearing preflight doctor check and Linux shell coverage
- pin the server CORS regression test to the installed UI origin

## Verification
- `cargo test -p refine-server --locked`
- `bash scripts/test-runtime-wrappers.sh`
- `bash scripts/test-local-ui-contract.sh`
- `cargo fmt --all -- --check`
- `shellcheck scripts/install-local.sh scripts/doctor-local.sh scripts/local-ui-contract.sh scripts/test-local-ui-contract.sh`
- `git diff --check`