### PR TITLE
fix: correct Mirror personal scoring inputs

### DIFF
--- a/SPEC-mirror.md
+++ b/SPEC-mirror.md
@@ -28,7 +28,7 @@ refine workspace 新 member `apps/mirror/`，纯 Rust CLI，只读 refine SQLite
 | 指标 | 数据来源 | 计算 | 绿 | 黄 | 红 |
 |------|---------|------|---|---|---|
 | Dreyfus 加权分 | cognitive_level tags | novice=1,adv=2,comp=3,prof=4,exp=5 加权平均 | >3.5 | 2.5-3.5 | <2.5 |
-| 决策质量率 | decision titles 含"因为/原因"比例 | 关键词匹配 | >60% | 40-60% | <40% |
+| 理由显式率 | decision titles 含"因为/原因"比例 | 关键词匹配；不等同决策质量 | >60% | 40-60% | <40% |
 | 深度思考产出比 | deep_inquiry 中 expert% vs delegation 中 expert% | 交叉统计 | 差>10% | 差0-10% | 反转 |
 
 层 1 信号灯 = 3 个指标中最差的那个
@@ -38,8 +38,8 @@ refine workspace 新 member `apps/mirror/`，纯 Rust CLI，只读 refine SQLite
 | 指标 | 数据来源 | 计算 | 绿 | 黄 | 红 |
 |------|---------|------|---|---|---|
 | 探索率 | exploration / 总协作模式 | 百分比 | >15% | 8-15% | <8% |
-| 深耕率 | 20+ session 项目 / 总项目 | 百分比 | 15-30% | <10%或>30% | <5%或>50% |
-| 碎片化指数 | 1 session 项目 / 总项目 | 百分比 | <20% | 20-40% | >40% |
+| 成熟项目占比 | 20+ session 项目 / 总项目 | 百分比 | 15-30% | 10-15% | <10%或>30% |
+| 一次性项目占比 | 1 session 项目 / 总项目 | 百分比；不等同上下文切换 | <20% | 20-40% | >40% |
 
 层 2 信号灯 = 3 个指标中最差的那个
 
@@ -49,7 +49,7 @@ refine workspace 新 member `apps/mirror/`，纯 Rust CLI，只读 refine SQLite
 |------|---------|------|---|---|---|
 | delegation 率 | delegation / 总协作模式 | 百分比 | <40% | 40-55% | >55% |
 | 模式多样性 | 协作模式中 >0 的数量 | 整数 | >=4 | 2-3 | 1 |
