### PR TITLE
fix: bound shared extraction LLM calls

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -73,6 +73,27 @@ win over that file. A repository `.env` remains an explicit development
 fallback only, and scheduled scripts pass it to the loader after the process
 and secure-file sources.
 
+### Strict extraction timeout and retry policy
+
+CLI `refine extract`, desktop extraction, and server extraction all use the
+same protected core path for both the initial LLM request and a JSON-repair
+request. Each attempt has a timeout, and transient timeouts, HTTP 408/425/5xx,
+and recognized transport failures are retried with exponential backoff. Auth,
+content-policy rejection, and other deterministic errors fail immediately.
+
+The defaults and bounded process-environment overrides are:
+
+| Variable | Default | Accepted range | Meaning |
+|----------|---------|----------------|---------|
+| `REFINE_EXTRACTION_MAX_ATTEMPTS` | `3` | `1..=5` | Total attempts per initial or repair request, including the first call |
+| `REFINE_EXTRACTION_RETRY_BASE_DELAY_SECS` | `1` | `0..=60` | Base delay; later retries use exponential backoff |
+| `REFINE_EXTRACTION_REQUEST_TIMEOUT_MILLIS` | `90000` | `1000..=300000` | Timeout for each provider attempt |
+
+Numeric values outside a range are clamped to its nearest bound. Missing,
+empty, or invalid values use the documented default. These settings are read
+by the shared core extraction path, so callers should not add their own retry
+loop around it.
+
 ## 3. Run Sync Stack (Server + Extension)
 
 ### Start server

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -79,7 +79,10 @@ CLI `refine extract`, desktop extraction, and server extraction all use the
 same protected core path for both the initial LLM request and a JSON-repair
 request. Each attempt has a timeout, and transient timeouts, HTTP 408/425/5xx,
 and recognized transport failures are retried with exponential backoff. Auth,
-content-policy rejection, and other deterministic errors fail immediately.
+HTTP 429/rate-limit responses, content-policy rejection, and other
+deterministic errors fail immediately. Extraction does not consult or update
+the legacy process-global quota marker, because that marker is not scoped by
+provider, endpoint, or credential.
 
 The defaults and bounded process-environment overrides are:
 

--- a/packages/core/src/infra/llm_retry.rs
+++ b/packages/core/src/infra/llm_retry.rs
@@ -180,12 +180,27 @@ fn is_retryable_error(err: &InfraError, retry_http_429: bool) -> bool {
 
 fn is_rate_limit_message(message: &str) -> bool {
     let message = message.to_ascii_lowercase();
-    message.contains("429")
-        || message.contains("rate limit")
-        || message.contains("rate_limit")
-        || message.contains("rate-limit")
-        || message.contains("too many requests")
-        || message.contains("quota exceeded")
+    let tokens = message
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+
+    tokens.contains(&"429")
+        || tokens
+            .iter()
+            .any(|token| *token == "ratelimit" || token.starts_with("ratelimiterror"))
+        || tokens.windows(2).any(|pair| {
+            matches!(
+                pair,
+                ["rate", "limit"]
+                    | ["rate", "limited"]
+                    | ["rate", "exceeded"]
+                    | ["quota", "exceeded"]
+            )
+        })
+        || tokens
+            .windows(3)
+            .any(|triple| matches!(triple, ["too", "many", "requests"]))
 }
 
 fn backoff_delay_secs(base_delay_secs: u64, attempt: usize) -> u64 {
@@ -239,6 +254,23 @@ mod tests {
             &InfraError::LlmRequest("429 rate limit".into()),
             false,
         ));
+        assert!(is_retryable_error(
+            &InfraError::LlmRequest("request to http://127.0.0.1:4290/v1 timed out".into(),),
+            false,
+        ));
+        for message in [
+            "HTTP 429",
+            "RateLimitError",
+            "rate_limit",
+            "rate exceeded",
+            "too many requests",
+            "quota exceeded",
+        ] {
+            assert!(!is_retryable_error(
+                &InfraError::LlmRequest(message.into()),
+                false,
+            ));
+        }
     }
     use crate::infra::quota_state::{is_exhausted as is_quota_exhausted, set_quota_file_override};
     use async_trait::async_trait;

