### PR TITLE
fix: persist extracted documents and items atomically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,6 +3053,7 @@ dependencies = [
 name = "refine-desktop"
 version = "0.1.3"
 dependencies = [
+ "async-trait",
  "dirs 5.0.1",
  "refine-core",
  "serde",
@@ -3060,6 +3061,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
+ "tempfile",
  "tiny_http",
  "tokio",
  "tracing",

--- a/apps/cli/src/handlers.rs
+++ b/apps/cli/src/handlers.rs
@@ -7,7 +7,10 @@ use refine_core::infra::SqliteStore;
 use refine_core::knowledge::{
     DocumentId, DocumentRepository, Item, ItemId, ItemRepository, ItemType, Source,
 };
-use refine_core::refinement::{apply_defaults, extract_items_with_llm, ExtractionPolicy};
+use refine_core::refinement::{
+    extract_document_with_strict_defaults, persist_extracted_document, ExtractionPolicy,
+    ItemExtractionInput,
+};
 use refine_core::search::{SearchEngine, SearchQuery};
 use refine_core::session::SessionSource;
 use std::io::{self, Read};
@@ -120,18 +123,24 @@ async fn handle_extract(stdin: bool, store: Arc<SqliteStore>) -> Result<()> {
     io::stdin().read_to_string(&mut content)?;
 
     let llm_client = build_llm_client_from_env()?;
-    let mut items =
-        extract_items_with_llm(llm_client.as_ref(), &content, ExtractionPolicy::default())
-            .await
-            .context("提炼失败")?;
     let source = Source::new("cli");
-    let doc_id = DocumentId::new();
-    apply_defaults(&mut items, &source, &doc_id, &content);
+    let input = ItemExtractionInput {
+        source: "cli",
+        title: None,
+        raw_content: &content,
+        captured_at: None,
+        policy: ExtractionPolicy::default(),
+    };
+    let aggregate = extract_document_with_strict_defaults(llm_client.as_ref(), &input, &source)
+        .await
+        .context("提炼失败")?;
 
-    let item_store: &dyn ItemRepository = store.as_ref();
-    println!("提炼完成：{} 条", items.len());
-    for item in &items {
-        item_store.save(item).await?;
+    let doc_store: &dyn DocumentRepository = store.as_ref();
+    persist_extracted_document(doc_store, &aggregate)
+        .await
+        .context("保存提炼结果失败")?;
+    println!("提炼完成：{} 条", aggregate.items.len());
+    for item in &aggregate.items {
         println!(
             "  + [{}] {} ({})",
             format!("{:?}", item.item_type()).to_lowercase(),

--- a/apps/cli/src/handlers.rs
+++ b/apps/cli/src/handlers.rs
@@ -3,7 +3,7 @@ use crate::ingest_sessions::{handle_ingest_sessions, IngestOptions};
 use crate::insights::{handle_insights, InsightsOptions};
 use crate::support::{build_llm_client_from_env, format_item, parse_item_type};
 use anyhow::{Context, Result};
-use refine_core::infra::SqliteStore;
+use refine_core::infra::{LlmClient, SqliteStore};
 use refine_core::knowledge::{
     DocumentId, DocumentRepository, Item, ItemId, ItemRepository, ItemType, Source,
 };
@@ -123,24 +123,10 @@ async fn handle_extract(stdin: bool, store: Arc<SqliteStore>) -> Result<()> {
     io::stdin().read_to_string(&mut content)?;
 
     let llm_client = build_llm_client_from_env()?;
-    let source = Source::new("cli");
-    let input = ItemExtractionInput {
-        source: "cli",
-        title: None,
-        raw_content: &content,
-        captured_at: None,
-        policy: ExtractionPolicy::default(),
-    };
-    let aggregate = extract_document_with_strict_defaults(llm_client.as_ref(), &input, &source)
-        .await
-        .context("提炼失败")?;
-
-    let doc_store: &dyn DocumentRepository = store.as_ref();
-    persist_extracted_document(doc_store, &aggregate)
-        .await
-        .context("保存提炼结果失败")?;
-    println!("提炼完成：{} 条", aggregate.items.len());
-    for item in &aggregate.items {
+    let items =
+        extract_and_persist_cli_content(&content, store.as_ref(), llm_client.as_ref()).await?;
+    println!("提炼完成：{} 条", items.len());
+    for item in &items {
         println!(
             "  + [{}] {} ({})",
             format!("{:?}", item.item_type()).to_lowercase(),
@@ -150,6 +136,30 @@ async fn handle_extract(stdin: bool, store: Arc<SqliteStore>) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn extract_and_persist_cli_content(
+    content: &str,
+    store: &SqliteStore,
+    llm_client: &dyn LlmClient,
+) -> Result<Vec<Item>> {
+    let source = Source::new("cli");
+    let input = ItemExtractionInput {
+        source: "cli",
+        title: None,
+        raw_content: content,
+        captured_at: None,
+        policy: ExtractionPolicy::default(),
+    };
+    let aggregate = extract_document_with_strict_defaults(llm_client, &input, &source)
+        .await
+        .context("提炼失败")?;
+
+    let doc_store: &dyn DocumentRepository = store;
+    persist_extracted_document(doc_store, &aggregate)
+        .await
+        .context("保存提炼结果失败")?;
+    Ok(aggregate.items)
 }
 
 async fn handle_search(query: &str, limit: usize, engine: Arc<SearchEngine>) -> Result<()> {
@@ -326,8 +336,21 @@ fn parse_add_item_type(raw_type: &str) -> Result<ItemType> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_add_item_type;
-    use refine_core::knowledge::ItemType;
+    use super::{extract_and_persist_cli_content, parse_add_item_type};
+    use async_trait::async_trait;
+    use refine_core::error::InfraResult;
+    use refine_core::infra::{LlmClient, SqliteStore};
+    use refine_core::knowledge::{DocumentRepository, ItemRepository, ItemType};
+    use tempfile::tempdir;
+
+    struct FakeLlm;
+
+    #[async_trait]
+    impl LlmClient for FakeLlm {
+        async fn complete(&self, _prompt: &str, _system: Option<&str>) -> InfraResult<String> {
+            Ok(r#"{"items":[{"type":"knowledge","title":"CLI item","summary":"S","content":"C","tags":[]}]}"#.to_string())
+        }
+    }
 
     #[test]
     fn parse_add_item_type_accepts_supported_values() {
@@ -347,5 +370,24 @@ mod tests {
     fn parse_add_item_type_rejects_unknown_value() {
         let err = parse_add_item_type("invalid").expect_err("expected invalid type error");
         assert!(err.to_string().contains("无效的类型"));
+    }
+
+    #[tokio::test]
+    async fn cli_extract_persists_document_and_items_together() {
+        let temp = tempdir().unwrap();
+        let store = SqliteStore::open(&temp.path().join("refine.db")).unwrap();
+
+        let items =
+            extract_and_persist_cli_content("Human: hello\nAssistant: world", &store, &FakeLlm)
+                .await
+                .unwrap();
+
+        assert_eq!(items.len(), 1);
+        let doc_id = items[0].document_id().unwrap();
+        assert!(DocumentRepository::find_by_id(&store, doc_id)
+            .await
+            .unwrap()
+            .is_some());
+        assert_eq!(ItemRepository::count_items(&store, None).await.unwrap(), 1);
     }
 }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -24,3 +24,7 @@ tiny_http = { version = "0.12.0", features = ["ssl"] }
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
+
+[dev-dependencies]
+async-trait.workspace = true
+tempfile = "3"

--- a/apps/desktop/src-tauri/src/app/mod.rs
+++ b/apps/desktop/src-tauri/src/app/mod.rs
@@ -5,7 +5,7 @@ mod state;
 use refine_core::infra::{
     ensure_db_dir, migrate_stale_dbs, resolve_db_path, MigrationReport, SqliteStore,
 };
-use refine_core::knowledge::ItemRepository;
+use refine_core::knowledge::{DocumentRepository, ItemRepository};
 use refine_core::search::SearchEngine;
 use std::sync::Arc;
 
@@ -34,8 +34,13 @@ pub fn build_state() -> AppState {
     }
 
     let sqlite_store = Arc::new(SqliteStore::open(&db_path).expect("打开数据库失败"));
-    let store: Arc<dyn ItemRepository> = sqlite_store;
+    let store: Arc<dyn ItemRepository> = sqlite_store.clone();
+    let doc_store: Arc<dyn DocumentRepository> = sqlite_store;
     let engine = Arc::new(SearchEngine::new(store.clone()));
 
-    AppState { store, engine }
+    AppState {
+        store,
+        doc_store,
+        engine,
+    }
 }

--- a/apps/desktop/src-tauri/src/app/state.rs
+++ b/apps/desktop/src-tauri/src/app/state.rs
@@ -1,9 +1,10 @@
-use refine_core::knowledge::ItemRepository;
+use refine_core::knowledge::{DocumentRepository, ItemRepository};
 use refine_core::search::SearchEngine;
 use std::sync::Arc;
 
 /// 应用状态
 pub struct AppState {
     pub store: Arc<dyn ItemRepository>,
+    pub doc_store: Arc<dyn DocumentRepository>,
     pub engine: Arc<SearchEngine>,
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     let state = app::build_state();
 
     // 启动 HTTP API 服务器（供浏览器扩展调用）
-    server::start_server(state.store.clone());
+    server::start_server(state.store.clone(), state.doc_store.clone());
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())

--- a/apps/desktop/src-tauri/src/server/extract.rs
+++ b/apps/desktop/src-tauri/src/server/extract.rs
@@ -1,7 +1,8 @@
 use refine_core::infra::LlmClient;
-use refine_core::knowledge::{DocumentId, ItemRepository, Source};
+use refine_core::knowledge::{DocumentRepository, Source};
 use refine_core::refinement::{
-    extract_items_with_strict_defaults, ExtractionPolicy, ItemExtractionInput,
+    extract_document_with_strict_defaults, persist_extracted_document, ExtractionPolicy,
+    ItemExtractionInput,
 };
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -15,16 +16,20 @@ pub(super) struct IngestRequest {
 }
 
 pub(super) fn ingest_conversation(
-    store: &Arc<dyn ItemRepository>,
+    doc_store: &Arc<dyn DocumentRepository>,
     runtime: &Runtime,
     llm_client: Option<&Arc<dyn LlmClient>>,
     req: IngestRequest,
 ) -> Result<Vec<String>, String> {
-    runtime.block_on(extract_and_store(store, llm_client.map(Arc::clone), req))
+    runtime.block_on(extract_and_store(
+        doc_store,
+        llm_client.map(Arc::clone),
+        req,
+    ))
 }
 
 async fn extract_and_store(
-    store: &Arc<dyn ItemRepository>,
+    doc_store: &Arc<dyn DocumentRepository>,
     llm_client: Option<Arc<dyn LlmClient>>,
     req: IngestRequest,
 ) -> Result<Vec<String>, String> {
@@ -39,16 +44,13 @@ async fn extract_and_store(
         captured_at: None,
         policy: ExtractionPolicy::default(),
     };
-    let doc_id = DocumentId::new();
-    let items = extract_items_with_strict_defaults(llm_client, &input, &source, &doc_id)
+    let aggregate = extract_document_with_strict_defaults(llm_client, &input, &source)
         .await
         .map_err(|e| e.to_string())?;
 
-    let mut ids = Vec::with_capacity(items.len());
-    for item in &items {
-        store.save(item).await.map_err(|e| e.to_string())?;
-        ids.push(item.id().to_string());
-    }
+    let ids = persist_extracted_document(doc_store.as_ref(), &aggregate)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(ids)
 }

--- a/apps/desktop/src-tauri/src/server/extract.rs
+++ b/apps/desktop/src-tauri/src/server/extract.rs
@@ -13,6 +13,7 @@ pub(super) struct IngestRequest {
     pub url: String,
     pub source: String,
     pub title: Option<String>,
+    pub captured_at: Option<String>,
 }
 
 pub(super) fn ingest_conversation(
@@ -41,7 +42,7 @@ async fn extract_and_store(
         source: &req.source,
         title: req.title.as_deref(),
         raw_content: &req.content,
-        captured_at: None,
+        captured_at: req.captured_at.as_deref(),
         policy: ExtractionPolicy::default(),
     };
     let aggregate = extract_document_with_strict_defaults(llm_client, &input, &source)
@@ -53,4 +54,86 @@ async fn extract_and_store(
         .map_err(|e| e.to_string())?;
 
     Ok(ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use refine_core::error::InfraResult;
+    use refine_core::infra::SqliteStore;
+    use refine_core::knowledge::{DocumentRepository, ItemRepository};
+    use tempfile::tempdir;
+
+    struct FakeLlm;
+
+    #[async_trait]
+    impl LlmClient for FakeLlm {
+        async fn complete(&self, _prompt: &str, _system: Option<&str>) -> InfraResult<String> {
+            Ok(r#"{"items":[{"type":"knowledge","title":"Desktop item","summary":"S","content":"C","tags":[]}]}"#.to_string())
+        }
+    }
+
+    fn request(captured_at: Option<&str>) -> IngestRequest {
+        IngestRequest {
+            content: "Human: hello\nAssistant: world".to_string(),
+            url: "https://example.test/conversation".to_string(),
+            source: "extension".to_string(),
+            title: Some("Conversation".to_string()),
+            captured_at: captured_at.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn desktop_ingest_persists_event_time_and_reuses_url_identity() {
+        let temp = tempdir().unwrap();
+        let sqlite = Arc::new(SqliteStore::open(&temp.path().join("refine.db")).unwrap());
+        let doc_store: Arc<dyn DocumentRepository> = sqlite.clone();
+        let item_store: Arc<dyn ItemRepository> = sqlite;
+        let runtime = Runtime::new().unwrap();
+        let llm: Arc<dyn LlmClient> = Arc::new(FakeLlm);
+
+        ingest_conversation(
+            &doc_store,
+            &runtime,
+            Some(&llm),
+            request(Some("2020-01-02T03:04:05Z")),
+        )
+        .unwrap();
+        ingest_conversation(
+            &doc_store,
+            &runtime,
+            Some(&llm),
+            request(Some("2020-01-02T03:04:05Z")),
+        )
+        .unwrap();
+
+        let doc = runtime
+            .block_on(doc_store.find_by_url("https://example.test/conversation"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(doc.captured_at().to_rfc3339(), "2020-01-02T03:04:05+00:00");
+        assert_eq!(runtime.block_on(doc_store.count()).unwrap(), 1);
+        assert_eq!(runtime.block_on(item_store.count_items(None)).unwrap(), 1);
+    }
+
+    #[test]
+    fn desktop_ingest_rejects_invalid_event_time_without_persisting() {
+        let temp = tempdir().unwrap();
+        let sqlite = Arc::new(SqliteStore::open(&temp.path().join("refine.db")).unwrap());
+        let doc_store: Arc<dyn DocumentRepository> = sqlite.clone();
+        let runtime = Runtime::new().unwrap();
+        let llm: Arc<dyn LlmClient> = Arc::new(FakeLlm);
+
+        let err = ingest_conversation(
+            &doc_store,
+            &runtime,
+            Some(&llm),
+            request(Some("not-a-timestamp")),
+        )
+        .expect_err("invalid captured_at must be rejected");
+
+        assert!(err.contains("invalid captured_at"));
+        assert_eq!(runtime.block_on(doc_store.count()).unwrap(), 0);
+    }
 }

--- a/apps/desktop/src-tauri/src/server/http.rs
+++ b/apps/desktop/src-tauri/src/server/http.rs
@@ -106,6 +106,7 @@ fn handle_create_conversation(
         url,
         source,
         title,
+        captured_at,
         idempotency_key,
         ..
     } = payload;
@@ -131,6 +132,7 @@ fn handle_create_conversation(
             url: normalized.url,
             source: normalized.source,
             title: normalized.title,
+            captured_at,
         },
     );
 

--- a/apps/desktop/src-tauri/src/server/http.rs
+++ b/apps/desktop/src-tauri/src/server/http.rs
@@ -4,7 +4,7 @@ use refine_core::infra::{
     normalize_conversation_input, validate_contract_version, CreateConversationRequest, ItemDto,
     LlmClient, CONTRACT_VERSION, CONTRACT_VERSION_HEADER,
 };
-use refine_core::knowledge::ItemRepository;
+use refine_core::knowledge::{DocumentRepository, ItemRepository};
 use serde_json::json;
 use std::io::Cursor;
 use std::sync::Arc;
@@ -18,6 +18,7 @@ const CLIENT_HEADER_VALUE: &str = "extension";
 pub(super) fn handle_request(
     request: &mut tiny_http::Request,
     store: &Arc<dyn ItemRepository>,
+    doc_store: &Arc<dyn DocumentRepository>,
     runtime: &Runtime,
     llm_client: Option<&Arc<dyn LlmClient>>,
 ) -> Response<Cursor<Vec<u8>>> {
@@ -62,7 +63,7 @@ pub(super) fn handle_request(
             }
             handle_create_conversation(
                 request,
-                store,
+                doc_store,
                 runtime,
                 llm_client,
                 allowed_origin.as_deref(),
@@ -84,7 +85,7 @@ pub(super) fn handle_request(
 
 fn handle_create_conversation(
     request: &mut tiny_http::Request,
-    store: &Arc<dyn ItemRepository>,
+    doc_store: &Arc<dyn DocumentRepository>,
     runtime: &Runtime,
     llm_client: Option<&Arc<dyn LlmClient>>,
     allowed_origin: Option<&str>,
@@ -122,7 +123,7 @@ fn handle_create_conversation(
         };
 
     let extract_result = extract::ingest_conversation(
-        store,
+        doc_store,
         runtime,
         llm_client,
         IngestRequest {

--- a/apps/desktop/src-tauri/src/server/mod.rs
+++ b/apps/desktop/src-tauri/src/server/mod.rs
@@ -7,7 +7,7 @@ mod http;
 mod json;
 
 use refine_core::infra::{build_required_llm_client_from_env, LlmClient};
-use refine_core::knowledge::ItemRepository;
+use refine_core::knowledge::{DocumentRepository, ItemRepository};
 use std::sync::Arc;
 use tiny_http::Server;
 use tokio::runtime::Builder as RuntimeBuilder;
@@ -16,7 +16,7 @@ const DEFAULT_SERVER_PORT: u16 = 21567;
 const MAX_SERVER_WORKERS: usize = 8;
 
 /// 启动 HTTP 服务器
-pub fn start_server(store: Arc<dyn ItemRepository>) {
+pub fn start_server(store: Arc<dyn ItemRepository>, doc_store: Arc<dyn DocumentRepository>) {
     std::thread::spawn(move || {
         let port = resolve_server_port();
         let server = match Server::http(format!("127.0.0.1:{}", port)) {
@@ -51,9 +51,10 @@ pub fn start_server(store: Arc<dyn ItemRepository>) {
         for _ in 0..worker_count {
             let server = Arc::clone(&server);
             let store = Arc::clone(&store);
+            let doc_store = Arc::clone(&doc_store);
             let llm_client = llm_client.clone();
             handles.push(std::thread::spawn(move || {
-                run_worker(server, store, llm_client);
+                run_worker(server, store, doc_store, llm_client);
             }));
         }
 
@@ -73,6 +74,7 @@ fn resolve_server_port() -> u16 {
 fn run_worker(
     server: Arc<Server>,
     store: Arc<dyn ItemRepository>,
+    doc_store: Arc<dyn DocumentRepository>,
     llm_client: Option<Arc<dyn LlmClient>>,
 ) {
     let runtime = match RuntimeBuilder::new_current_thread().enable_all().build() {
@@ -89,7 +91,13 @@ fn run_worker(
             Err(_) => break,
         };
 
-        let response = http::handle_request(&mut request, &store, &runtime, llm_client.as_ref());
+        let response = http::handle_request(
+            &mut request,
+            &store,
+            &doc_store,
+            &runtime,
+            llm_client.as_ref(),
+        );
         let _ = request.respond(response);
     }
 }

--- a/apps/server/src/extraction.rs
+++ b/apps/server/src/extraction.rs
@@ -54,6 +54,10 @@ async fn run_extraction(
     if let Some(title) = &conversation.title {
         doc.set_title(title);
     }
+    let captured_at = chrono::DateTime::parse_from_rfc3339(&conversation.captured_at)
+        .map_err(|err| format!("invalid conversation captured_at: {err}"))?
+        .with_timezone(&chrono::Utc);
+    doc.set_captured_at(captured_at);
     let doc = canonicalize_document(&state.doc_store, doc).await?;
     let doc_id = doc.id().clone();
 

--- a/packages/core/src/infra/sqlite/worker.rs
+++ b/packages/core/src/infra/sqlite/worker.rs
@@ -2,9 +2,9 @@ use super::rows::{configure_connection, configure_read_only_connection};
 use super::{conversation_ops, doc_ops, ops};
 use crate::conversation::{ConversationRecord, EventRecord, ExtractionJobRecord};
 use crate::error::{InfraError, InfraResult};
-use crate::knowledge::{Document, Item, ItemType};
+use crate::knowledge::{Document, Item, ItemType, RestoreDocumentParams};
 use chrono::{DateTime, Utc};
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::{Connection, OpenFlags, Transaction, TransactionBehavior};
 use std::path::PathBuf;
 use std::sync::mpsc;
 use tokio::sync::oneshot;
@@ -510,12 +510,12 @@ fn save_document_with_replaced_items(
     doc: &Document,
     items: &[Item],
 ) -> InfraResult<()> {
-    let tx = conn
-        .unchecked_transaction()
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
         .map_err(|e| InfraError::Database(e.to_string()))?;
-    doc_ops::save(&tx, doc)?;
+    let (doc, items) = canonicalize_document_items(&tx, doc, items)?;
+    doc_ops::save(&tx, &doc)?;
     ops::delete_by_document_id(&tx, doc.id().as_str())?;
-    for item in items {
+    for item in &items {
         ops::save(&tx, item)?;
     }
     tx.commit()
@@ -529,18 +529,51 @@ fn save_document_with_replaced_items_and_delete_documents(
     items: &[Item],
     obsolete_document_ids: &[String],
 ) -> InfraResult<()> {
-    let tx = conn
-        .unchecked_transaction()
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
         .map_err(|e| InfraError::Database(e.to_string()))?;
-    doc_ops::save(&tx, doc)?;
+    let (doc, items) = canonicalize_document_items(&tx, doc, items)?;
+    doc_ops::save(&tx, &doc)?;
     ops::delete_by_document_id(&tx, doc.id().as_str())?;
-    for item in items {
+    for item in &items {
         ops::save(&tx, item)?;
     }
     delete_documents_with_items_in_transaction(&tx, obsolete_document_ids)?;
     tx.commit()
         .map_err(|e| InfraError::Database(e.to_string()))?;
     Ok(())
+}
+
+fn canonicalize_document_items(
+    conn: &Connection,
+    doc: &Document,
+    items: &[Item],
+) -> InfraResult<(Document, Vec<Item>)> {
+    let existing = doc_ops::find_by_url(conn, doc.url())?;
+    let canonical_doc = match existing {
+        Some(existing) if existing.id() != doc.id() => Document::restore(RestoreDocumentParams {
+            id: existing.id().clone(),
+            title: doc
+                .title()
+                .map(ToOwned::to_owned)
+                .or_else(|| existing.title().map(ToOwned::to_owned)),
+            raw_content: doc.raw_content().to_string(),
+            source: doc.source().to_string(),
+            url: doc.url().to_string(),
+            source_version: doc.source_version().map(ToOwned::to_owned),
+            captured_at: doc.captured_at(),
+            created_at: existing.created_at(),
+            updated_at: doc.updated_at(),
+        }),
+        _ => doc.clone(),
+    };
+    let canonical_id = canonical_doc.id().clone();
+    let mut canonical_items = items.to_vec();
+    for item in &mut canonical_items {
+        if item.document_id() == Some(doc.id()) {
+            item.set_document_id(canonical_id.clone());
+        }
+    }
+    Ok((canonical_doc, canonical_items))
 }
 
 fn delete_documents_with_items(conn: &Connection, document_ids: &[String]) -> InfraResult<()> {

--- a/packages/core/src/refinement/mod.rs
+++ b/packages/core/src/refinement/mod.rs
@@ -17,6 +17,7 @@ pub use conversation::{Conversation, Message, Role};
 pub use extractor::{ExtractionResult, Extractor};
 pub use policy::{ExtractionPolicy, PromptTemplate};
 pub use usecase::{
-    apply_defaults, extract_items_with_llm, extract_items_with_strict_defaults,
+    apply_defaults, extract_document_with_strict_defaults, extract_items_with_llm,
+    extract_items_with_strict_defaults, persist_extracted_document, ExtractedDocument,
     ItemExtractionInput, EXTRACTION_SYSTEM_PROMPT, JSON_REPAIR_SYSTEM_PROMPT,
 };

--- a/packages/core/src/refinement/usecase.rs
+++ b/packages/core/src/refinement/usecase.rs
@@ -3,9 +3,9 @@
 //! 在不引入新 crate 的过渡阶段，将 LLM 调用、JSON 修复集中，
 //! 供 server/desktop/cli 复用，避免多处重复实现。
 
-use crate::error::{DomainError, DomainResult};
+use crate::error::{DomainError, DomainResult, InfraResult};
 use crate::infra::LlmClient;
-use crate::knowledge::{DocumentId, Item, Source};
+use crate::knowledge::{Document, DocumentId, DocumentRepository, Item, Source};
 use crate::refinement::{
     Conversation, ExtractionPolicy, ExtractionResult, Extractor, PromptTemplate,
 };
@@ -22,6 +22,59 @@ pub struct ItemExtractionInput<'a> {
     pub raw_content: &'a str,
     pub captured_at: Option<&'a str>,
     pub policy: ExtractionPolicy,
+}
+
+/// A document and all items extracted from it. Persist this aggregate through
+/// `DocumentRepository::save_with_replaced_items` so foreign keys and partial
+/// writes cannot diverge.
+pub struct ExtractedDocument {
+    pub document: Document,
+    pub items: Vec<Item>,
+}
+
+/// Build and strictly extract one complete document aggregate.
+pub async fn extract_document_with_strict_defaults(
+    llm_client: &dyn LlmClient,
+    input: &ItemExtractionInput<'_>,
+    source: &Source,
+) -> DomainResult<ExtractedDocument> {
+    let mut document = Document::new(input.source, input.raw_content);
+    if let Some(title) = input.title.filter(|value| !value.trim().is_empty()) {
+        document.set_title(title);
+    }
+    if let Some(url) = source.url.as_deref() {
+        document.set_url(url);
+    } else {
+        document.set_url(&format!("refine://{}/{}", input.source, document.id()));
+    }
+    if let Some(captured_at) = input.captured_at {
+        let captured_at = chrono::DateTime::parse_from_rfc3339(captured_at)
+            .map_err(|err| {
+                DomainError::Validation(format!("invalid captured_at timestamp: {err}"))
+            })?
+            .with_timezone(&chrono::Utc);
+        document.set_captured_at(captured_at);
+    }
+
+    let items =
+        extract_items_with_strict_defaults(llm_client, input, source, document.id()).await?;
+    Ok(ExtractedDocument { document, items })
+}
+
+/// Persist the complete extracted aggregate through the repository's atomic
+/// document+items boundary and return the stable item identities.
+pub async fn persist_extracted_document(
+    repository: &dyn DocumentRepository,
+    aggregate: &ExtractedDocument,
+) -> InfraResult<Vec<String>> {
+    repository
+        .save_with_replaced_items(&aggregate.document, &aggregate.items)
+        .await?;
+    Ok(aggregate
+        .items
+        .iter()
+        .map(|item| item.id().to_string())
+        .collect())
 }
 
 /// 为提炼结果补齐来源、文档关联与兜底 content。
@@ -265,5 +318,110 @@ mod tests {
             items[0].document_id().map(|id| id.as_str()),
             Some(doc_id.as_str())
         );
+    }
+
+    #[tokio::test]
+    async fn extracted_document_uses_one_identity_for_document_and_items() {
+        let client = SequenceLlmClient::new(vec![
+            r#"{"items":[{"type":"knowledge","title":"T","summary":"S","content":"C","tags":[]}]}"#,
+        ]);
+        let input = ItemExtractionInput {
+            source: "cli",
+            title: Some("Imported conversation"),
+            raw_content: "Human: hello\nAssistant: world",
+            captured_at: Some("2026-08-13T00:00:00Z"),
+            policy: ExtractionPolicy::default(),
+        };
+        let source = Source::new("cli").with_url("stdin://conversation");
+
+        let aggregate = extract_document_with_strict_defaults(&client, &input, &source)
+            .await
+            .unwrap();
+
+        assert_eq!(aggregate.document.title(), Some("Imported conversation"));
+        assert_eq!(aggregate.document.url(), "stdin://conversation");
+        assert_eq!(aggregate.items.len(), 1);
+        assert_eq!(
+            aggregate.items[0].document_id(),
+            Some(aggregate.document.id())
+        );
+    }
+
+    #[tokio::test]
+    async fn extracted_document_persists_document_and_items_atomically() {
+        use crate::infra::SqliteStore;
+        use crate::knowledge::{DocumentRepository, ItemRepository};
+        use tempfile::tempdir;
+
+        let client = SequenceLlmClient::new(vec![
+            r#"{"items":[{"type":"knowledge","title":"T","summary":"S","content":"C","tags":[]}]}"#,
+        ]);
+        let input = ItemExtractionInput {
+            source: "cli",
+            title: None,
+            raw_content: "Human: hello\nAssistant: world",
+            captured_at: None,
+            policy: ExtractionPolicy::default(),
+        };
+        let aggregate = extract_document_with_strict_defaults(&client, &input, &Source::new("cli"))
+            .await
+            .unwrap();
+        let temp = tempdir().unwrap();
+        let store = SqliteStore::open(&temp.path().join("refine.db")).unwrap();
+
+        let ids = persist_extracted_document(&store, &aggregate)
+            .await
+            .unwrap();
+
+        assert_eq!(ids.len(), 1);
+        assert!(
+            DocumentRepository::find_by_id(&store, aggregate.document.id())
+                .await
+                .unwrap()
+                .is_some()
+        );
+        let persisted = ItemRepository::find_by_document_id(&store, aggregate.document.id())
+            .await
+            .unwrap();
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].id().as_str(), ids[0]);
+    }
+
+    #[tokio::test]
+    async fn aggregate_persistence_rolls_back_document_and_prior_items_on_failure() {
+        use crate::infra::SqliteStore;
+        use crate::knowledge::{DocumentRepository, ItemRepository};
+        use tempfile::tempdir;
+
+        let client = SequenceLlmClient::new(vec![
+            r#"{"items":[{"type":"knowledge","title":"first","summary":"S","content":"C","tags":[]},{"type":"skill","title":"second","summary":"S","content":"C","tags":[]}]}"#,
+        ]);
+        let input = ItemExtractionInput {
+            source: "cli",
+            title: None,
+            raw_content: "Human: hello\nAssistant: world",
+            captured_at: None,
+            policy: ExtractionPolicy::default(),
+        };
+        let mut aggregate =
+            extract_document_with_strict_defaults(&client, &input, &Source::new("cli"))
+                .await
+                .unwrap();
+        aggregate.items[1].set_document_id(DocumentId::from("missing-document"));
+        let temp = tempdir().unwrap();
+        let store = SqliteStore::open(&temp.path().join("refine.db")).unwrap();
+
+        let err = persist_extracted_document(&store, &aggregate)
+            .await
+            .expect_err("the second item must violate its document foreign key");
+
+        assert!(err.to_string().contains("FOREIGN KEY"));
+        assert!(
+            DocumentRepository::find_by_id(&store, aggregate.document.id())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(ItemRepository::count_items(&store, None).await.unwrap(), 0);
     }
 }

--- a/packages/core/src/refinement/usecase.rs
+++ b/packages/core/src/refinement/usecase.rs
@@ -424,4 +424,97 @@ mod tests {
         );
         assert_eq!(ItemRepository::count_items(&store, None).await.unwrap(), 0);
     }
+
+    #[tokio::test]
+    async fn repeated_url_reuses_canonical_document_identity() {
+        use crate::infra::SqliteStore;
+        use crate::knowledge::{DocumentRepository, ItemRepository};
+        use tempfile::tempdir;
+
+        let input = ItemExtractionInput {
+            source: "browser",
+            title: None,
+            raw_content: "Human: hello\nAssistant: world",
+            captured_at: Some("2020-01-02T03:04:05Z"),
+            policy: ExtractionPolicy::default(),
+        };
+        let source = Source::new("browser").with_url("https://same.example/conversation");
+        let first = extract_document_with_strict_defaults(
+            &SequenceLlmClient::new(vec![r#"{"items":[{"type":"knowledge","title":"first","summary":"S","content":"C","tags":[]}]}"#]),
+            &input,
+            &source,
+        )
+        .await
+        .unwrap();
+        let second = extract_document_with_strict_defaults(
+            &SequenceLlmClient::new(vec![r#"{"items":[{"type":"knowledge","title":"second","summary":"S","content":"C","tags":[]}]}"#]),
+            &input,
+            &source,
+        )
+        .await
+        .unwrap();
+        assert_ne!(first.document.id(), second.document.id());
+        let temp = tempdir().unwrap();
+        let store = SqliteStore::open(&temp.path().join("refine.db")).unwrap();
+
+        persist_extracted_document(&store, &first).await.unwrap();
+        persist_extracted_document(&store, &second).await.unwrap();
+
+        let canonical = DocumentRepository::find_by_url(&store, source.url.as_deref().unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(canonical.id(), first.document.id());
+        assert_eq!(
+            canonical.captured_at().to_rfc3339(),
+            "2020-01-02T03:04:05+00:00"
+        );
+        let items = ItemRepository::find_by_document_id(&store, canonical.id())
+            .await
+            .unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title(), "second");
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_url_persistence_converges_without_foreign_key_errors() {
+        use crate::infra::SqliteStore;
+        use crate::knowledge::{DocumentRepository, ItemRepository};
+        use tempfile::tempdir;
+
+        let input = ItemExtractionInput {
+            source: "browser",
+            title: None,
+            raw_content: "Human: hello\nAssistant: world",
+            captured_at: None,
+            policy: ExtractionPolicy::default(),
+        };
+        let source = Source::new("browser").with_url("https://same.example/concurrent");
+        let first = extract_document_with_strict_defaults(
+            &SequenceLlmClient::new(vec![r#"{"items":[{"type":"knowledge","title":"first","summary":"S","content":"C","tags":[]}]}"#]),
+            &input,
+            &source,
+        )
+        .await
+        .unwrap();
+        let second = extract_document_with_strict_defaults(
+            &SequenceLlmClient::new(vec![r#"{"items":[{"type":"knowledge","title":"second","summary":"S","content":"C","tags":[]}]}"#]),
+            &input,
+            &source,
+        )
+        .await
+        .unwrap();
+        let temp = tempdir().unwrap();
+        let store = SqliteStore::open(&temp.path().join("refine.db")).unwrap();
+
+        let (first_result, second_result) = tokio::join!(
+            persist_extracted_document(&store, &first),
+            persist_extracted_document(&store, &second)
+        );
+        first_result.unwrap();
+        second_result.unwrap();
+
+        assert_eq!(DocumentRepository::count(&store).await.unwrap(), 1);
+        assert_eq!(ItemRepository::count_items(&store, None).await.unwrap(), 1);
+    }
 }


### PR DESCRIPTION
Closes #164

## Summary

- introduce a shared extracted Document+Items aggregate with one document identity
- persist aggregates through the transactional document repository boundary
- switch CLI extract and the Tauri HTTP bridge away from item-by-item saves
- canonicalize duplicate URLs inside the SQLite transaction, including concurrent captures
- preserve title, URL, captured time, and source metadata on the persisted document
- cover the core transaction plus the CLI and desktop application entry functions with temporary SQLite tests

## Review fixes

- reuse the existing document ID when a URL is captured again, and rewrite the new items to that canonical identity
- carry `captured_at` from the extension request through desktop ingestion; reject invalid timestamps without persisting
- serialize same-URL aggregate writes with an immediate SQLite transaction
- preserve the standalone server path and apply its conversation capture timestamp to the document

## Verification

- `cargo test -p refine-core -p refine-cli -p refine-desktop --locked`
  - CLI: 58 passed
  - Core: 143 unit + 23 integration passed
  - Desktop: 3 passed
- `cargo check -p refine-core -p refine-cli -p refine-desktop -p refine-server --locked`
- `cargo clippy -p refine-core -p refine-cli -p refine-desktop -p refine-server --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- GitHub CI: 10/10 checks passed, including RustSec and desktop UI tests