-| Bug/决策比 | bugfix / decision | 比率 | <0.6 | 0.6-0.8 | >0.8 |
+| Bug/决策抽取比 | extracted bugfix / extracted decision | 提取量比率，不等同协作质量 | <0.6 | 0.6-0.8 | >0.8 |
 
 层 3 信号灯 = 3 个指标中最差的那个
 

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -135,6 +135,9 @@ pub enum Commands {
         /// Explicitly retry sessions previously quarantined for deterministic provider rejection.
         #[arg(long)]
         retry_quarantined: bool,
+        /// Backfill project/provenance metadata on existing observations without calling an LLM.
+        #[arg(long, requires = "source")]
+        backfill_session_metadata: bool,
     },
     /// 生成认知洞察报告
     Insights {

--- a/apps/cli/src/handlers.rs
+++ b/apps/cli/src/handlers.rs
@@ -42,6 +42,7 @@ pub async fn run(
             dry_run,
             legacy_local_scan,
             retry_quarantined,
+            backfill_session_metadata,
         } => {
             let provider = IngestProvider::resolve(provider, legacy_local_scan)?;
             let source_filter = source
@@ -59,7 +60,10 @@ pub async fn run(
             if legacy_local_scan {
                 eprintln!("warning: --legacy-local-scan is deprecated; use --provider local");
             }
-            let llm_client = if dry_run {
+            if backfill_session_metadata && provider != IngestProvider::Local {
+                anyhow::bail!("--backfill-session-metadata requires --provider local");
+            }
+            let llm_client = if dry_run || backfill_session_metadata {
                 None
             } else {
                 Some(build_llm_client_from_env()?)
@@ -73,6 +77,7 @@ pub async fn run(
                     latest,
                     dry_run,
                     retry_quarantined,
+                    backfill_session_metadata,
                 },
                 db_path,
                 doc_store,

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -15,10 +15,11 @@ use refine_core::infra::{
     llm_with_retry_policy, LlmClient, LlmRetryPolicy, DEFAULT_MAX_RETRIES,
     DEFAULT_RETRY_BASE_DELAY_SECS,
 };
-use refine_core::knowledge::{Document, DocumentRepository, RestoreDocumentParams};
+use refine_core::knowledge::{Document, DocumentRepository, RestoreDocumentParams, Tag};
 use refine_core::session::{
-    build_facet_prompt, chunk_session, discover_sessions, facets_to_items, needs_chunking,
-    parse_facet_response, parse_session_file, FilterConfig, SessionSource, FACET_SYSTEM_PROMPT,
+    build_facet_prompt, chunk_session, discover_sessions, facets_to_items_with_mode,
+    needs_chunking, normalize_project_name, parse_facet_response, parse_session_file, FilterConfig,
+    SessionMode, SessionSource, FACET_SYSTEM_PROMPT,
 };
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -51,6 +52,7 @@ pub struct IngestOptions {
     pub latest: Option<usize>,
     pub dry_run: bool,
     pub retry_quarantined: bool,
+    pub backfill_session_metadata: bool,
 }
 
 #[derive(Debug)]
@@ -79,6 +81,7 @@ struct PendingSession {
     url: String,
     source: SessionSource,
     project: Option<String>,
+    mode: SessionMode,
     captured_at: DateTime<Utc>,
     has_embedded_timestamp: bool,
     raw_content: String,
@@ -93,9 +96,80 @@ fn project_for_ingest(
     discovered_project: Option<&str>,
     session_project: Option<&str>,
 ) -> Option<String> {
-    discovered_project
-        .or(session_project)
+    session_project
+        .or(discovered_project)
         .map(ToOwned::to_owned)
+}
+
+fn is_observation_metadata_tag(tag: &str) -> bool {
+    matches!(
+        tag,
+        "decision"
+            | "bugfix"
+            | "novice"
+            | "advanced_beginner"
+            | "competent"
+            | "proficient"
+            | "expert"
+            | "delegation"
+            | "pair_programming"
+            | "review"
+            | "exploration"
+            | "teaching"
+            | "deep_inquiry"
+    ) || tag.starts_with("session_mode_")
+}
+
+async fn backfill_session_metadata(
+    doc_store: &Arc<dyn DocumentRepository>,
+    document: &Document,
+    mode: SessionMode,
+    project: Option<&str>,
+) -> Result<bool> {
+    let expected = mode.as_tag();
+    let project = project.and_then(normalize_project_name);
+    let mut items = doc_store
+        .find_items_by_document_id(document.id())
+        .await
+        .context("load observations for session-mode backfill")?;
+    let mut changed = false;
+    for item in &mut items {
+        let old_tags = item
+            .tags()
+            .iter()
+            .map(|tag| tag.as_str())
+            .collect::<Vec<_>>();
+        let mut tags = item
+            .tags()
+            .iter()
+            .filter(|tag| {
+                is_observation_metadata_tag(tag.as_str())
+                    && !tag.as_str().starts_with("session_mode_")
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        tags.push(Tag::try_new(expected).expect("static session mode tag is valid"));
+        if let Some(project) = project.as_deref() {
+            if let Some(tag) = Tag::try_new(project) {
+                tags.push(tag);
+            }
+        }
+        let new_tags = tags.iter().map(|tag| tag.as_str()).collect::<Vec<_>>();
+        if old_tags == new_tags {
+            continue;
+        }
+        item.set_tags(tags)
+            .map_err(|error| anyhow::anyhow!("set session-mode tag: {error}"))?;
+        changed = true;
+    }
+
+    if changed {
+        doc_store
+            .save_with_replaced_items(document, &items)
+            .await
+            .context("persist session-mode metadata backfill")?;
+    }
+    Ok(changed)
 }
 
 fn session_captured_at(
@@ -129,7 +203,12 @@ fn document_with_source_version(document: &Document, source_version: &str) -> Do
     })
 }
 
-fn incremental_cursor_path(home: &Path, source: Option<&SessionSource>, db_path: &Path) -> PathBuf {
+fn incremental_cursor_path(
+    home: &Path,
+    source: Option<&SessionSource>,
+    db_path: &Path,
+    cursor_name: &str,
+) -> PathBuf {
     let source_key = match source {
         Some(SessionSource::ClaudeCode) => "claude-code",
         Some(SessionSource::Codex) => "codex",
@@ -139,7 +218,7 @@ fn incremental_cursor_path(home: &Path, source: Option<&SessionSource>, db_path:
     let db_key = encode_path_for_filename(db_path);
     home.join(".refine")
         .join("ingest-cursors")
-        .join(format!("last-ingest-mtime-{source_key}-{db_key}"))
+        .join(format!("last-{cursor_name}-mtime-{source_key}-{db_key}"))
 }
 
 fn encode_path_for_filename(path: &Path) -> String {
@@ -153,17 +232,26 @@ fn encode_path_for_filename(path: &Path) -> String {
 }
 
 /// Read the Unix-second timestamp from the scoped ingest cursor file.
-fn read_last_ingest_mtime(source: Option<&SessionSource>, db_path: &Path) -> Option<SystemTime> {
+fn read_last_scan_mtime(
+    source: Option<&SessionSource>,
+    db_path: &Path,
+    cursor_name: &str,
+) -> Option<SystemTime> {
     let home = dirs::home_dir()?;
-    let path = incremental_cursor_path(&home, source, db_path);
+    let path = incremental_cursor_path(&home, source, db_path, cursor_name);
     let secs: u64 = std::fs::read_to_string(path).ok()?.trim().parse().ok()?;
     Some(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
 }
 
 /// Persist the Unix-second timestamp to the scoped ingest cursor file.
-fn write_last_ingest_mtime(source: Option<&SessionSource>, db_path: &Path, t: SystemTime) {
+fn write_last_scan_mtime(
+    source: Option<&SessionSource>,
+    db_path: &Path,
+    cursor_name: &str,
+    t: SystemTime,
+) {
     let Some(home) = dirs::home_dir() else { return };
-    let path = incremental_cursor_path(&home, source, db_path);
+    let path = incremental_cursor_path(&home, source, db_path, cursor_name);
     let Some(dir) = path.parent() else { return };
     if let Err(e) = std::fs::create_dir_all(dir) {
         tracing::warn!("failed to create {}: {}", dir.display(), e);
@@ -186,6 +274,9 @@ pub async fn handle_ingest_sessions(
         anyhow::bail!(
             "--source requires --provider local because remem does not expose a trustworthy Claude/Codex source"
         );
+    }
+    if options.backfill_session_metadata && options.provider != IngestProvider::Local {
+        anyhow::bail!("--backfill-session-metadata requires --provider local");
     }
 
     match options.provider {
@@ -375,6 +466,7 @@ async fn handle_remem_ingest_sessions_with_summaries(
             url,
             source: remem_session.session.source,
             project: Some(remem_session.project),
+            mode: remem_session.session.meta.mode,
             captured_at,
             has_embedded_timestamp: true,
             raw_content,
@@ -412,9 +504,14 @@ async fn handle_legacy_ingest_sessions(
     // 1-hour overlap on the cutoff absorbs clock skew and files modified near the boundary.
     let incremental = options.limit.is_none() && options.latest.is_none() && !options.dry_run;
     let source = options.source.clone();
+    let cursor_name = if options.backfill_session_metadata {
+        "metadata"
+    } else {
+        "ingest"
+    };
     let scan_start = SystemTime::now();
     let mtime_after = if incremental {
-        read_last_ingest_mtime(source.as_ref(), db_path).map(|last| {
+        read_last_scan_mtime(source.as_ref(), db_path, cursor_name).map(|last| {
             last.checked_sub(Duration::from_secs(3600))
                 .unwrap_or(SystemTime::UNIX_EPOCH)
         })
@@ -450,6 +547,8 @@ async fn handle_legacy_ingest_sessions(
     let mut skipped_dup = 0usize;
     let mut skipped_filter = 0usize;
     let mut stale_refresh = 0usize;
+    let mut metadata_backfilled = 0usize;
+    let mut metadata_missing = 0usize;
 
     // 阶段 1: 串行做去重 + 过滤 + 解析（快，不需要 LLM）
     for (idx, ds) in sessions_to_process.iter().enumerate() {
@@ -465,6 +564,7 @@ async fn handle_legacy_ingest_sessions(
         };
 
         let project = project_for_ingest(ds.project.as_deref(), session.meta.project.as_deref());
+        let mode = session.meta.mode;
         let has_embedded_timestamp = session.meta.started_at.is_some();
         let captured_at = session_captured_at(session.meta.started_at, ds.modified_at);
         let raw_content = session.to_document_content();
@@ -475,6 +575,25 @@ async fn handle_legacy_ingest_sessions(
             captured_at,
             &raw_content,
         )?;
+
+        if options.backfill_session_metadata {
+            let existing = remem_document.as_ref().or(legacy_document.as_ref());
+            match existing {
+                Some(_document) if options.dry_run => {
+                    println!("  [dry-run] {} | would backfill {:?}", legacy_url, mode);
+                    metadata_backfilled += 1;
+                }
+                Some(document) => {
+                    if backfill_session_metadata(&doc_store, document, mode, project.as_deref())
+                        .await?
+                    {
+                        metadata_backfilled += 1;
+                    }
+                }
+                None => metadata_missing += 1,
+            }
+            continue;
+        }
 
         let mut legacy_documents_to_delete = Vec::new();
         let (url, effective_source, existing_document) = if let Some(remem_doc) = remem_document {
@@ -497,6 +616,8 @@ async fn handle_legacy_ingest_sessions(
                         );
                     }
                 } else {
+                    backfill_session_metadata(&doc_store, &remem_doc, mode, project.as_deref())
+                        .await?;
                     doc_store
                         .delete_documents_with_items(&legacy_documents_to_delete)
                         .await
@@ -512,6 +633,15 @@ async fn handle_legacy_ingest_sessions(
                 if session_needs_refresh(existing_doc, ds.modified_at) {
                     stale_refresh += 1;
                 } else {
+                    if !options.dry_run {
+                        backfill_session_metadata(
+                            &doc_store,
+                            existing_doc,
+                            mode,
+                            project.as_deref(),
+                        )
+                        .await?;
+                    }
                     skipped_dup += 1;
                     continue;
                 }
@@ -557,6 +687,7 @@ async fn handle_legacy_ingest_sessions(
             url,
             source: effective_source,
             project,
+            mode,
             captured_at,
             has_embedded_timestamp,
             raw_content,
@@ -566,6 +697,17 @@ async fn handle_legacy_ingest_sessions(
             existing_document,
             legacy_documents_to_delete,
         });
+    }
+
+    if options.backfill_session_metadata {
+        if incremental && !options.dry_run {
+            write_last_scan_mtime(source.as_ref(), db_path, cursor_name, scan_start);
+        }
+        println!(
+            "会话元数据回填完成: 更新 {}, 未找到既有文档 {}（未调用 LLM）",
+            metadata_backfilled, metadata_missing
+        );
+        return Ok(());
     }
 
     process_pending_sessions(
@@ -583,7 +725,7 @@ async fn handle_legacy_ingest_sessions(
 
     // Advance the incremental scan cursor so the next run only sees newer files.
     if incremental && !options.dry_run {
-        write_last_ingest_mtime(source.as_ref(), db_path, scan_start);
+        write_last_scan_mtime(source.as_ref(), db_path, cursor_name, scan_start);
     }
 
     Ok(())
@@ -798,7 +940,8 @@ async fn process_single_session(
     let facet_response = extract_and_parse_facets_with_retry(&content, client, quota_hit).await?;
 
     let doc = build_session_document(ps, &facet_response.session_summary);
-    let items = facets_to_items(&facet_response, doc.id(), ps.project.as_deref());
+    let items =
+        facets_to_items_with_mode(&facet_response, doc.id(), ps.project.as_deref(), ps.mode);
     let item_count = items.len();
     doc_store
         .save_with_replaced_items_and_delete_documents(&doc, &items, &ps.legacy_documents_to_delete)

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -82,6 +82,7 @@ async fn source_filter_requires_explicit_local_provider() {
             latest: None,
             dry_run: true,
             retry_quarantined: false,
+            backfill_session_metadata: false,
         },
         Path::new("/tmp/refine-test.db"),
         doc_store,
@@ -101,10 +102,10 @@ impl LlmClient for StaticLlmClient {
 }
 
 #[test]
-fn project_for_ingest_prefers_discovered_project_then_session_metadata() {
+fn project_for_ingest_prefers_session_metadata_then_discovered_project() {
     assert_eq!(
         project_for_ingest(Some("claude-project"), Some("codex-cwd")).as_deref(),
-        Some("claude-project")
+        Some("codex-cwd")
     );
     assert_eq!(
         project_for_ingest(None, Some("codex-cwd")).as_deref(),
@@ -176,6 +177,51 @@ fn session_needs_refresh_when_file_mtime_is_newer_than_saved_document() {
     assert!(session_needs_refresh(&doc, new_mtime));
 }
 
+#[tokio::test]
+async fn session_metadata_backfill_updates_existing_items_without_llm() {
+    let store = Arc::new(SqliteStore::in_memory().expect("in-memory sqlite store"));
+    let doc_store: Arc<dyn DocumentRepository> = store.clone();
+    let item_store: Arc<dyn ItemRepository> = store;
+    let mut document = Document::new("remem-raw-session", "raw");
+    document.set_url("remem-raw://existing");
+    doc_store.save(&document).await.unwrap();
+
+    let mut item = Item::new_observation("existing", "existing");
+    item.set_document_id(document.id().clone());
+    item.set_tags(vec![
+        Tag::new("-users-lifcc-desktop-code-work-infra-her").unwrap()
+    ])
+    .unwrap();
+    item_store.save(&item).await.unwrap();
+
+    assert!(backfill_session_metadata(
+        &doc_store,
+        &document,
+        SessionMode::Unattended,
+        Some("/Users/lifcc/Desktop/code/work/infra/her"),
+    )
+    .await
+    .unwrap());
+    let items = doc_store
+        .find_items_by_document_id(document.id())
+        .await
+        .unwrap();
+    assert_eq!(items.len(), 1);
+    assert!(items[0]
+        .tags()
+        .iter()
+        .any(|tag| tag.as_str() == "session_mode_unattended"));
+    assert!(items[0].tags().iter().any(|tag| tag.as_str() == "her"));
+    assert!(!backfill_session_metadata(
+        &doc_store,
+        &document,
+        SessionMode::Unattended,
+        Some("her"),
+    )
+    .await
+    .unwrap());
+}
+
 #[test]
 fn source_snapshot_uses_full_content_and_preserves_document_time() {
     let mut versioned = Document::new("remem-raw-session", "raw");
@@ -213,23 +259,26 @@ fn scoped_cursor_keeps_other_sources_discoverable() {
     fs::write(&codex_path, "{}").unwrap();
     filetime::set_file_mtime(&codex_path, filetime::FileTime::from_unix_time(1_000, 0)).unwrap();
 
-    write_last_ingest_mtime_at(
+    write_last_scan_mtime_at(
         home,
         Some(&SessionSource::ClaudeCode),
         &db_path,
+        "ingest",
         SystemTime::UNIX_EPOCH + Duration::from_secs(10_000),
     );
 
-    let claude_cutoff = read_last_ingest_mtime_at(home, Some(&SessionSource::ClaudeCode), &db_path)
-        .unwrap()
-        .checked_sub(Duration::from_secs(3600))
-        .unwrap();
+    let claude_cutoff =
+        read_last_scan_mtime_at(home, Some(&SessionSource::ClaudeCode), &db_path, "ingest")
+            .unwrap()
+            .checked_sub(Duration::from_secs(3600))
+            .unwrap();
     let claude_discovered =
         discover_sessions_in(home, Some(SessionSource::ClaudeCode), Some(claude_cutoff));
     assert_eq!(claude_discovered.len(), 1);
 
-    let codex_cutoff = read_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_path)
-        .map(|last| last.checked_sub(Duration::from_secs(3600)).unwrap());
+    let codex_cutoff =
+        read_last_scan_mtime_at(home, Some(&SessionSource::Codex), &db_path, "ingest")
+            .map(|last| last.checked_sub(Duration::from_secs(3600)).unwrap());
     assert!(codex_cutoff.is_none());
 
     let codex_discovered = discover_sessions_in(home, Some(SessionSource::Codex), codex_cutoff);
@@ -247,39 +296,56 @@ fn cursor_is_partitioned_by_database_path() {
     fs::write(&db_b, "").unwrap();
 
     let when = SystemTime::UNIX_EPOCH + Duration::from_secs(42);
-    write_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_a, when);
+    write_last_scan_mtime_at(home, Some(&SessionSource::Codex), &db_a, "ingest", when);
 
     assert_eq!(
-        read_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_a),
+        read_last_scan_mtime_at(home, Some(&SessionSource::Codex), &db_a, "ingest"),
         Some(when)
     );
     assert_eq!(
-        read_last_ingest_mtime_at(home, Some(&SessionSource::Codex), &db_b),
+        read_last_scan_mtime_at(home, Some(&SessionSource::Codex), &db_b, "ingest"),
         None
     );
     assert_ne!(
-        incremental_cursor_path(home, Some(&SessionSource::Codex), &db_a),
-        incremental_cursor_path(home, Some(&SessionSource::Codex), &db_b)
+        incremental_cursor_path(home, Some(&SessionSource::Codex), &db_a, "ingest"),
+        incremental_cursor_path(home, Some(&SessionSource::Codex), &db_b, "ingest")
     );
 }
 
-fn read_last_ingest_mtime_at(
+#[test]
+fn metadata_cursor_does_not_reuse_ingest_cursor() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("refine.db");
+    assert_ne!(
+        incremental_cursor_path(tmp.path(), Some(&SessionSource::Codex), &db_path, "ingest"),
+        incremental_cursor_path(
+            tmp.path(),
+            Some(&SessionSource::Codex),
+            &db_path,
+            "metadata"
+        )
+    );
+}
+
+fn read_last_scan_mtime_at(
     home: &Path,
     source: Option<&SessionSource>,
     db_path: &Path,
+    cursor_name: &str,
 ) -> Option<SystemTime> {
-    let path = incremental_cursor_path(home, source, db_path);
+    let path = incremental_cursor_path(home, source, db_path, cursor_name);
     let secs: u64 = std::fs::read_to_string(path).ok()?.trim().parse().ok()?;
     Some(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
 }
 
-fn write_last_ingest_mtime_at(
+fn write_last_scan_mtime_at(
     home: &Path,
     source: Option<&SessionSource>,
     db_path: &Path,
+    cursor_name: &str,
     t: SystemTime,
 ) {
-    let path = incremental_cursor_path(home, source, db_path);
+    let path = incremental_cursor_path(home, source, db_path, cursor_name);
     let dir = path.parent().unwrap();
     fs::create_dir_all(dir).unwrap();
     let dur = t.duration_since(SystemTime::UNIX_EPOCH).unwrap();
@@ -315,6 +381,7 @@ async fn process_single_session_links_items_to_saved_document_id() {
         url: "file:///tmp/session.jsonl".to_string(),
         source: SessionSource::Codex,
         project: Some("refine".to_string()),
+        mode: SessionMode::Interactive,
         captured_at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
         has_embedded_timestamp: true,
         raw_content: "User: fix the ingest bug".to_string(),
@@ -345,6 +412,10 @@ async fn process_single_session_links_items_to_saved_document_id() {
     assert!(linked_items
         .iter()
         .all(|item| item.document_id() == Some(saved_doc.id())));
+    assert!(linked_items.iter().all(|item| item
+        .tags()
+        .iter()
+        .any(|tag| tag.as_str() == "session_mode_interactive")));
 }
 
 #[tokio::test]
@@ -392,6 +463,7 @@ async fn process_single_session_refresh_replaces_old_items_and_preserves_raw_tra
         url: existing_doc.url().to_string(),
         source: SessionSource::Codex,
         project: Some("refine".to_string()),
+        mode: SessionMode::Unknown,
         captured_at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
         has_embedded_timestamp: false,
         raw_content: "User: original transcript\nAssistant: final answer\n".to_string(),
@@ -457,6 +529,7 @@ async fn remem_save_removes_superseded_legacy_document_and_facets() {
         url: "remem-raw://v1/local/repo/session-1".to_string(),
         source: SessionSource::RememRaw,
         project: Some("refine".to_string()),
+        mode: SessionMode::Unknown,
         captured_at: Utc.with_ymd_and_hms(2026, 7, 20, 0, 0, 0).unwrap(),
         has_embedded_timestamp: true,
         raw_content: "User: old\nAssistant: new\n".to_string(),

--- a/apps/cli/src/remem_sessions.rs
+++ b/apps/cli/src/remem_sessions.rs
@@ -1,6 +1,8 @@
 use anyhow::{bail, ensure, Context, Result};
 use chrono::{DateTime, Utc};
-use refine_core::session::{MessageRole, Session, SessionMessage, SessionMeta, SessionSource};
+use refine_core::session::{
+    MessageRole, Session, SessionMessage, SessionMeta, SessionMode, SessionSource,
+};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
@@ -360,6 +362,7 @@ fn load_one_session<R: Runner>(runner: &R, summary: RememSessionSummary) -> Resu
                 project: None,
                 model: None,
                 started_at: Some(started_at),
+                mode: SessionMode::Unknown,
             },
         },
     };

--- a/apps/mirror/src/advice.rs
+++ b/apps/mirror/src/advice.rs
@@ -7,10 +7,8 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::sync::Arc;
 
-// Bump whenever score semantics change. Advice generated from the pre-#146
-// project-count fragmentation metric must never be displayed with current
-// session-weighted scores.
-const ADVICE_CACHE_VERSION: &str = "advice-v3-score-v2";
+// Bump whenever score semantics change.
+const ADVICE_CACHE_VERSION: &str = "advice-v4-score-v3";
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
 const ADVICE_STALE_AFTER_HOURS: i64 = 72;

--- a/apps/mirror/src/advice.rs
+++ b/apps/mirror/src/advice.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::sync::Arc;
 
-const ADVICE_CACHE_VERSION: &str = "advice-v2";
+// Bump whenever score semantics change. Advice generated from the pre-#146
+// project-count fragmentation metric must never be displayed with current
+// session-weighted scores.
+const ADVICE_CACHE_VERSION: &str = "advice-v3-score-v2";
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
 const ADVICE_STALE_AFTER_HOURS: i64 = 72;
@@ -316,6 +319,18 @@ mod tests {
             .to_string(),
         )
         .unwrap();
+
+        let loaded = load_cached_from_path(&path).unwrap();
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn test_pre_scoring_fix_advice_cache_is_invalidated() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("advice.json");
+        let mut cached = cached_advice("fragmentation is 46%", Utc::now());
+        cached.cache_version = "advice-v2".into();
+        std::fs::write(&path, serde_json::to_string(&cached).unwrap()).unwrap();
 
         let loaded = load_cached_from_path(&path).unwrap();
         assert!(loaded.is_none());

--- a/apps/mirror/src/dashboard.rs
+++ b/apps/mirror/src/dashboard.rs
@@ -20,7 +20,6 @@ const COLLAB: &[(&str, &str)] = &[
     ("review", "review"),
     ("pair_prog", "pair_programming"),
     ("teaching", "teaching"),
-    ("debugging", "debugging"),
 ];
 const BAR_W: usize = 10;
 

--- a/apps/mirror/src/score/compute.rs
+++ b/apps/mirror/src/score/compute.rs
@@ -35,7 +35,7 @@ pub(super) fn dreyfus_weighted(stats: &GlobalStats) -> f64 {
     }
 }
 
-fn decision_quality_rate(cluster: &ClusterResult) -> f64 {
+fn reason_explicitness_rate(cluster: &ClusterResult) -> f64 {
     let total: usize = cluster
         .projects
         .values()
@@ -55,7 +55,7 @@ fn decision_quality_rate(cluster: &ClusterResult) -> f64 {
 
 pub(super) fn layer1(cluster: &ClusterResult, t: &Targets) -> LayerScore {
     let dw = dreyfus_weighted(&cluster.global_stats);
-    let dq = decision_quality_rate(cluster);
+    let dq = reason_explicitness_rate(cluster);
 
     let sig_dw = if dw > t.dreyfus_green {
         Signal::Green
@@ -109,25 +109,29 @@ fn layer2(cluster: &ClusterResult, t: &Targets) -> LayerScore {
         exploration as f64 / collab_total as f64
     };
 
-    let total_sessions: usize = cluster.projects.values().map(|p| p.session_count).sum();
-    let deep_sessions: usize = cluster
+    // These thresholds were specified for project buckets, not for sessions
+    // inside those buckets. Keep the numerator and denominator at the same
+    // project granularity and exclude the synthetic untagged bucket.
+    let scored_projects: Vec<_> = cluster
         .projects
         .values()
-        .filter(|p| p.session_count >= 20)
-        .map(|p| p.session_count)
-        .sum();
-    let frag_sessions: usize = cluster
-        .projects
-        .values()
-        .filter(|p| p.session_count == 1)
-        .map(|p| p.session_count)
-        .sum();
-    let (deep_rate, frag_rate) = if total_sessions == 0 {
+        .filter(|project| project.project_name != "other" && project.session_count > 0)
+        .collect();
+    let project_count = scored_projects.len();
+    let mature_projects = scored_projects
+        .iter()
+        .filter(|project| project.session_count >= 20)
+        .count();
+    let one_off_projects = scored_projects
+        .iter()
+        .filter(|project| project.session_count == 1)
+        .count();
+    let (deep_rate, frag_rate) = if project_count == 0 {
         (0.0, 0.0)
     } else {
         (
-            deep_sessions as f64 / total_sessions as f64,
-            frag_sessions as f64 / total_sessions as f64,
+            mature_projects as f64 / project_count as f64,
+            one_off_projects as f64 / project_count as f64,
         )
     };
 

--- a/apps/mirror/src/score/indicators.rs
+++ b/apps/mirror/src/score/indicators.rs
@@ -52,8 +52,8 @@ const INDICATOR_SPECS: [IndicatorSpec; 8] = [
         format: IndicatorFormat::Percent0,
         direction: Direction::HigherBetter,
         aliases: &["Decision Quality", "决策质量"],
-        display_en: "Decision Quality",
-        display_zh: "决策质量",
+        display_en: "Reason Explicitness",
+        display_zh: "理由显式率",
     },
     IndicatorSpec {
         key: "exploration",
@@ -68,16 +68,16 @@ const INDICATOR_SPECS: [IndicatorSpec; 8] = [
         format: IndicatorFormat::Percent0,
         direction: Direction::Band,
         aliases: &["Deep Invest", "深耕率", "深挖率", "深挖占比"],
-        display_en: "Deep Invest",
-        display_zh: "深耕率",
+        display_en: "Mature Project Share",
+        display_zh: "成熟项目占比",
     },
     IndicatorSpec {
         key: "fragmentation",
         format: IndicatorFormat::Percent0,
         direction: Direction::LowerBetter,
         aliases: &["Fragmentation", "碎片化"],
-        display_en: "Fragmentation",
-        display_zh: "碎片化",
+        display_en: "One-off Project Share",
+        display_zh: "一次性项目占比",
     },
     IndicatorSpec {
         key: "delegation",
@@ -100,8 +100,8 @@ const INDICATOR_SPECS: [IndicatorSpec; 8] = [
         format: IndicatorFormat::Fixed2,
         direction: Direction::LowerBetter,
         aliases: &["Bug/Decision", "bug/decision", "bug/决策"],
-        display_en: "bug/decision",
-        display_zh: "bug/决策",
+        display_en: "Bug/Decision Extraction Ratio",
+        display_zh: "Bug/决策抽取比",
     },
 ];
 

--- a/apps/mirror/src/score/persistence.rs
+++ b/apps/mirror/src/score/persistence.rs
@@ -6,13 +6,12 @@ use std::path::Path;
 
 use crate::config::{ensure_mirror_dir, mirror_dir};
 
-use super::indicators::{canonical_indicator_key, indicator_specs};
 use super::types::ScoreResult;
 
 // ── Persistence ──
 
 const SCORE_HISTORY_LIMIT: usize = 365;
-pub(super) const SCORE_SCHEMA_VERSION: u32 = 2;
+pub(super) const SCORE_SCHEMA_VERSION: u32 = 3;
 
 #[derive(Serialize)]
 struct PersistedScoreRef<'a> {
@@ -33,27 +32,11 @@ impl PersistedScore {
     fn uses_current_scoring_semantics(&self) -> bool {
         match self.score_schema_version {
             Some(version) => version == SCORE_SCHEMA_VERSION,
-            // PR #146 briefly produced unversioned snapshots with the current
-            // eight-indicator contract. Accept only that exact fingerprint;
-            // older unversioned snapshots used incompatible breadth formulas.
-            None => has_current_indicator_contract(&self.score),
+            // Unversioned eight-indicator snapshots used the v2
+            // session-weighted breadth formulas, so they are activity-only.
+            None => false,
         }
     }
-}
-
-fn has_current_indicator_contract(score: &ScoreResult) -> bool {
-    let mut actual: Vec<&str> = score
-        .layers
-        .iter()
-        .flat_map(|layer| &layer.indicators)
-        .map(|indicator| canonical_indicator_key(&indicator.name))
-        .collect();
-    actual.sort_unstable();
-    actual.dedup();
-
-    let mut expected: Vec<&str> = indicator_specs().iter().map(|spec| spec.key).collect();
-    expected.sort_unstable();
-    actual == expected
 }
 
 pub fn persist_score(result: &ScoreResult) -> Result<()> {

--- a/apps/mirror/src/score/persistence.rs
+++ b/apps/mirror/src/score/persistence.rs
@@ -1,15 +1,60 @@
 use anyhow::{Context, Result};
 use fs2::FileExt;
+use serde::{Deserialize, Serialize};
 use std::io::{BufRead, Write};
 use std::path::Path;
 
 use crate::config::{ensure_mirror_dir, mirror_dir};
 
+use super::indicators::{canonical_indicator_key, indicator_specs};
 use super::types::ScoreResult;
 
 // ── Persistence ──
 
 const SCORE_HISTORY_LIMIT: usize = 365;
+pub(super) const SCORE_SCHEMA_VERSION: u32 = 2;
+
+#[derive(Serialize)]
+struct PersistedScoreRef<'a> {
+    score_schema_version: u32,
+    #[serde(flatten)]
+    score: &'a ScoreResult,
+}
+
+#[derive(Deserialize)]
+struct PersistedScore {
+    #[serde(default)]
+    score_schema_version: Option<u32>,
+    #[serde(flatten)]
+    score: ScoreResult,
+}
+
+impl PersistedScore {
+    fn uses_current_scoring_semantics(&self) -> bool {
+        match self.score_schema_version {
+            Some(version) => version == SCORE_SCHEMA_VERSION,
+            // PR #146 briefly produced unversioned snapshots with the current
+            // eight-indicator contract. Accept only that exact fingerprint;
+            // older unversioned snapshots used incompatible breadth formulas.
+            None => has_current_indicator_contract(&self.score),
+        }
+    }
+}
+
+fn has_current_indicator_contract(score: &ScoreResult) -> bool {
+    let mut actual: Vec<&str> = score
+        .layers
+        .iter()
+        .flat_map(|layer| &layer.indicators)
+        .map(|indicator| canonical_indicator_key(&indicator.name))
+        .collect();
+    actual.sort_unstable();
+    actual.dedup();
+
+    let mut expected: Vec<&str> = indicator_specs().iter().map(|spec| spec.key).collect();
+    expected.sort_unstable();
+    actual == expected
+}
 
 pub fn persist_score(result: &ScoreResult) -> Result<()> {
     let dir = ensure_mirror_dir()?;
@@ -57,7 +102,10 @@ fn persist_score_to_path_locked(path: &Path, result: &ScoreResult) -> Result<()>
         }
     };
 
-    lines.push(serde_json::to_string(result)?);
+    lines.push(serde_json::to_string(&PersistedScoreRef {
+        score_schema_version: SCORE_SCHEMA_VERSION,
+        score: result,
+    })?);
     if lines.len() > SCORE_HISTORY_LIMIT {
         let trim = lines.len() - SCORE_HISTORY_LIMIT;
         lines.drain(0..trim);
@@ -125,6 +173,36 @@ pub fn load_recent_scores(n: usize) -> Result<Vec<ScoreResult>> {
 }
 
 pub(super) fn load_recent_scores_from_path(path: &Path, n: usize) -> Result<Vec<ScoreResult>> {
+    let all = load_persisted_scores_from_path(path)?;
+    let compatible: Vec<ScoreResult> = all
+        .into_iter()
+        .filter(PersistedScore::uses_current_scoring_semantics)
+        .map(|entry| entry.score)
+        .collect();
+    let start = compatible.len().saturating_sub(n);
+    Ok(compatible[start..].to_vec())
+}
+
+/// Load score timestamps across every historical scoring schema.
+///
+/// Streaks track whether scoring ran on a day, so a scoring-formula migration
+/// must not reset them. Metric trends use `load_recent_scores` instead and are
+/// intentionally restricted to comparable score schemas.
+pub(super) fn load_score_activity(n: usize) -> Result<Vec<ScoreResult>> {
+    let path = mirror_dir().join("scores.jsonl");
+    load_score_activity_from_path(&path, n)
+}
+
+pub(super) fn load_score_activity_from_path(path: &Path, n: usize) -> Result<Vec<ScoreResult>> {
+    let all: Vec<ScoreResult> = load_persisted_scores_from_path(path)?
+        .into_iter()
+        .map(|entry| entry.score)
+        .collect();
+    let start = all.len().saturating_sub(n);
+    Ok(all[start..].to_vec())
+}
+
+fn load_persisted_scores_from_path(path: &Path) -> Result<Vec<PersistedScore>> {
     let file = match std::fs::File::open(path) {
         Ok(f) => f,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -151,7 +229,7 @@ pub(super) fn load_recent_scores_from_path(path: &Path, n: usize) -> Result<Vec<
         if line.is_empty() {
             continue;
         }
-        let parsed = serde_json::from_str::<ScoreResult>(line).with_context(|| {
+        let parsed = serde_json::from_str::<PersistedScore>(line).with_context(|| {
             format!(
                 "failed to parse JSON on line {} in score history {}",
                 line_no,
@@ -160,6 +238,5 @@ pub(super) fn load_recent_scores_from_path(path: &Path, n: usize) -> Result<Vec<
         })?;
         all.push(parsed);
     }
-    let start = all.len().saturating_sub(n);
-    Ok(all[start..].to_vec())
+    Ok(all)
 }

--- a/apps/mirror/src/score/streak.rs
+++ b/apps/mirror/src/score/streak.rs
@@ -56,7 +56,7 @@ pub fn format_streak(streak: u32) -> Option<String> {
 
 /// Load scores and compute current streak. Convenience wrapper for integration.
 pub fn current_streak() -> u32 {
-    let scores = match super::persistence::load_recent_scores(365) {
+    let scores = match super::persistence::load_score_activity(365) {
         Ok(s) => s,
         Err(_) => return 0,
     };

--- a/apps/mirror/src/score/tests/compute.rs
+++ b/apps/mirror/src/score/tests/compute.rs
@@ -26,7 +26,7 @@ fn test_layer1_has_2_indicators() {
 }
 
 #[test]
-fn test_layer2_uses_session_weighted_project_rates() {
+fn test_layer2_uses_project_bucket_rates() {
     let targets = crate::config::Targets::default();
     let cluster = make_cluster(
         HashMap::new(),
@@ -45,8 +45,8 @@ fn test_layer2_uses_session_weighted_project_rates() {
     let deep_invest = indicator(breadth, "deep_invest");
     let fragmentation = indicator(breadth, "fragmentation");
 
-    assert!((deep_invest.actual - (20.0 / 22.0 * 100.0)).abs() < 0.0001);
-    assert!((fragmentation.actual - (2.0 / 22.0 * 100.0)).abs() < 0.0001);
+    assert!((deep_invest.actual - (1.0 / 3.0 * 100.0)).abs() < 0.0001);
+    assert!((fragmentation.actual - (2.0 / 3.0 * 100.0)).abs() < 0.0001);
 }
 
 #[test]

--- a/apps/mirror/src/score/tests/persistence.rs
+++ b/apps/mirror/src/score/tests/persistence.rs
@@ -3,7 +3,9 @@ use chrono::{Duration, Utc};
 use std::collections::HashSet;
 use std::sync::{Arc, Barrier};
 
-use super::super::persistence::persist_score_to_path;
+use super::super::persistence::{
+    load_score_activity_from_path, persist_score_to_path, SCORE_SCHEMA_VERSION,
+};
 
 #[test]
 fn test_persist_and_load() {
@@ -33,6 +35,13 @@ fn test_persist_and_load() {
     };
 
     persist_score_to_path(&path, &result).unwrap();
+
+    let persisted = std::fs::read_to_string(&path).unwrap();
+    let persisted: serde_json::Value = serde_json::from_str(persisted.trim()).unwrap();
+    assert_eq!(
+        persisted["score_schema_version"].as_u64(),
+        Some(u64::from(SCORE_SCHEMA_VERSION))
+    );
 
     let loaded = load_recent_scores_from_path(&path, 10).unwrap();
     assert_eq!(loaded.len(), 1);
@@ -176,15 +185,95 @@ fn test_load_recent_scores_reports_invalid_jsonl_line() {
 }
 
 #[test]
-fn test_load_recent_scores_accepts_legacy_missing_timestamp() {
+fn test_legacy_unversioned_scores_are_activity_only() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("scores.jsonl");
 
     let legacy_line = r#"{"layers":[{"name":"L1","signal":"Green","indicators":[]},{"name":"L2","signal":"Yellow","indicators":[]},{"name":"L3","signal":"Red","indicators":[]}],"tension":"legacy tension"}"#;
     std::fs::write(&path, format!("{}\n", legacy_line)).unwrap();
 
-    let loaded = load_recent_scores_from_path(&path, 10).unwrap();
-    assert_eq!(loaded.len(), 1);
-    assert_eq!(loaded[0].tension.as_deref(), Some("legacy tension"));
-    assert_eq!(loaded[0].timestamp, chrono::DateTime::<Utc>::UNIX_EPOCH);
+    let compatible = load_recent_scores_from_path(&path, 10).unwrap();
+    assert!(compatible.is_empty());
+
+    let activity = load_score_activity_from_path(&path, 10).unwrap();
+    assert_eq!(activity.len(), 1);
+    assert_eq!(activity[0].tension.as_deref(), Some("legacy tension"));
+    assert_eq!(activity[0].timestamp, chrono::DateTime::<Utc>::UNIX_EPOCH);
+}
+
+#[test]
+fn test_unversioned_current_indicator_contract_is_compatible() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("scores.jsonl");
+    let mut score = make_score_result(
+        4.0,
+        80.0,
+        20.0,
+        0.5,
+        12.0,
+        25.0,
+        1.0,
+        30.0,
+        6.0,
+        0.2,
+        0.8,
+        Utc::now(),
+    );
+    remove_indicator(&mut score, "depth_output");
+    remove_indicator(&mut score, "knowledge_rate");
+    remove_indicator(&mut score, "friction_density");
+    std::fs::write(
+        &path,
+        format!("{}\n", serde_json::to_string(&score).unwrap()),
+    )
+    .unwrap();
+
+    let compatible = load_recent_scores_from_path(&path, 10).unwrap();
+    assert_eq!(compatible.len(), 1);
+}
+
+#[test]
+fn test_old_scoring_semantics_do_not_pollute_current_history() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("scores.jsonl");
+    let old = make_score_result(
+        4.0,
+        80.0,
+        20.0,
+        0.5,
+        5.3,
+        11.8,
+        46.0,
+        42.2,
+        6.0,
+        0.28,
+        2.5,
+        Utc::now() - Duration::days(1),
+    );
+    std::fs::write(&path, format!("{}\n", serde_json::to_string(&old).unwrap())).unwrap();
+
+    let mut current = old.clone();
+    remove_indicator(&mut current, "depth_output");
+    remove_indicator(&mut current, "knowledge_rate");
+    remove_indicator(&mut current, "friction_density");
+    current.layers[1]
+        .indicators
+        .iter_mut()
+        .find(|indicator| indicator.name == "fragmentation")
+        .unwrap()
+        .actual = 0.6;
+    current.timestamp = Utc::now();
+    persist_score_to_path(&path, &current).unwrap();
+
+    let compatible = load_recent_scores_from_path(&path, 10).unwrap();
+    assert_eq!(compatible.len(), 1);
+    let fragmentation = compatible[0].layers[1]
+        .indicators
+        .iter()
+        .find(|indicator| indicator.name == "fragmentation")
+        .unwrap();
+    assert_eq!(fragmentation.actual, 0.6);
+
+    let activity = load_score_activity_from_path(&path, 10).unwrap();
+    assert_eq!(activity.len(), 2, "legacy rows must remain auditable");
 }

--- a/apps/mirror/src/score/tests/persistence.rs
+++ b/apps/mirror/src/score/tests/persistence.rs
@@ -202,7 +202,7 @@ fn test_legacy_unversioned_scores_are_activity_only() {
 }
 
 #[test]
-fn test_unversioned_current_indicator_contract_is_compatible() {
+fn test_unversioned_v2_indicator_contract_is_activity_only() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("scores.jsonl");
     let mut score = make_score_result(
@@ -229,7 +229,7 @@ fn test_unversioned_current_indicator_contract_is_compatible() {
     .unwrap();
 
     let compatible = load_recent_scores_from_path(&path, 10).unwrap();
-    assert_eq!(compatible.len(), 1);
+    assert!(compatible.is_empty());
 }
 
 #[test]

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -61,8 +61,12 @@ explicit alternative is:
 bash scripts/configure-llm-env.sh --from-env
 ```
 
-The loader precedence is current non-empty process credentials, then the
-secure file, then an explicitly supplied repository `.env` fallback. It
+The shell loader precedence is current non-empty process credentials, then the
+secure file, then an explicitly supplied repository `.env` fallback. Provider
+selection then prefers explicit `REFINE_*` credentials, followed by an
+explicit `BASE_*` OpenAI-compatible endpoint, followed by ambient provider
+variables. Thus an inherited `ANTHROPIC_AUTH_TOKEN` cannot override Refine's
+configured `BASE_URL`. It
 supports the Anthropic aliases `REFINE_ANTHROPIC_API_KEY`,
 `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_API_KEY`; the OpenAI aliases
 `REFINE_OPENAI_API_KEY` and `OPENAI_API_KEY`; and the compatibility
@@ -126,7 +130,7 @@ scripts/install-local.sh --no-start
 | Label | Role | Trigger | Log |
 | --- | --- | --- | --- |
 | `com.lifcc.refine-server` | Local API/dashboard | RunAtLoad + KeepAlive | `~/Library/Logs/refine-server.log` |
-| `com.lifcc.refine-daily-ingest` | `refine ingest-sessions` + `mirror score` | Daily 08:00 | `~/Library/Logs/refine-daily-ingest.log` |
+| `com.lifcc.refine-daily-ingest` | `refine ingest-sessions` + incremental Codex metadata backfill + `mirror score` | Daily 08:00 | `~/Library/Logs/refine-daily-ingest.log` |
 | `com.lifcc.refine-weekly-insights` | `refine insights --prescription` | Sunday 09:00 | `~/Library/Logs/refine-insights.log` |
 | `com.lifcc.refine-ui-dev` | Desktop UI Vite dev server | RunAtLoad + KeepAlive | `.run/launchd-refine-ui.*.log` |
 

--- a/docs/SPEC-codex-session-ingestion-for-mirror-weekly.md
+++ b/docs/SPEC-codex-session-ingestion-for-mirror-weekly.md
@@ -77,8 +77,13 @@ The experiment drops three noisy live indicators:
   to be a color-bearing collaboration metric.
 
 Historical `scores.jsonl` entries that contain those old indicators remain
-deserializable. The baseline registry simply stops computing personal averages
-for removed live indicators.
+deserializable and remain available as score-run activity for streak tracking.
+They do not participate in current MOTD, dashboard, or personal-trend reads:
+new entries carry `score_schema_version = 2`, and metric consumers only compare
+entries with the current scoring semantics. Unversioned entries with the exact
+eight-indicator contract are accepted for the short PR #146 transition window;
+older 11-indicator entries are activity-only. This prevents project-count
+fragmentation values from contaminating session-weighted baselines.
 
 ## Breadth Weighting
 
@@ -115,6 +120,8 @@ The three lights are absolute target signals. The optional arrow is the
 overall personal trend. Advice cache handling is deliberately visible:
 
 - Generation only reuses a fresh cache entry for the exact score/model key.
+- Cache versions include the scoring schema, so advice generated from an older
+  score formula is rejected immediately after an upgrade.
 - Display callers can still load stale cache entries so they can show
   `advice stale` instead of silently showing nothing.
 - MOTD falls back to static tips when cached advice is stale, and marks that

--- a/docs/SPEC-codex-session-ingestion-for-mirror-weekly.md
+++ b/docs/SPEC-codex-session-ingestion-for-mirror-weekly.md
@@ -1,7 +1,7 @@
 # SPEC: Mirror Scoring and Codex Weekly Semantics
 
-Date: 2026-08-12
-Status: Accepted for issue #145
+Date: 2026-08-13
+Status: Accepted scoring schema v3
 
 ## Goal
 
@@ -17,17 +17,17 @@ these parts, so this issue must not replay them:
 
 | Area from PR #141 | Current `main` state | Decision |
 | --- | --- | --- |
-| Codex transcript parser | Current `response_item.payload.type = "message"` schema, roles, text types, metadata, and timestamp extraction are already implemented in `packages/core/src/session/parser.rs`. | Do not edit parser transport. |
-| Codex project attribution | `apps/cli/src/ingest_sessions.rs` already falls back from discovery project to `session.meta.project` before `facets_to_items`. | Do not replay ingest changes. |
+| Codex transcript parser | Current `response_item.payload.type = "message"` schema, roles, text types, metadata, and timestamp extraction are already implemented in `packages/core/src/session/parser.rs`. | Preserve message transport; extend only explicit metadata provenance. |
+| Codex project attribution | Discovery paths and session metadata can disagree or encode the same repository differently. | Prefer repository metadata and normalize path aliases. |
 | Event-time storage | Session documents have `captured_at`; session ingestion sets it from `SessionMeta.started_at` or file mtime. | Preserve. |
 | Weekly event-time window | `mirror weekly` already uses `find_observations_by_event_range`. | Preserve. |
 | Score/dashboard event-time window | `mirror score` and dashboard already use the same event-time query for default and `--since` windows. | Preserve. |
-| Scheduled workflow hardening | PR #143 made daily/weekly automation locked, serialized, and failure-visible. | Do not edit scheduler scripts. |
+| Scheduled workflow hardening | PR #143 made daily/weekly automation locked, serialized, and failure-visible. | Preserve locking and failure propagation; add the metadata reconciliation step. |
 | Cognitive portrait archive | PR #144 extracted generated reports and scheduling. | Do not add generated reports. |
 
 The remaining portable work is therefore limited to scoring semantics,
 statusline/advice visibility, weekly action cards, clustering input stability,
-and this specification.
+metadata reconciliation, and this specification.
 
 ## Event-Time Window Semantics
 
@@ -59,13 +59,13 @@ Mirror now scores three layers with eight live indicators:
 | Layer | Indicator | Direction | Target source |
 | --- | --- | --- | --- |
 | Depth | `dreyfus` | Higher is better | Weighted cognitive level average |
-| Depth | `decision_quality` | Higher is better | Decision titles with explicit reason keywords |
+| Depth | `decision_quality` | Higher is better | Decision titles with explicit reason keywords; displayed as **Reason Explicitness**, not decision quality |
 | Breadth | `exploration` | Higher is better | Exploration observations over all collaboration-mode observations |
-| Breadth | `deep_invest` | Band | Session-weighted share of projects with at least 20 sessions |
-| Breadth | `fragmentation` | Lower is better | Session-weighted share of single-session projects |
+| Breadth | `deep_invest` | Band | Projects with at least 20 sessions over scored projects; displayed as **Mature Project Share** |
+| Breadth | `fragmentation` | Lower is better | Single-session projects over scored projects; displayed as **One-off Project Share** |
 | Collaboration | `delegation` | Lower is better | Delegation observations over all collaboration-mode observations |
 | Collaboration | `mode_diversity` | Higher is better | Count of observed collaboration modes |
-| Collaboration | `bug_decision` | Lower is better | Bugfix count over decision count |
+| Collaboration | `bug_decision` | Lower is better | Extracted bugfix count over extracted decision count; displayed as an extraction ratio |
 
 The experiment drops three noisy live indicators:
 
@@ -79,17 +79,16 @@ The experiment drops three noisy live indicators:
 Historical `scores.jsonl` entries that contain those old indicators remain
 deserializable and remain available as score-run activity for streak tracking.
 They do not participate in current MOTD, dashboard, or personal-trend reads:
-new entries carry `score_schema_version = 2`, and metric consumers only compare
-entries with the current scoring semantics. Unversioned entries with the exact
-eight-indicator contract are accepted for the short PR #146 transition window;
-older 11-indicator entries are activity-only. This prevents project-count
-fragmentation values from contaminating session-weighted baselines.
+new entries carry `score_schema_version = 3`, and metric consumers only compare
+entries with the current scoring semantics. All unversioned entries and v1/v2
+entries are activity-only. This prevents incompatible project denominators
+from contaminating current baselines while preserving score-run streaks.
 
 ## Breadth Weighting
 
-`deep_invest` and `fragmentation` are session-weighted, not bucket-weighted.
-A one-session side project should not have the same weight as a deeply worked
-project. For example:
+`deep_invest` and `fragmentation` use project buckets because their fixed
+thresholds were defined as percentages of projects. Mixing a session-weighted
+numerator with project-level target bands produced false red signals. For example:
 
 ```text
 solo-a: 1 session
@@ -99,11 +98,27 @@ deep-a: 20 sessions
 
 The resulting rates are:
 
-- `deep_invest = 20 / 22 = 90.9%`
-- `fragmentation = 2 / 22 = 9.1%`
+- `deep_invest = 1 / 3 = 33.3%`
+- `fragmentation = 2 / 3 = 66.7%`
 
-The old bucket-weighted interpretation would have produced `33.3%` and
-`66.7%`, overstating fragmentation.
+The synthetic `other` bucket is excluded. These indicators describe portfolio
+shape, not time allocation or context switching; their display names must not
+claim otherwise.
+
+## Personal Cohort Provenance
+
+Mirror's personal score includes direct interactive sessions and legacy
+sessions whose provenance is unknown. It excludes documents explicitly tagged
+as unattended Codex exec or subagent work. The classification is based only on
+Codex `session_meta` fields (`originator` and `thread_source`), never on titles,
+prompt keywords, project names, or inferred scheduler intent.
+
+`codex_exec` proves an unattended execution surface, not that a scheduler
+started it. Mirror therefore calls this cohort `unattended`, not `scheduled`.
+Metadata tags are persisted on every observation item. A local metadata-only
+backfill can tag already extracted remem-backed observations without another
+LLM extraction via `refine ingest-sessions --provider local --source codex
+--backfill-session-metadata`.
 
 ## Statusline and Advice Cache
 
@@ -152,6 +167,9 @@ Project clustering must not let ingestion artifacts distort breadth metrics:
 - `tool` and `tools` path segments are both generic and are removed during
   project normalization.
 - `agent_<hex>` session identifiers are not project names.
+- `/` and `-users-...` path encodings normalize through the same path-segment
+  rules; generic grouping directories such as `infra` do not become projects.
+- Codex `git.repository_url` is preferred to cwd/discovery aliases when present.
 - `session_count` is deduplicated per project, while `global_stats.total_sessions`
   remains globally deduplicated.
 - Profile project shares use the sum of per-project session assignments as
@@ -170,10 +188,11 @@ Focused validation for this issue:
 ```bash
 cargo fmt --all --check
 cargo test -p mirror
-cargo test -p refine-core session::clustering
+cargo test -p refine-core session::
+cargo test -p refine-cli ingest_sessions
 git diff --check
 ```
 
-Broader workspace tests are useful before release, but this issue intentionally
-does not change parser transport, LLM ingest, SQLite migrations, or scheduler
-scripts.
+Broader workspace tests are useful before release. This v3 correction changes
+metadata parsing and metadata-only ingest backfill, but not message transport,
+LLM facet semantics, SQLite schema, or scheduler scripts.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -135,6 +135,8 @@ refine ingest-sessions --provider remem
 refine ingest-sessions --provider local
 refine ingest-sessions --provider local --source claude
 refine ingest-sessions --provider local --source codex
+# One-time provenance backfill for already extracted observations (no LLM):
+refine ingest-sessions --provider local --source codex --backfill-session-metadata
 # Deprecated compatibility alias for --provider local
 refine ingest-sessions --legacy-local-scan --source claude
 refine insights --prescription

--- a/packages/core/src/infra/llm.rs
+++ b/packages/core/src/infra/llm.rs
@@ -21,33 +21,45 @@ pub trait LlmClient: Send + Sync {
 
 /// 从环境变量构建 LLM 客户端。
 ///
-/// 优先级：
-/// 1. Anthropic (`REFINE_ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY`)
-/// 2. OpenAI-compatible (`REFINE_OPENAI_API_KEY` / `OPENAI_API_KEY` / `BASE_API_KEY`)
+/// 优先级：显式 Refine 配置 > 显式 BASE OpenAI-compatible 配置 >
+/// ambient provider variables. This prevents an unrelated inherited
+/// `ANTHROPIC_AUTH_TOKEN` from hijacking Refine's own BASE endpoint.
 pub fn build_llm_client_from_env() -> Option<Arc<dyn LlmClient>> {
+    if env_var(&["REFINE_ANTHROPIC_API_KEY"]).is_some() {
+        return anthropic_config_from_env().map(build_anthropic_client);
+    }
+    if env_var(&["REFINE_OPENAI_API_KEY"]).is_some() {
+        return openai_config_from_env().map(build_openai_client);
+    }
+    if let Some(config) = base_openai_config_from_env() {
+        return Some(build_openai_client(config));
+    }
     if let Some(config) = anthropic_config_from_env() {
-        let mut client = ClaudeClient::new(&config.api_key);
-        if let Some(model) = config.model {
-            client = client.with_model(&model);
-        }
-        if let Some(base_url) = config.base_url {
-            client = client.with_base_url(&base_url);
-        }
-        return Some(Arc::new(client));
+        return Some(build_anthropic_client(config));
     }
+    openai_config_from_env().map(build_openai_client)
+}
 
-    if let Some(config) = openai_config_from_env() {
-        let mut client = OpenAIClient::new(&config.api_key);
-        if let Some(model) = config.model {
-            client = client.with_model(&model);
-        }
-        if let Some(base_url) = config.base_url {
-            client = client.with_base_url(&base_url);
-        }
-        return Some(Arc::new(client));
+fn build_anthropic_client(config: LlmEnvConfig) -> Arc<dyn LlmClient> {
+    let mut client = ClaudeClient::new(&config.api_key);
+    if let Some(model) = config.model {
+        client = client.with_model(&model);
     }
+    if let Some(base_url) = config.base_url {
+        client = client.with_base_url(&base_url);
+    }
+    Arc::new(client)
+}
 
-    None
+fn build_openai_client(config: LlmEnvConfig) -> Arc<dyn LlmClient> {
+    let mut client = OpenAIClient::new(&config.api_key);
+    if let Some(model) = config.model {
+        client = client.with_model(&model);
+    }
+    if let Some(base_url) = config.base_url {
+        client = client.with_base_url(&base_url);
+    }
+    Arc::new(client)
 }
 
 pub fn build_required_llm_client_from_env() -> Result<Arc<dyn LlmClient>, String> {
@@ -313,6 +325,14 @@ fn openai_config_from_env() -> Option<LlmEnvConfig> {
     })
 }
 
+fn base_openai_config_from_env() -> Option<LlmEnvConfig> {
+    Some(LlmEnvConfig {
+        api_key: env_var(&["BASE_API_KEY"])?,
+        model: env_var(&["BASE_MODEL"]),
+        base_url: env_var(&["BASE_URL"]),
+    })
+}
+
 fn normalize_openai_base_url(url: &str) -> String {
     url.trim()
         .trim_end_matches('/')
@@ -415,6 +435,23 @@ mod tests {
                 config.base_url.as_deref(),
                 Some("https://refine.example.test")
             );
+        });
+    }
+
+    #[test]
+    fn base_openai_config_beats_ambient_anthropic_credentials() {
+        let Ok(_env_lock) = ENV_LOCK.lock() else {
+            panic!("failed to lock env");
+        };
+        with_clean_llm_env(|| {
+            std::env::set_var("ANTHROPIC_AUTH_TOKEN", "ambient-kimi-key");
+            std::env::set_var("ANTHROPIC_BASE_URL", "https://api.kimi.com/coding/");
+            std::env::set_var("BASE_API_KEY", "personal-gpt-key");
+            std::env::set_var("BASE_MODEL", "gpt-5.4");
+            std::env::set_var("BASE_URL", "http://127.0.0.1:8200/v1");
+
+            let client = build_llm_client_from_env().expect("LLM should be configured");
+            assert!(client.cache_identity().starts_with("openai:gpt-5.4:"));
         });
     }
 

--- a/packages/core/src/infra/sqlite/mod.rs
+++ b/packages/core/src/infra/sqlite/mod.rs
@@ -204,6 +204,12 @@ impl DocumentRepository for SqliteStore {
         .await
     }
 
+    async fn find_items_by_document_id(&self, id: &DocumentId) -> InfraResult<Vec<Item>> {
+        let document_id = id.as_str().to_string();
+        self.request(|resp| SqliteCommand::FindByDocumentId { document_id, resp })
+            .await
+    }
+
     async fn count(&self) -> InfraResult<usize> {
         self.request(|resp| SqliteCommand::DocCount { resp }).await
     }

--- a/packages/core/src/knowledge/doc_repository.rs
+++ b/packages/core/src/knowledge/doc_repository.rs
@@ -11,6 +11,7 @@ pub trait DocumentRepository: Send + Sync {
     async fn find_by_id(&self, id: &DocumentId) -> InfraResult<Option<Document>>;
     async fn find_by_url(&self, url: &str) -> InfraResult<Option<Document>>;
     async fn find_recent(&self, offset: usize, limit: usize) -> InfraResult<Vec<Document>>;
+    async fn find_items_by_document_id(&self, id: &DocumentId) -> InfraResult<Vec<Item>>;
     async fn count(&self) -> InfraResult<usize>;
     async fn save(&self, doc: &Document) -> InfraResult<()>;
     async fn save_with_replaced_items(&self, doc: &Document, items: &[Item]) -> InfraResult<()>;

--- a/packages/core/src/session/clustering.rs
+++ b/packages/core/src/session/clustering.rs
@@ -19,7 +19,10 @@ const META_TAGS: &[&str] = &[
     "exploration",
     "teaching",
     "deep_inquiry",
-    "debugging",
+    "session_mode_interactive",
+    "session_mode_unattended",
+    "session_mode_subagent",
+    "session_mode_unknown",
 ];
 
 const GENERIC_PATH_SEGMENTS: &[&str] = &[
@@ -35,6 +38,9 @@ const GENERIC_PATH_SEGMENTS: &[&str] = &[
     "life",
     "information",
     "mutil",
+    "infra",
+    "private",
+    "tmp",
 ];
 
 /// 单个项目的聚类数据
@@ -81,10 +87,33 @@ pub struct ClusterResult {
 
 /// 主函数：从全量 observation 生成聚类结果
 pub fn cluster_observations(items: &[Item]) -> ClusterResult {
+    // Mirror measures the user's direct interactive work. Codex can reliably
+    // identify unattended exec and subagent sessions, so exclude those
+    // cohorts by provenance. Unknown legacy sessions remain included.
+    let excluded_doc_ids: HashSet<String> = items
+        .iter()
+        .filter(|item| {
+            item.tags()
+                .iter()
+                .any(|tag| is_excluded_session_mode(tag.as_str()))
+        })
+        .filter_map(|item| item.document_id().map(|id| id.as_str().to_string()))
+        .collect();
+
     // Single filtering pass: compute tags once per item to avoid double allocation.
     let obs_with_tags: Vec<(&Item, Vec<&str>)> = items
         .iter()
         .filter(|i| i.item_type() == ItemType::Observation)
+        .filter(|item| {
+            let excluded_by_doc = item
+                .document_id()
+                .is_some_and(|id| excluded_doc_ids.contains(id.as_str()));
+            let excluded_by_tag = item
+                .tags()
+                .iter()
+                .any(|tag| is_excluded_session_mode(tag.as_str()));
+            !excluded_by_doc && !excluded_by_tag
+        })
         .map(|item| {
             let tags: Vec<&str> = item.tags().iter().map(|t| t.as_str()).collect();
             (item, tags)
@@ -262,7 +291,11 @@ fn is_session_id(segment: &str) -> bool {
 }
 
 pub fn normalize_project_name(raw: &str) -> Option<String> {
-    let segments: Vec<&str> = raw.split('-').filter(|s| !s.is_empty()).collect();
+    let normalized_path = raw.to_ascii_lowercase().replace(['/', '\\'], "-");
+    let segments: Vec<&str> = normalized_path
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect();
     let first_project_segment = segments
         .iter()
         .position(|segment| !GENERIC_PATH_SEGMENTS.contains(segment))?;
@@ -324,14 +357,12 @@ fn is_cognitive_level(tag: &str) -> bool {
 fn is_collab_mode(tag: &str) -> bool {
     matches!(
         tag,
-        "delegation"
-            | "pair_programming"
-            | "review"
-            | "exploration"
-            | "teaching"
-            | "deep_inquiry"
-            | "debugging"
+        "delegation" | "pair_programming" | "review" | "exploration" | "teaching" | "deep_inquiry"
     )
+}
+
+fn is_excluded_session_mode(tag: &str) -> bool {
+    matches!(tag, "session_mode_unattended" | "session_mode_subagent")
 }
 
 #[cfg(test)]
@@ -396,6 +427,15 @@ mod tests {
         );
         assert_eq!(normalize_project_name("my-tool"), Some("my-tool".into()));
         assert_eq!(
+            normalize_project_name("/Users/lifcc/Desktop/code/work/infra/her"),
+            Some("her".into())
+        );
+        assert_eq!(normalize_project_name("infra-her"), Some("her".into()));
+        assert_eq!(
+            normalize_project_name("/Users/lifcc/Desktop/code/work/life/looper"),
+            Some("looper".into())
+        );
+        assert_eq!(
             normalize_project_name("agent_019ec96be5fe7f53a6cca93bb6201c26"),
             None
         );
@@ -456,5 +496,22 @@ mod tests {
         assert_eq!(cluster.global_stats.total_sessions, 2);
         assert_eq!(cluster.projects["project-a"].session_count, 1);
         assert_eq!(cluster.projects["project-b"].session_count, 2);
+    }
+
+    #[test]
+    fn cluster_observations_excludes_unattended_and_subagent_documents() {
+        let cluster = cluster_observations(&[
+            observation(
+                "interactive",
+                "doc-1",
+                &["project-a", "session_mode_interactive"],
+            ),
+            observation("exec", "doc-2", &["project-a", "session_mode_unattended"]),
+            observation("child", "doc-3", &["project-a", "session_mode_subagent"]),
+            observation("legacy", "doc-4", &["project-a"]),
+        ]);
+
+        assert_eq!(cluster.global_stats.total_sessions, 2);
+        assert_eq!(cluster.projects["project-a"].session_count, 2);
     }
 }

--- a/packages/core/src/session/facets.rs
+++ b/packages/core/src/session/facets.rs
@@ -2,6 +2,7 @@
 //!
 //! 从会话内容中提取结构化认知维度 (facets)
 
+use super::SessionMode;
 use crate::knowledge::{DocumentId, Item, Tag};
 
 /// Facet 提取结果
@@ -137,6 +138,17 @@ pub fn facets_to_items(
     document_id: &DocumentId,
     project: Option<&str>,
 ) -> Vec<Item> {
+    facets_to_items_with_mode(facets, document_id, project, SessionMode::Unknown)
+}
+
+/// Convert facets to observations and persist the source-provenance cohort on
+/// every item so a document can be filtered without guessing from its title.
+pub fn facets_to_items_with_mode(
+    facets: &FacetResponse,
+    document_id: &DocumentId,
+    project: Option<&str>,
+    mode: SessionMode,
+) -> Vec<Item> {
     let mut items = Vec::new();
 
     // 宏观标注作为一个综合 observation
@@ -200,6 +212,7 @@ pub fn facets_to_items(
     let mut tags = vec![
         Tag::try_new(&facets.cognitive_level),
         Tag::try_new(&facets.collaboration_mode),
+        Tag::try_new(mode.as_tag()),
     ];
     if let Some(proj) = project {
         tags.push(Tag::try_new(proj));
@@ -216,6 +229,7 @@ pub fn facets_to_items(
         let mut item = Item::new_observation(decision, decision);
         item.set_document_id(document_id.clone());
         let mut dtags: Vec<Tag> = Tag::try_new("decision").into_iter().collect();
+        dtags.extend(Tag::try_new(mode.as_tag()));
         if let Some(proj) = project {
             dtags.extend(Tag::try_new(proj));
         }
@@ -230,6 +244,7 @@ pub fn facets_to_items(
         let mut item = Item::new_observation(bug, bug);
         item.set_document_id(document_id.clone());
         let mut btags: Vec<Tag> = Tag::try_new("bugfix").into_iter().collect();
+        btags.extend(Tag::try_new(mode.as_tag()));
         if let Some(proj) = project {
             btags.extend(Tag::try_new(proj));
         }

--- a/packages/core/src/session/mod.rs
+++ b/packages/core/src/session/mod.rs
@@ -17,10 +17,13 @@ mod types;
 pub use aggregation::{aggregate_observations, format_report, AggregationReport};
 pub use analysis_routes::{plan_routes, AnalysisRoute};
 pub use chunking::{chunk_session, needs_chunking, SessionChunk};
-pub use clustering::{cluster_observations, ClusterResult, GlobalStats, ProjectCluster};
+pub use clustering::{
+    cluster_observations, normalize_project_name, ClusterResult, GlobalStats, ProjectCluster,
+};
 pub use discovery::{discover_sessions, discover_sessions_in, DiscoveredSession};
 pub use facets::{
-    build_facet_prompt, facets_to_items, parse_facet_response, FacetResponse, FACET_SYSTEM_PROMPT,
+    build_facet_prompt, facets_to_items, facets_to_items_with_mode, parse_facet_response,
+    FacetResponse, FACET_SYSTEM_PROMPT,
 };
 pub use filter::{filter_sessions, passes_filter, FilterConfig};
 pub use parser::{parse_session_content, parse_session_file};
@@ -29,4 +32,4 @@ pub use report::{
     build_final_prompt, merge_route_results, RouteResult, INSIGHTS_SYSTEM_PROMPT,
     ROUTE_SYSTEM_PROMPT,
 };
-pub use types::{MessageRole, Session, SessionMessage, SessionMeta, SessionSource};
+pub use types::{MessageRole, Session, SessionMessage, SessionMeta, SessionMode, SessionSource};

--- a/packages/core/src/session/parser.rs
+++ b/packages/core/src/session/parser.rs
@@ -11,7 +11,7 @@
 //! 同时从原始 JSONL 提取首个时间戳填充 `SessionMeta.started_at`，
 //! 弥补先前的 declaration-execution gap（字段定义但从未写入）。
 
-use super::types::{MessageRole, Session, SessionMessage, SessionMeta, SessionSource};
+use super::types::{MessageRole, Session, SessionMessage, SessionMeta, SessionMode, SessionSource};
 use chrono::{DateTime, Utc};
 use std::path::Path;
 use tracing::warn;
@@ -149,6 +149,34 @@ fn project_name_from_cwd(cwd: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn project_name_from_repository_url(url: &str) -> Option<String> {
+    let trimmed = url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    let leaf = trimmed.rsplit(['/', ':']).next()?.trim_end_matches(".git");
+    (!leaf.is_empty()).then(|| leaf.to_string())
+}
+
+fn update_codex_session_mode(value: &serde_json::Value, meta: &mut SessionMeta) {
+    let thread_source = value
+        .pointer("/payload/thread_source")
+        .and_then(|v| v.as_str());
+    if thread_source == Some("subagent") {
+        meta.mode = SessionMode::Subagent;
+        return;
+    }
+
+    match value
+        .pointer("/payload/originator")
+        .and_then(|v| v.as_str())
+    {
+        Some("codex-tui") => meta.mode = SessionMode::Interactive,
+        Some("codex_exec") => meta.mode = SessionMode::Unattended,
+        _ => {}
+    }
+}
+
 /// 同时覆盖多种格式：Claude Code 行通常在顶层带 `timestamp`，
 /// Codex 新格式也可能把时间放在 `payload.timestamp`。
 /// 取首个能解析成 RFC3339 的时间戳作为 `started_at`，与 JSONL 写入顺序对齐。
@@ -277,12 +305,19 @@ fn parse_codex_line(
 
     match msg_type {
         "session_meta" => {
+            update_codex_session_mode(value, meta);
             if let Some(model) = value
                 .pointer("/payload/model")
                 .or_else(|| value.get("model"))
                 .and_then(|v| v.as_str())
             {
                 meta.model = Some(model.to_string());
+            }
+            if let Some(repository_url) = value
+                .pointer("/payload/git/repository_url")
+                .and_then(|v| v.as_str())
+            {
+                meta.project = project_name_from_repository_url(repository_url);
             }
             if meta.project.is_none() {
                 if let Some(cwd) = value.pointer("/payload/cwd").and_then(|v| v.as_str()) {
@@ -291,6 +326,7 @@ fn parse_codex_line(
             }
         }
         "turn_context" => {
+            update_codex_session_mode(value, meta);
             if let Some(model) = value.pointer("/payload/model").and_then(|v| v.as_str()) {
                 meta.model = Some(model.to_string());
             }
@@ -449,6 +485,33 @@ mod tests {
             session.meta.started_at.as_ref().map(|ts| ts.to_rfc3339()),
             Some("2026-05-25T08:00:00+00:00".to_string())
         );
+    }
+
+    #[test]
+    fn parse_codex_uses_repository_and_explicit_execution_provenance() {
+        let jsonl = r#"{"type":"session_meta","payload":{"cwd":"/tmp/refine-worktree","originator":"codex_exec","thread_source":"user","git":{"repository_url":"git@github.com:lifcc/refine.git"}}}"#;
+        let session = parse_session_content(
+            jsonl,
+            &PathBuf::from("/tmp/codex-meta.jsonl"),
+            SessionSource::Codex,
+        )
+        .unwrap();
+
+        assert_eq!(session.meta.project.as_deref(), Some("refine"));
+        assert_eq!(session.meta.mode, SessionMode::Unattended);
+    }
+
+    #[test]
+    fn parse_codex_subagent_provenance_takes_precedence() {
+        let jsonl = r#"{"type":"session_meta","payload":{"originator":"codex_exec","thread_source":"subagent"}}"#;
+        let session = parse_session_content(
+            jsonl,
+            &PathBuf::from("/tmp/codex-subagent.jsonl"),
+            SessionSource::Codex,
+        )
+        .unwrap();
+
+        assert_eq!(session.meta.mode, SessionMode::Subagent);
     }
 
     #[test]

--- a/packages/core/src/session/types.rs
+++ b/packages/core/src/session/types.rs
@@ -31,6 +31,29 @@ pub enum MessageRole {
     System,
 }
 
+/// How the session was driven. This is deliberately narrower than
+/// "scheduled": Codex metadata can prove that a run was interactive,
+/// unattended, or a subagent, but it cannot prove who scheduled an exec run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SessionMode {
+    Interactive,
+    Unattended,
+    Subagent,
+    #[default]
+    Unknown,
+}
+
+impl SessionMode {
+    pub fn as_tag(self) -> &'static str {
+        match self {
+            Self::Interactive => "session_mode_interactive",
+            Self::Unattended => "session_mode_unattended",
+            Self::Subagent => "session_mode_subagent",
+            Self::Unknown => "session_mode_unknown",
+        }
+    }
+}
+
 /// 会话消息
 #[derive(Debug, Clone)]
 pub struct SessionMessage {
@@ -44,6 +67,7 @@ pub struct SessionMeta {
     pub project: Option<String>,
     pub model: Option<String>,
     pub started_at: Option<DateTime<Utc>>,
+    pub mode: SessionMode,
 }
 
 /// 统一会话结构

--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -52,6 +52,18 @@ else
   echo "⚠️  ingest-sessions reported failures; success timestamp will not be updated"
 fi
 
+# Remem does not carry Codex originator/thread-source metadata. Reconcile the
+# matching local archive incrementally so personal scores exclude unattended
+# exec and subagent sessions without another LLM extraction.
+echo "Step 1b: backfill Codex session metadata"
+metadata_rc=0
+refine ingest-sessions --provider local --source codex --backfill-session-metadata 2>&1 \
+  || metadata_rc=$?
+if [ "$metadata_rc" -ne 0 ]; then
+  echo "ERROR: Step 1b metadata backfill failed with exit code ${metadata_rc}" >&2
+  FAILED_STEPS+=("session metadata backfill")
+fi
+
 # 2. Refresh mirror score + LLM advice (run regardless of ingest result)
 echo "Step 2: mirror score"
 score_rc=0

--- a/scripts/weekly-insights.sh
+++ b/scripts/weekly-insights.sh
@@ -49,6 +49,15 @@ else
   FAILED_STEPS+=("ingest-sessions")
 fi
 
+log "Step 1b: backfill Codex session metadata"
+metadata_rc=0
+"$REFINE_BIN" ingest-sessions --provider local --source codex \
+  --backfill-session-metadata 2>&1 || metadata_rc=$?
+if [[ "$metadata_rc" -ne 0 ]]; then
+  log "ERROR: Step 1b metadata backfill failed with exit code ${metadata_rc}"
+  FAILED_STEPS+=("session metadata backfill")
+fi
+
 # Step 2: 生成处方报告
 log "Step 2: insights --prescription"
 insights_rc=0


### PR DESCRIPTION
## Summary

- isolate Mirror score history by scoring schema and invalidate incompatible advice caches
- correct breadth formulas to use project-level denominators and rename overclaiming indicators
- normalize project aliases and exclude explicitly unattended/subagent Codex sessions from personal scoring
- add metadata-only Codex provenance backfill and run it incrementally in daily/weekly workflows
- prefer Refine's explicit BASE OpenAI-compatible endpoint over unrelated ambient Anthropic credentials

## Root cause

Mirror mixed session-weighted values with project-level target bands, treated generated extraction signals as stronger quality claims than the data supported, and lacked a reliable provenance cohort for unattended Codex work. Refine's LLM selection also preferred any ambient Anthropic credential over an explicitly configured BASE endpoint.

## User impact

On the real 90-day database, the corrected score changes from depth green / breadth red / collaboration yellow to depth green / breadth yellow / collaboration green. The metadata backfill updated 8,761 existing session documents without an LLM call.

## Validation

- `cargo test -p refine-core session:: --locked` — 48 passed
- `cargo test -p refine-cli ingest_sessions --locked` — 37 passed
- `cargo test -p mirror --locked` — 102 passed
- `bash scripts/test-runtime-wrappers.sh` — passed
- `cargo clippy -p refine-core -p refine-cli -p mirror --lib --bins --locked -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `shellcheck -x -e SC1091 scripts/daily-refresh.sh scripts/weekly-insights.sh` — passed
- real `mirror score` recomputation — depth green / breadth yellow / collaboration green

`cargo test --workspace --locked` was interrupted during the first desktop dependency build, so this PR does not claim a completed workspace-wide test run.

## Scope note

Three locally generated Tauri schema changes remain uncommitted in the worktree and are not included in this PR.
