### PR TITLE
Track RustSec warnings and gate vulnerable Rust dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,17 @@ jobs:
             test -f "$f" || { echo "Missing: $f"; exit 1; }
           done
 
+  rustsec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: cargo-audit@0.22.2
+      - name: Reject vulnerable Rust dependencies
+        run: cargo audit
+
   shell-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
         with:
           tool: cargo-audit@0.22.2
+          fallback: none
       - name: Reject vulnerable Rust dependencies
         run: cargo audit
 

--- a/docs/RUSTSEC_WARNINGS.md
+++ b/docs/RUSTSEC_WARNINGS.md
@@ -1,0 +1,46 @@
+# RustSec warning baseline
+
+This document records the non-vulnerability warnings emitted by
+`cargo audit 0.22.2` on 2026-08-13. They remain visible in CI and are not
+suppressed through an ignore list. `cargo audit` still exits non-zero for a
+vulnerability, so the CI job prevents a new vulnerable dependency from being
+merged while these upstream warnings are tracked separately.
+
+## Current dependency paths
+
+| Warning family | Target | Dependency path | Current blocker |
+| --- | --- | --- | --- |
+| `RUSTSEC-2024-0429` (`glib 0.18.5`, unsound iterator implementation) | Linux desktop only | `refine-desktop -> tauri 2.11.5 -> gtk/webkit2gtk -> glib 0.18.5` | Tauri's current Linux WebView stack still uses the GTK3 `0.18` bindings. There is no newer compatible `glib 0.18` release. |
+| Ten `RUSTSEC-2024-0411` through `RUSTSEC-2024-0420` GTK3 maintenance warnings | Linux desktop only | `refine-desktop -> tauri 2.11.5 -> gtk 0.18.2` and its `atk`, `gdk`, and `*-sys` crates | The GTK3 bindings are unmaintained, but remain part of Tauri's current Linux backend. Replacing them requires an upstream Tauri/WebKit backend change rather than a lockfile-only update here. |
+| `RUSTSEC-2024-0370` (`proc-macro-error 1.0.4`, unmaintained) | Linux desktop only | `gtk3-macros/glib-macros -> proc-macro-error` | This follows the same GTK3 dependency path and cannot be upgraded independently. |
+| Five `RUSTSEC-2025-0075` through `RUSTSEC-2025-0100` `unic-*` maintenance warnings | All desktop build targets | `tauri 2.11.5 -> tauri-utils 2.9.3 -> urlpattern 0.3.0 -> unic-* 0.9.0` | `urlpattern` has newer major releases, but Tauri controls this transitive version. The application does not depend on `urlpattern` directly. |
+
+`cargo tree --target aarch64-apple-darwin -i glib@0.18.5` returns no path,
+confirming that the GTK/glib warning family is not linked into the macOS
+desktop target. The `unic-*` path is cross-platform build tooling.
+
+## Upgrade policy
+
+1. Keep Tauri and its official plugins on the latest compatible release.
+2. On each Tauri update, rerun the commands below and remove this baseline row
+   as soon as the transitive path disappears.
+3. Do not add blanket `cargo audit` ignores for these warnings.
+4. Treat any advisory classified as a vulnerability as a blocking CI failure.
+5. If the `glib` unsound API becomes reachable from application code before an
+   upstream fix exists, disable the affected Linux surface or apply a narrowly
+   reviewed upstream patch instead of suppressing the advisory.
+
+## Reproduction
+
+```bash
+cargo audit
+cargo update -p tauri --dry-run
+cargo update -p glib@0.18.5 --dry-run
+cargo tree --target x86_64-unknown-linux-gnu -i glib@0.18.5
+cargo tree --target aarch64-apple-darwin -i glib@0.18.5
+cargo tree --target all -i proc-macro-error@1.0.4
+cargo tree --target all -i unic-char-property@0.9.0
+```
+
+At the recorded baseline, Tauri `2.11.5` is the latest published release and
+both targeted dry runs report no compatible dependency update.

--- a/docs/RUSTSEC_WARNINGS.md
+++ b/docs/RUSTSEC_WARNINGS.md
@@ -8,12 +8,32 @@ merged while these upstream warnings are tracked separately.
 
 ## Current dependency paths
 
-| Warning family | Target | Dependency path | Current blocker |
+| Advisory | Crate | Target | Dependency path |
 | --- | --- | --- | --- |