--- a/packages/core/src/infra/llm_retry.rs
+++ b/packages/core/src/infra/llm_retry.rs
@@ -47,6 +47,23 @@ pub async fn llm_with_retry_policy<F>(
     prompt: &str,
     system: &str,
     policy: LlmRetryPolicy,
+    on_retry: F,
+) -> InfraResult<String>
+where
+    F: FnMut(usize, usize, u64, &InfraError),
+{
+    llm_with_retry_policy_ref(client.as_ref(), prompt, system, policy, on_retry).await
+}
+
+/// Apply the shared timeout and retry policy to an already borrowed client.
+///
+/// Application-layer use cases can use this variant without manufacturing an
+/// `Arc`; long-lived callers should keep using [`llm_with_retry_policy`].
+pub async fn llm_with_retry_policy_ref<F>(
+    client: &dyn LlmClient,
+    prompt: &str,
+    system: &str,
+    policy: LlmRetryPolicy,
     mut on_retry: F,
 ) -> InfraResult<String>
 where
@@ -154,7 +171,7 @@ mod tests {
     use std::collections::VecDeque;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{LazyLock, Mutex};
+    use std::sync::{Arc, LazyLock, Mutex};
     use tempfile::TempDir;
     use tokio::sync::Mutex as AsyncMutex;
 

--- a/packages/core/src/infra/llm_retry.rs
+++ b/packages/core/src/infra/llm_retry.rs
@@ -17,6 +17,27 @@ pub struct LlmRetryPolicy {
     pub request_timeout_millis: u64,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct LlmRetryBehavior {
+    check_persistent_quota: bool,
+    record_persistent_quota: bool,
+    retry_http_429: bool,
+}
+
+impl LlmRetryBehavior {
+    const SHARED_DEFAULT: Self = Self {
+        check_persistent_quota: true,
+        record_persistent_quota: true,
+        retry_http_429: true,
+    };
+
+    pub(crate) const EXTRACTION: Self = Self {
+        check_persistent_quota: false,
+        record_persistent_quota: false,
+        retry_http_429: false,
+    };
+}
+
 impl Default for LlmRetryPolicy {
     fn default() -> Self {
         Self {
@@ -52,18 +73,27 @@ pub async fn llm_with_retry_policy<F>(
 where
     F: FnMut(usize, usize, u64, &InfraError),
 {
-    llm_with_retry_policy_ref(client.as_ref(), prompt, system, policy, on_retry).await
+    llm_with_retry_policy_ref(
+        client.as_ref(),
+        prompt,
+        system,
+        policy,
+        LlmRetryBehavior::SHARED_DEFAULT,
+        on_retry,
+    )
+    .await
 }
 
 /// Apply the shared timeout and retry policy to an already borrowed client.
 ///
 /// Application-layer use cases can use this variant without manufacturing an
 /// `Arc`; long-lived callers should keep using [`llm_with_retry_policy`].
-pub async fn llm_with_retry_policy_ref<F>(
+pub(crate) async fn llm_with_retry_policy_ref<F>(
     client: &dyn LlmClient,
     prompt: &str,
     system: &str,
     policy: LlmRetryPolicy,
+    behavior: LlmRetryBehavior,
     mut on_retry: F,
 ) -> InfraResult<String>
 where
@@ -73,7 +103,7 @@ where
     let request_timeout = Duration::from_millis(policy.request_timeout_millis.max(1));
 
     for attempt in 0..max_retries {
-        if is_quota_exhausted() {
+        if behavior.check_persistent_quota && is_quota_exhausted() {
             return Err(InfraError::RateLimited {
                 retry_after_secs: None,
             });
@@ -95,11 +125,14 @@ where
         match result {
             Ok(response) => return Ok(response),
             Err(err @ InfraError::RateLimited { retry_after_secs }) => {
-                set_quota_exhausted(retry_after_secs);
+                if behavior.record_persistent_quota {
+                    set_quota_exhausted(retry_after_secs);
+                }
                 return Err(err);
             }
             Err(err) => {
-                if !is_retryable_error(&err) || attempt == max_retries - 1 {
+                if !is_retryable_error(&err, behavior.retry_http_429) || attempt == max_retries - 1
+                {
                     return Err(err);
                 }
 
@@ -115,14 +148,20 @@ where
     unreachable!("retry loop always returns on success or failure")
 }
 
-fn is_retryable_error(err: &InfraError) -> bool {
+fn is_retryable_error(err: &InfraError, retry_http_429: bool) -> bool {
     if let InfraError::LlmHttp { status, .. } = err {
-        return *status == 408 || *status == 425 || *status == 429 || (500..=599).contains(status);
+        return *status == 408
+            || *status == 425
+            || (*status == 429 && retry_http_429)
+            || (500..=599).contains(status);
     }
     if matches!(err, InfraError::LlmRejected { .. }) {
         return false;
     }
     let msg = err.to_string();
+    if !retry_http_429 && is_rate_limit_message(&msg) {
+        return false;
+    }
     msg.contains("cooldown")
         || msg.contains("service_busy")
         || msg.contains("rate")
@@ -139,6 +178,16 @@ fn is_retryable_error(err: &InfraError) -> bool {
         || msg.contains("system_cpu_overloaded")
 }
 
+fn is_rate_limit_message(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    message.contains("429")
+        || message.contains("rate limit")
+        || message.contains("rate_limit")
+        || message.contains("rate-limit")
+        || message.contains("too many requests")
+        || message.contains("quota exceeded")
+}
+
 fn backoff_delay_secs(base_delay_secs: u64, attempt: usize) -> u64 {
     let backoff_factor = 1u64.checked_shl(attempt as u32).unwrap_or(u64::MAX);
     base_delay_secs.saturating_mul(backoff_factor)
@@ -150,24 +199,50 @@ mod tests {
 
     #[test]
     fn typed_http_status_controls_retryability() {
-        assert!(is_retryable_error(&InfraError::LlmHttp {
-            status: 503,
-            message: "moderation service unavailable".into(),
-        }));
-        assert!(is_retryable_error(&InfraError::LlmHttp {
-            status: 429,
-            message: "rate limited".into(),
-        }));
-        assert!(!is_retryable_error(&InfraError::LlmHttp {
-            status: 400,
-            message: "bad request".into(),
-        }));
-        assert!(is_retryable_error(&InfraError::LlmRequest(
-            "system_cpu_overloaded".into()
-        )));
+        assert!(is_retryable_error(
+            &InfraError::LlmHttp {
+                status: 503,
+                message: "moderation service unavailable".into(),
+            },
+            true,
+        ));
+        assert!(is_retryable_error(
+            &InfraError::LlmHttp {
+                status: 429,
+                message: "rate limited".into(),
+            },
+            true,
+        ));
+        assert!(!is_retryable_error(
+            &InfraError::LlmHttp {
+                status: 429,
+                message: "rate limited".into(),
+            },
+            false,
+        ));
+        assert!(!is_retryable_error(
+            &InfraError::LlmHttp {
+                status: 400,
+                message: "bad request".into(),
+            },
+            true,
+        ));
+        assert!(is_retryable_error(
+            &InfraError::LlmRequest("system_cpu_overloaded".into()),
+            true,
+        ));
+        assert!(is_retryable_error(
+            &InfraError::LlmRequest("provider rate table unavailable".into()),
+            false,
+        ));
+        assert!(!is_retryable_error(
+            &InfraError::LlmRequest("429 rate limit".into()),
+            false,
+        ));
     }
     use crate::infra::quota_state::{is_exhausted as is_quota_exhausted, set_quota_file_override};
     use async_trait::async_trait;
+    use chrono::{Duration as ChronoDuration, SecondsFormat, Utc};
     use std::collections::VecDeque;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -236,14 +311,23 @@ mod tests {
 
     struct QuotaTestGuard {
         _dir: TempDir,
+        path: PathBuf,
     }
 
     impl QuotaTestGuard {
         fn new() -> Self {
             let dir = TempDir::new().expect("tempdir");
             let path = dir.path().join(".refine").join("quota_exhausted_until");
-            set_quota_file_override(Some(path));
-            Self { _dir: dir }
+            set_quota_file_override(Some(path.clone()));
+            Self { _dir: dir, path }
+        }
+
+        fn mark_exhausted(&self) {
+            std::fs::create_dir_all(self.path.parent().expect("quota parent"))
+                .expect("create quota parent");
+            let until = Utc::now() + ChronoDuration::minutes(1);
+            std::fs::write(&self.path, until.to_rfc3339_opts(SecondsFormat::Secs, true))
+                .expect("write quota marker");
         }
     }
 
@@ -310,6 +394,51 @@ mod tests {
 
         assert_eq!(result, "ok");
         assert_eq!(client.calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn extraction_behavior_isolated_from_persistent_quota_state() {
+        let _env_guard = QUOTA_TEST_LOCK.lock().await;
+        let quota_guard = QuotaTestGuard::new();
+        quota_guard.mark_exhausted();
+        assert!(is_quota_exhausted());
+
+        let client = SequenceClient::new(vec![Ok("ok".into())]);
+        let result = llm_with_retry_policy_ref(
+            &client,
+            "prompt",
+            "system",
+            LlmRetryPolicy {
+                max_retries: 3,
+                base_delay_secs: 0,
+                ..LlmRetryPolicy::default()
+            },
+            LlmRetryBehavior::EXTRACTION,
+            |_attempt, _max_retries, _delay_secs, _err| {},
+        )
+        .await
+        .expect("unrelated persistent quota must not block extraction");
+
+        assert_eq!(result, "ok");
+        assert_eq!(client.calls(), 1);
+
+        let fresh_guard = QuotaTestGuard::new();
+        assert!(!is_quota_exhausted());
+        let limited_client = SequenceClient::new(vec![Err(InfraError::RateLimited {
+            retry_after_secs: Some(60),
+        })]);
+        llm_with_retry_policy_ref(
+            &limited_client,
+            "prompt",
+            "system",
+            LlmRetryPolicy::default(),
+            LlmRetryBehavior::EXTRACTION,
+            |_attempt, _max_retries, _delay_secs, _err| {},
+        )
+        .await
+        .expect_err("explicit rate limit must fail fast");
+        assert!(!is_quota_exhausted());
+        drop(fresh_guard);
     }
 
     #[tokio::test]

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -785,8 +785,8 @@ pub use llm::{
     OpenAIClient,
 };
 pub use llm_retry::{
-    llm_with_retry, llm_with_retry_policy, LlmRetryPolicy, DEFAULT_MAX_RETRIES,
-    DEFAULT_RETRY_BASE_DELAY_SECS,
+    llm_with_retry, llm_with_retry_policy, llm_with_retry_policy_ref, LlmRetryPolicy,
+    DEFAULT_MAX_RETRIES, DEFAULT_RETRY_BASE_DELAY_SECS,
 };
 pub use paths::{default_db_path, ensure_db_dir, resolve_db_path, stale_db_candidates};
 pub use quota_state::{is_exhausted as is_quota_exhausted, set_exhausted as set_quota_exhausted};

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -785,9 +785,10 @@ pub use llm::{
     OpenAIClient,
 };
 pub use llm_retry::{
-    llm_with_retry, llm_with_retry_policy, llm_with_retry_policy_ref, LlmRetryPolicy,
-    DEFAULT_MAX_RETRIES, DEFAULT_RETRY_BASE_DELAY_SECS,
+    llm_with_retry, llm_with_retry_policy, LlmRetryPolicy, DEFAULT_MAX_RETRIES,
+    DEFAULT_RETRY_BASE_DELAY_SECS,
 };
+pub(crate) use llm_retry::{llm_with_retry_policy_ref, LlmRetryBehavior};
 pub use paths::{default_db_path, ensure_db_dir, resolve_db_path, stale_db_candidates};
 pub use quota_state::{is_exhausted as is_quota_exhausted, set_exhausted as set_quota_exhausted};
 pub use sqlite::SqliteStore;

--- a/packages/core/src/refinement/usecase.rs
+++ b/packages/core/src/refinement/usecase.rs
@@ -4,7 +4,7 @@
 //! 供 server/desktop/cli 复用，避免多处重复实现。
 
 use crate::error::{DomainError, DomainResult, InfraResult};
-use crate::infra::LlmClient;
+use crate::infra::{llm_with_retry_policy_ref, LlmClient, LlmRetryPolicy};
 use crate::knowledge::{Document, DocumentId, DocumentRepository, Item, Source};
 use crate::refinement::{
     Conversation, ExtractionPolicy, ExtractionResult, Extractor, PromptTemplate,
@@ -14,6 +14,55 @@ pub const EXTRACTION_SYSTEM_PROMPT: &str =
     "你是 Refine 的知识提炼助手。严格按要求返回 JSON，不要输出额外说明文本。";
 pub const JSON_REPAIR_SYSTEM_PROMPT: &str =
     "你是 JSON 修复器。只输出一个合法 JSON 对象，不要输出 markdown 或解释。";
+pub const DEFAULT_EXTRACTION_MAX_ATTEMPTS: usize = 3;
+pub const DEFAULT_EXTRACTION_RETRY_BASE_DELAY_SECS: u64 = 1;
+pub const DEFAULT_EXTRACTION_REQUEST_TIMEOUT_MILLIS: u64 = 90_000;
+const MAX_EXTRACTION_ATTEMPTS: usize = 5;
+const MAX_EXTRACTION_RETRY_BASE_DELAY_SECS: u64 = 60;
+const MIN_EXTRACTION_REQUEST_TIMEOUT_MILLIS: u64 = 1_000;
+const MAX_EXTRACTION_REQUEST_TIMEOUT_MILLIS: u64 = 300_000;
+
+/// Bounded extraction policy. Environment overrides are intentionally capped
+/// so a typo cannot restore an effectively unbounded provider wait or retry
+/// storm.
+pub fn extraction_retry_policy_from_env() -> LlmRetryPolicy {
+    extraction_retry_policy_with(|key| std::env::var(key).ok())
+}
+
+fn extraction_retry_policy_with(mut get: impl FnMut(&str) -> Option<String>) -> LlmRetryPolicy {
+    let max_retries = parse_bounded_env(
+        get("REFINE_EXTRACTION_MAX_ATTEMPTS"),
+        DEFAULT_EXTRACTION_MAX_ATTEMPTS,
+        1,
+        MAX_EXTRACTION_ATTEMPTS,
+    );
+    let base_delay_secs = parse_bounded_env(
+        get("REFINE_EXTRACTION_RETRY_BASE_DELAY_SECS"),
+        DEFAULT_EXTRACTION_RETRY_BASE_DELAY_SECS,
+        0,
+        MAX_EXTRACTION_RETRY_BASE_DELAY_SECS,
+    );
+    let request_timeout_millis = parse_bounded_env(
+        get("REFINE_EXTRACTION_REQUEST_TIMEOUT_MILLIS"),
+        DEFAULT_EXTRACTION_REQUEST_TIMEOUT_MILLIS,
+        MIN_EXTRACTION_REQUEST_TIMEOUT_MILLIS,
+        MAX_EXTRACTION_REQUEST_TIMEOUT_MILLIS,
+    );
+    LlmRetryPolicy {
+        max_retries,
+        base_delay_secs,
+        request_timeout_millis,
+    }
+}
+
+fn parse_bounded_env<T>(raw: Option<String>, default: T, min: T, max: T) -> T
+where
+    T: Copy + Ord + std::str::FromStr,
+{
+    raw.and_then(|value| value.trim().parse::<T>().ok())
+        .map(|value| value.clamp(min, max))
+        .unwrap_or(default)
+}
 
 /// 提炼输入参数（供多端复用）
 pub struct ItemExtractionInput<'a> {
@@ -112,16 +161,37 @@ pub async fn extract_items_with_llm(
     raw_content: &str,
     policy: ExtractionPolicy,
 ) -> DomainResult<Vec<Item>> {
+    extract_items_with_llm_policy(
+        llm_client,
+        raw_content,
+        policy,
+        extraction_retry_policy_from_env(),
+    )
+    .await
+}
+
+async fn extract_items_with_llm_policy(
+    llm_client: &dyn LlmClient,
+    raw_content: &str,
+    policy: ExtractionPolicy,
+    retry_policy: LlmRetryPolicy,
+) -> DomainResult<Vec<Item>> {
     let conversation = Conversation::parse(raw_content)?;
     let prompt = PromptTemplate::extraction_prompt(&conversation.raw, &policy);
-    let llm_response = llm_client
-        .complete(&prompt, Some(EXTRACTION_SYSTEM_PROMPT))
-        .await
-        .map_err(|err| DomainError::Extraction(format!("LLM 调用失败: {}", err)))?;
+    let llm_response =
+        protected_llm_call(llm_client, &prompt, EXTRACTION_SYSTEM_PROMPT, retry_policy)
+            .await
+            .map_err(|err| DomainError::Extraction(format!("LLM 调用失败: {}", err)))?;
 
     let extractor = Extractor::new(policy);
-    let extraction =
-        parse_extraction_with_repair(llm_client, &extractor, &conversation, &llm_response).await?;
+    let extraction = parse_extraction_with_repair(
+        llm_client,
+        &extractor,
+        &conversation,
+        &llm_response,
+        retry_policy,
+    )
+    .await?;
 
     if extraction.items.is_empty() {
         return Err(DomainError::Extraction("提炼结果为空".to_string()));
@@ -130,11 +200,36 @@ pub async fn extract_items_with_llm(
     Ok(extraction.items)
 }
 
+async fn protected_llm_call(
+    llm_client: &dyn LlmClient,
+    prompt: &str,
+    system: &str,
+    retry_policy: LlmRetryPolicy,
+) -> InfraResult<String> {
+    llm_with_retry_policy_ref(
+        llm_client,
+        prompt,
+        system,
+        retry_policy,
+        |attempt, max_attempts, delay_secs, err| {
+            tracing::warn!(
+                attempt,
+                max_attempts,
+                delay_secs,
+                error = %err,
+                "LLM extraction attempt failed; retrying"
+            );
+        },
+    )
+    .await
+}
+
 async fn parse_extraction_with_repair(
     llm_client: &dyn LlmClient,
     extractor: &Extractor,
     conversation: &Conversation,
     raw_response: &str,
+    retry_policy: LlmRetryPolicy,
 ) -> DomainResult<ExtractionResult> {
     match extractor.parse_response(raw_response, conversation) {
         Ok(extraction) => Ok(extraction),
@@ -143,12 +238,16 @@ async fn parse_extraction_with_repair(
             tracing::warn!("首次提炼解析失败，尝试 JSON 修复重试: {}", first_message);
 
             let repair_prompt = build_json_repair_prompt(raw_response, &first_message);
-            let repaired_response = llm_client
-                .complete(&repair_prompt, Some(JSON_REPAIR_SYSTEM_PROMPT))
-                .await
-                .map_err(|err| {
-                    DomainError::Extraction(format!("原始解析失败，且 JSON 修复请求失败: {}", err))
-                })?;
+            let repaired_response = protected_llm_call(
+                llm_client,
+                &repair_prompt,
+                JSON_REPAIR_SYSTEM_PROMPT,
+                retry_policy,
+            )
+            .await
+            .map_err(|err| {
+                DomainError::Extraction(format!("原始解析失败，且 JSON 修复请求失败: {}", err))
+            })?;
 
             extractor
                 .parse_response(&repaired_response, conversation)
@@ -193,15 +292,29 @@ fn build_json_repair_prompt(raw_response: &str, parse_error: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::InfraResult;
+    use crate::error::{InfraError, InfraResult};
     use async_trait::async_trait;
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     struct SequenceLlmClient {
         responses: Arc<Mutex<Vec<String>>>,
     }
 
     struct AlwaysFailLlmClient;
+
+    enum LlmStep {
+        Return(InfraResult<String>),
+        Delayed(Duration, InfraResult<String>),
+    }
+
+    struct ScriptedLlmClient {
+        calls: AtomicUsize,
+        steps: Mutex<VecDeque<LlmStep>>,
+        systems: Mutex<Vec<Option<String>>>,
+    }
 
     impl SequenceLlmClient {
         fn new(responses: Vec<&str>) -> Self {
@@ -210,6 +323,24 @@ mod tests {
                     responses.into_iter().map(ToString::to_string).collect(),
                 )),
             }
+        }
+    }
+
+    impl ScriptedLlmClient {
+        fn new(steps: Vec<LlmStep>) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                steps: Mutex::new(VecDeque::from(steps)),
+                systems: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+
+        fn systems(&self) -> Vec<Option<String>> {
+            self.systems.lock().expect("systems lock poisoned").clone()
         }
     }
 
@@ -236,6 +367,239 @@ mod tests {
                 "mock failure".to_string(),
             ))
         }
+    }
+
+    #[async_trait]
+    impl LlmClient for ScriptedLlmClient {
+        async fn complete(&self, _prompt: &str, system: Option<&str>) -> InfraResult<String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.systems
+                .lock()
+                .expect("systems lock poisoned")
+                .push(system.map(ToString::to_string));
+            let step = self
+                .steps
+                .lock()
+                .expect("steps lock poisoned")
+                .pop_front()
+                .unwrap_or_else(|| {
+                    LlmStep::Return(Err(InfraError::LlmRequest(
+                        "no scripted response".to_string(),
+                    )))
+                });
+            match step {
+                LlmStep::Return(result) => result,
+                LlmStep::Delayed(delay, result) => {
+                    tokio::time::sleep(delay).await;
+                    result
+                }
+            }
+        }
+    }
+
+    fn immediate_response(response: &str) -> LlmStep {
+        LlmStep::Return(Ok(response.to_string()))
+    }
+
+    fn immediate_error(error: InfraError) -> LlmStep {
+        LlmStep::Return(Err(error))
+    }
+
+    fn delayed_response(delay_millis: u64, response: &str) -> LlmStep {
+        LlmStep::Delayed(
+            Duration::from_millis(delay_millis),
+            Ok(response.to_string()),
+        )
+    }
+
+    fn fast_retry_policy(max_attempts: usize, timeout_millis: u64) -> LlmRetryPolicy {
+        LlmRetryPolicy {
+            max_retries: max_attempts,
+            base_delay_secs: 0,
+            request_timeout_millis: timeout_millis,
+        }
+    }
+
+    const VALID_EXTRACTION: &str =
+        r#"{"items":[{"type":"knowledge","title":"T","summary":"S","content":"C","tags":[]}] }"#;
+    const INVALID_EXTRACTION: &str = r#"{"items":[{"type":"knowledge","title":"broken""#;
+
+    #[test]
+    fn extraction_environment_policy_defaults_and_clamps_overrides() {
+        let defaults = extraction_retry_policy_with(|_| None);
+        assert_eq!(defaults.max_retries, DEFAULT_EXTRACTION_MAX_ATTEMPTS);
+        assert_eq!(
+            defaults.base_delay_secs,
+            DEFAULT_EXTRACTION_RETRY_BASE_DELAY_SECS
+        );
+        assert_eq!(
+            defaults.request_timeout_millis,
+            DEFAULT_EXTRACTION_REQUEST_TIMEOUT_MILLIS
+        );
+
+        let bounded = extraction_retry_policy_with(|key| match key {
+            "REFINE_EXTRACTION_MAX_ATTEMPTS" => Some("99".to_string()),
+            "REFINE_EXTRACTION_RETRY_BASE_DELAY_SECS" => Some("999".to_string()),
+            "REFINE_EXTRACTION_REQUEST_TIMEOUT_MILLIS" => Some("1".to_string()),
+            _ => None,
+        });
+        assert_eq!(bounded.max_retries, MAX_EXTRACTION_ATTEMPTS);
+        assert_eq!(
+            bounded.base_delay_secs,
+            MAX_EXTRACTION_RETRY_BASE_DELAY_SECS
+        );
+        assert_eq!(
+            bounded.request_timeout_millis,
+            MIN_EXTRACTION_REQUEST_TIMEOUT_MILLIS
+        );
+    }
+
+    #[tokio::test]
+    async fn initial_extraction_retries_transient_failure() {
+        let client = ScriptedLlmClient::new(vec![
+            immediate_error(InfraError::LlmHttp {
+                status: 503,
+                message: "temporarily unavailable".to_string(),
+            }),
+            immediate_response(VALID_EXTRACTION),
+        ]);
+
+        let items = extract_items_with_llm_policy(
+            &client,
+            "Human: hello\nAssistant: world",
+            ExtractionPolicy::default(),
+            fast_retry_policy(2, 50),
+        )
+        .await
+        .expect("transient initial failure should recover");
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(client.calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn initial_extraction_timeout_is_bounded_and_retried() {
+        let client = ScriptedLlmClient::new(vec![
+            delayed_response(30, VALID_EXTRACTION),
+            immediate_response(VALID_EXTRACTION),
+        ]);
+
+        let items = extract_items_with_llm_policy(
+            &client,
+            "Human: hello\nAssistant: world",
+            ExtractionPolicy::default(),
+            fast_retry_policy(2, 5),
+        )
+        .await
+        .expect("timed-out initial attempt should recover");
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(client.calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn initial_extraction_does_not_retry_deterministic_errors() {
+        for error in [
+            InfraError::LlmHttp {
+                status: 401,
+                message: "invalid api key".to_string(),
+            },
+            InfraError::LlmRejected {
+                code: "content_filter".to_string(),
+                message: "blocked".to_string(),
+            },
+        ] {
+            let client = ScriptedLlmClient::new(vec![
+                immediate_error(error),
+                immediate_response(VALID_EXTRACTION),
+            ]);
+            extract_items_with_llm_policy(
+                &client,
+                "Human: hello\nAssistant: world",
+                ExtractionPolicy::default(),
+                fast_retry_policy(3, 50),
+            )
+            .await
+            .expect_err("auth and content-policy failures must fail fast");
+            assert_eq!(client.calls(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn json_repair_retries_transient_failure() {
+        let client = ScriptedLlmClient::new(vec![
+            immediate_response(INVALID_EXTRACTION),
+            immediate_error(InfraError::LlmHttp {
+                status: 503,
+                message: "upstream unavailable".to_string(),
+            }),
+            immediate_response(VALID_EXTRACTION),
+        ]);
+
+        let items = extract_items_with_llm_policy(
+            &client,
+            "Human: hello\nAssistant: world",
+            ExtractionPolicy::default(),
+            fast_retry_policy(2, 50),
+        )
+        .await
+        .expect("transient repair failure should recover");
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(client.calls(), 3);
+        assert_eq!(
+            client.systems(),
+            vec![
+                Some(EXTRACTION_SYSTEM_PROMPT.to_string()),
+                Some(JSON_REPAIR_SYSTEM_PROMPT.to_string()),
+                Some(JSON_REPAIR_SYSTEM_PROMPT.to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn json_repair_timeout_is_bounded_and_retried() {
+        let client = ScriptedLlmClient::new(vec![
+            immediate_response(INVALID_EXTRACTION),
+            delayed_response(30, VALID_EXTRACTION),
+            immediate_response(VALID_EXTRACTION),
+        ]);
+
+        let items = extract_items_with_llm_policy(
+            &client,
+            "Human: hello\nAssistant: world",
+            ExtractionPolicy::default(),
+            fast_retry_policy(2, 5),
+        )
+        .await
+        .expect("timed-out repair attempt should recover");
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(client.calls(), 3);
+    }
+
+    #[tokio::test]
+    async fn json_repair_does_not_retry_deterministic_rejection() {
+        let client = ScriptedLlmClient::new(vec![
+            immediate_response(INVALID_EXTRACTION),
+            immediate_error(InfraError::LlmRejected {
+                code: "content_filter".to_string(),
+                message: "blocked".to_string(),
+            }),
+            immediate_response(VALID_EXTRACTION),
+        ]);
+
+        let error = extract_items_with_llm_policy(
+            &client,
+            "Human: hello\nAssistant: world",
+            ExtractionPolicy::default(),
+            fast_retry_policy(3, 50),
+        )
+        .await
+        .expect_err("deterministic repair rejection must fail fast");
+
+        assert!(error.to_string().contains("JSON 修复请求失败"));
+        assert_eq!(client.calls(), 2);
     }
 
     #[tokio::test]

--- a/packages/core/src/refinement/usecase.rs
+++ b/packages/core/src/refinement/usecase.rs
@@ -4,7 +4,7 @@
 //! 供 server/desktop/cli 复用，避免多处重复实现。
 
 use crate::error::{DomainError, DomainResult, InfraResult};
-use crate::infra::{llm_with_retry_policy_ref, LlmClient, LlmRetryPolicy};
+use crate::infra::{llm_with_retry_policy_ref, LlmClient, LlmRetryBehavior, LlmRetryPolicy};
 use crate::knowledge::{Document, DocumentId, DocumentRepository, Item, Source};
 use crate::refinement::{
     Conversation, ExtractionPolicy, ExtractionResult, Extractor, PromptTemplate,
@@ -211,6 +211,7 @@ async fn protected_llm_call(
         prompt,
         system,
         retry_policy,
+        LlmRetryBehavior::EXTRACTION,
         |attempt, max_attempts, delay_secs, err| {
             tracing::warn!(
                 attempt,
@@ -504,6 +505,10 @@ mod tests {
                 status: 401,
                 message: "invalid api key".to_string(),
             },
+            InfraError::LlmHttp {
+                status: 429,
+                message: "rate limited".to_string(),
+            },
             InfraError::LlmRejected {
                 code: "content_filter".to_string(),
                 message: "blocked".to_string(),
@@ -520,7 +525,7 @@ mod tests {
                 fast_retry_policy(3, 50),
             )
             .await
-            .expect_err("auth and content-policy failures must fail fast");
+            .expect_err("auth, rate-limit, and content-policy failures must fail fast");
             assert_eq!(client.calls(), 1);
         }
     }
@@ -579,27 +584,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn json_repair_does_not_retry_deterministic_rejection() {
-        let client = ScriptedLlmClient::new(vec![
-            immediate_response(INVALID_EXTRACTION),
-            immediate_error(InfraError::LlmRejected {
+    async fn json_repair_does_not_retry_deterministic_errors() {
+        for error in [
+            InfraError::LlmHttp {
+                status: 429,
+                message: "rate limited".to_string(),
+            },
+            InfraError::LlmRejected {
                 code: "content_filter".to_string(),
                 message: "blocked".to_string(),
-            }),
-            immediate_response(VALID_EXTRACTION),
-        ]);
+            },
+        ] {
+            let client = ScriptedLlmClient::new(vec![
+                immediate_response(INVALID_EXTRACTION),
+                immediate_error(error),
+                immediate_response(VALID_EXTRACTION),
+            ]);
 
-        let error = extract_items_with_llm_policy(
-            &client,
-            "Human: hello\nAssistant: world",
-            ExtractionPolicy::default(),
-            fast_retry_policy(3, 50),
-        )
-        .await
-        .expect_err("deterministic repair rejection must fail fast");
+            let error = extract_items_with_llm_policy(
+                &client,
+                "Human: hello\nAssistant: world",
+                ExtractionPolicy::default(),
+                fast_retry_policy(3, 50),
+            )
+            .await
+            .expect_err("deterministic repair failure must fail fast");
 
-        assert!(error.to_string().contains("JSON 修复请求失败"));
-        assert_eq!(client.calls(), 2);
+            assert!(error.to_string().contains("JSON 修复请求失败"));
+            assert_eq!(client.calls(), 2);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #167

## Summary
- route both initial extraction and JSON-repair requests through the shared timeout/retry layer
- add bounded extraction-specific environment overrides with conservative defaults
- keep deterministic auth/content-policy failures fail-fast and cover both phases with regression tests
- document the shared policy for CLI, server, desktop, and mirror callers

## Scope boundary
Provider-specific HTTP 429/quota classification is tracked separately as H07 and is intentionally not changed here.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p refine-core refinement::usecase::tests --locked --target-dir /tmp/refine-h06-final-target` (16 passed)
- `cargo test -p refine-core infra::llm_retry::tests --locked --target-dir /tmp/refine-h06-final-target` (9 passed)
- `cargo clippy -p refine-core --locked --target-dir /tmp/refine-h06-final-target -- -D warnings`
- `cargo check -p refine-cli -p refine-server -p refine-desktop -p mirror --locked --target-dir /tmp/refine-h06-final-target`