-| `RUSTSEC-2024-0429` (`glib 0.18.5`, unsound iterator implementation) | Linux desktop only | `refine-desktop -> tauri 2.11.5 -> gtk/webkit2gtk -> glib 0.18.5` | Tauri's current Linux WebView stack still uses the GTK3 `0.18` bindings. There is no newer compatible `glib 0.18` release. |
-| Ten `RUSTSEC-2024-0411` through `RUSTSEC-2024-0420` GTK3 maintenance warnings | Linux desktop only | `refine-desktop -> tauri 2.11.5 -> gtk 0.18.2` and its `atk`, `gdk`, and `*-sys` crates | The GTK3 bindings are unmaintained, but remain part of Tauri's current Linux backend. Replacing them requires an upstream Tauri/WebKit backend change rather than a lockfile-only update here. |
-| `RUSTSEC-2024-0370` (`proc-macro-error 1.0.4`, unmaintained) | Linux desktop only | `gtk3-macros/glib-macros -> proc-macro-error` | This follows the same GTK3 dependency path and cannot be upgraded independently. |
-| Five `RUSTSEC-2025-0075` through `RUSTSEC-2025-0100` `unic-*` maintenance warnings | All desktop build targets | `tauri 2.11.5 -> tauri-utils 2.9.3 -> urlpattern 0.3.0 -> unic-* 0.9.0` | `urlpattern` has newer major releases, but Tauri controls this transitive version. The application does not depend on `urlpattern` directly. |
+| `RUSTSEC-2024-0429` | `glib 0.18.5` | Linux desktop only | `refine-desktop -> tauri/tauri-runtime-wry -> gtk/webkit2gtk -> glib` |
+| `RUSTSEC-2024-0413` | `atk 0.18.2` | Linux desktop only | `refine-desktop -> tauri -> gtk -> atk` |
+| `RUSTSEC-2024-0416` | `atk-sys 0.18.2` | Linux desktop only | `refine-desktop -> tauri -> gtk/webkit2gtk -> atk-sys` |
+| `RUSTSEC-2024-0412` | `gdk 0.18.2` | Linux desktop only | `refine-desktop -> tauri-runtime-wry -> wry/gtk -> gdk` |
+| `RUSTSEC-2024-0418` | `gdk-sys 0.18.2` | Linux desktop only | `refine-desktop -> tauri-runtime-wry -> wry/tao/gtk -> gdk-sys` |
+| `RUSTSEC-2024-0411` | `gdkwayland-sys 0.18.2` | Linux desktop only | `refine-desktop -> tauri-runtime-wry -> tao -> gdkwayland-sys` |
+| `RUSTSEC-2024-0417` | `gdkx11 0.18.2` | Linux desktop only | `refine-desktop -> tauri-runtime-wry -> wry -> gdkx11` |
+| `RUSTSEC-2024-0414` | `gdkx11-sys 0.18.2` | Linux desktop only | `refine-desktop -> tauri-runtime-wry -> wry/tao -> gdkx11-sys` |
+| `RUSTSEC-2024-0415` | `gtk 0.18.2` | Linux desktop only | `refine-desktop -> tauri/tauri-runtime-wry -> gtk` |
+| `RUSTSEC-2024-0420` | `gtk-sys 0.18.2` | Linux desktop only | `refine-desktop -> tauri-runtime-wry -> gtk/webkit2gtk -> gtk-sys` |
+| `RUSTSEC-2024-0419` | `gtk3-macros 0.18.2` | Linux desktop only | `refine-desktop -> tauri -> gtk -> gtk3-macros` |
+| `RUSTSEC-2024-0370` | `proc-macro-error 1.0.4` | Linux desktop only | `refine-desktop -> tauri -> gtk -> glib-macros/gtk3-macros -> proc-macro-error` |
+| `RUSTSEC-2025-0081` | `unic-char-property 0.9.0` | All desktop build targets | `refine-desktop -> tauri/tauri-build -> tauri-utils -> urlpattern -> unic-ucd-ident -> unic-char-property` |
+| `RUSTSEC-2025-0075` | `unic-char-range 0.9.0` | All desktop build targets | `refine-desktop -> tauri/tauri-build -> tauri-utils -> urlpattern -> unic-ucd-ident -> unic-char-property -> unic-char-range` |
+| `RUSTSEC-2025-0080` | `unic-common 0.9.0` | All desktop build targets | `refine-desktop -> tauri/tauri-build -> tauri-utils -> urlpattern -> unic-ucd-ident -> unic-ucd-version -> unic-common` |
+| `RUSTSEC-2025-0100` | `unic-ucd-ident 0.9.0` | All desktop build targets | `refine-desktop -> tauri/tauri-build -> tauri-utils -> urlpattern -> unic-ucd-ident` |
+| `RUSTSEC-2025-0098` | `unic-ucd-version 0.9.0` | All desktop build targets | `refine-desktop -> tauri/tauri-build -> tauri-utils -> urlpattern -> unic-ucd-ident -> unic-ucd-version` |
+
+The GTK3 bindings are unmaintained and the `glib` iterator advisory is marked
+unsound, but both are controlled by Tauri's current Linux WebView backend.
+There is no newer compatible `glib 0.18` release, so replacing this family
+requires an upstream Tauri/WebKit backend change rather than a lockfile-only
+update here. The five `unic-*` crates are controlled by Tauri's transitive
+`urlpattern 0.3.0`; the application does not depend on `urlpattern` directly.
 
 `cargo tree --target aarch64-apple-darwin -i glib@0.18.5` returns no path,
 confirming that the GTK/glib warning family is not linked into the macOS


### PR DESCRIPTION
Closes #158

## What changed

- add a dedicated CI job that installs pinned `cargo-audit 0.22.2` through a full-SHA action with fallback disabled, then rejects vulnerable Rust dependencies
- document all 17 current RustSec warnings individually, including advisory ID, crate, dependency path, target-platform exposure, and upstream blocker
- keep the existing warnings visible instead of adding blanket advisory ignores

## Root cause and impact

The current warnings are controlled by Tauri 2.11.5 transitive dependencies. The GTK/glib/proc-macro warnings are Linux-only; the `unic-*` warnings come through Tauri's cross-platform `urlpattern 0.3` build path. Tauri is already at the latest published release and targeted dry runs offer no compatible upgrade.

This PR makes new vulnerabilities a CI blocker while preserving an explicit upgrade plan for the upstream-bound warnings.

## Verification

- `cargo audit` — exits 0 with the documented 17 warnings and no vulnerabilities
- `cargo update -p tauri --dry-run` — no compatible updates
- `cargo update -p glib@0.18.5 --dry-run` — no compatible updates
- `cargo tree --target x86_64-unknown-linux-gnu -i glib@0.18.5`
- `cargo tree --target aarch64-apple-darwin -i glib@0.18.5` — no dependency path
- `cargo check --workspace --locked`
- YAML parse of `.github/workflows/ci.yml`
- `git diff --check`