### PR TITLE
fix: propagate provider rate limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,6 +3037,7 @@ dependencies = [
  "dirs 5.0.1",
  "filetime",
  "fs2",
+ "httpdate",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -866,7 +866,7 @@ async fn llm_call_with_retry(
     }
 
     let prompt = build_facet_prompt(content);
-    match llm_with_retry_policy(
+    let result = llm_with_retry_policy(
         client,
         &prompt,
         FACET_SYSTEM_PROMPT,
@@ -880,8 +880,15 @@ async fn llm_call_with_retry(
             );
         },
     )
-    .await
-    {
+    .await;
+    finish_llm_call(result, quota_hit)
+}
+
+fn finish_llm_call(
+    result: std::result::Result<String, InfraError>,
+    quota_hit: &Arc<AtomicBool>,
+) -> Result<String> {
+    match result {
         Ok(response) => Ok(response),
         Err(InfraError::RateLimited { retry_after_secs }) => {
             quota_hit.store(true, Ordering::Relaxed);

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -545,6 +545,30 @@ async fn quota_hit_short_circuits_before_llm_call() {
     assert!(err.to_string().contains("LLM 配额已耗尽"));
 }
 
+#[tokio::test]
+async fn provider_rate_limit_sets_batch_early_stop_without_retrying() {
+    let client = Arc::new(SequenceLlmClient::new(vec!["unused".to_string()]));
+    let client_dyn = client.clone() as Arc<dyn LlmClient>;
+    let quota_hit = Arc::new(AtomicBool::new(false));
+
+    let first = finish_llm_call(
+        Err(InfraError::RateLimited {
+            retry_after_secs: Some(42),
+        }),
+        &quota_hit,
+    )
+    .expect_err("provider quota must stop the first call");
+    assert!(first.to_string().contains("LLM 配额已耗尽"));
+    assert!(quota_hit.load(Ordering::Relaxed));
+    assert_eq!(client.calls(), 0);
+
+    let second = llm_call_with_retry(&client_dyn, "other content", &quota_hit)
+        .await
+        .expect_err("later batch work must short-circuit");
+    assert!(second.to_string().contains("跳过"));
+    assert_eq!(client.calls(), 0);
+}
+
 #[test]
 fn content_rejection_survives_anyhow_context() {
     let error = anyhow::Error::new(InfraError::LlmRejected {

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -20,6 +20,7 @@ chrono.workspace = true
 sha2.workspace = true
 fs2.workspace = true
 dirs = "5"
+httpdate = "1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/packages/core/src/infra/llm.rs
+++ b/packages/core/src/infra/llm.rs
@@ -286,17 +286,24 @@ fn classify_provider_error(
 }
 
 fn parse_retry_after(value: Option<&reqwest::header::HeaderValue>) -> Option<u64> {
+    parse_retry_after_at(value, SystemTime::now())
+}
+
+fn parse_retry_after_at(
+    value: Option<&reqwest::header::HeaderValue>,
+    now: SystemTime,
+) -> Option<u64> {
     let value = value?.to_str().ok()?.trim();
     if let Ok(seconds) = value.parse::<u64>() {
         return Some(seconds);
     }
 
     let retry_at = httpdate::parse_http_date(value).ok()?;
+    let remaining = retry_at.duration_since(now).unwrap_or_default();
     Some(
-        retry_at
-            .duration_since(SystemTime::now())
-            .unwrap_or_default()
-            .as_secs(),
+        remaining
+            .as_secs()
+            .saturating_add(u64::from(remaining.subsec_nanos() > 0)),
     )
 }
 
@@ -534,6 +541,27 @@ mod tests {
         let invalid = reqwest::header::HeaderValue::from_static("not-a-delay");
         assert_eq!(parse_retry_after(Some(&invalid)), None);
         assert_eq!(parse_retry_after(None), None);
+    }
+
+    #[test]
+    fn retry_after_http_date_rounds_future_fraction_up_without_extending_past_dates() {
+        let retry_at = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(100);
+        let header =
+            reqwest::header::HeaderValue::from_str(&httpdate::fmt_http_date(retry_at)).unwrap();
+
+        let half_second_before = SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(99_500);
+        assert_eq!(
+            parse_retry_after_at(Some(&header), half_second_before),
+            Some(1)
+        );
+        assert_eq!(parse_retry_after_at(Some(&header), retry_at), Some(0));
+        assert_eq!(
+            parse_retry_after_at(
+                Some(&header),
+                retry_at + std::time::Duration::from_millis(1)
+            ),
+            Some(0)
+        );
     }
 
     #[tokio::test]

--- a/packages/core/src/infra/llm.rs
+++ b/packages/core/src/infra/llm.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 /// LLM 客户端接口
 #[async_trait]
@@ -115,8 +116,10 @@ impl LlmClient for ClaudeClient {
 
         if !resp.status().is_success() {
             let status = resp.status();
+            let retry_after_secs =
+                parse_retry_after(resp.headers().get(reqwest::header::RETRY_AFTER));
             let err = resp.text().await.unwrap_or_default();
-            return Err(classify_provider_error(status, &err));
+            return Err(classify_provider_error(status, retry_after_secs, &err));
         }
 
         let data: ClaudeResponse = resp
@@ -203,8 +206,10 @@ impl LlmClient for OpenAIClient {
 
         if !resp.status().is_success() {
             let status = resp.status();
+            let retry_after_secs =
+                parse_retry_after(resp.headers().get(reqwest::header::RETRY_AFTER));
             let err = resp.text().await.unwrap_or_default();
-            return Err(classify_provider_error(status, &err));
+            return Err(classify_provider_error(status, retry_after_secs, &err));
         }
 
         let data: OpenAIResponse = resp
@@ -239,7 +244,15 @@ fn env_var(keys: &[&str]) -> Option<String> {
         .filter(|value| !value.trim().is_empty())
 }
 
-fn classify_provider_error(status: reqwest::StatusCode, body: &str) -> InfraError {
+fn classify_provider_error(
+    status: reqwest::StatusCode,
+    retry_after_secs: Option<u64>,
+    body: &str,
+) -> InfraError {
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return InfraError::RateLimited { retry_after_secs };
+    }
+
     let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
     let error = parsed.as_ref().and_then(|value| value.get("error"));
     let code = error
@@ -270,6 +283,21 @@ fn classify_provider_error(status: reqwest::StatusCode, body: &str) -> InfraErro
         status: status.as_u16(),
         message: body.to_string(),
     }
+}
+
+fn parse_retry_after(value: Option<&reqwest::header::HeaderValue>) -> Option<u64> {
+    let value = value?.to_str().ok()?.trim();
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(seconds);
+    }
+
+    let retry_at = httpdate::parse_http_date(value).ok()?;
+    Some(
+        retry_at
+            .duration_since(SystemTime::now())
+            .unwrap_or_default()
+            .as_secs(),
+    )
 }
 
 fn is_content_rejection(code: &str, message: &str) -> bool {
@@ -345,6 +373,8 @@ impl LlmClient for MockLlmClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -438,6 +468,7 @@ mod tests {
     fn sensitive_words_error_is_structured_as_non_retryable_rejection() {
         let error = classify_provider_error(
             reqwest::StatusCode::BAD_REQUEST,
+            None,
             r#"{"error":{"message":"sensitive_words_detected","code":"sensitive_words_detected"}}"#,
         );
         assert!(matches!(
@@ -450,6 +481,7 @@ mod tests {
     fn sensitive_words_message_without_code_is_still_non_retryable() {
         let error = classify_provider_error(
             reqwest::StatusCode::BAD_REQUEST,
+            None,
             r#"{"error":{"message":"request blocked: sensitive_words_detected"}}"#,
         );
         assert!(matches!(
@@ -462,24 +494,84 @@ mod tests {
     fn unknown_provider_error_stays_request_error() {
         let error = classify_provider_error(
             reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            None,
             r#"{"error":{"message":"upstream unavailable","code":"upstream_error"}}"#,
         );
         assert!(matches!(error, InfraError::LlmHttp { status: 503, .. }));
     }
 
     #[test]
-    fn provider_rate_limit_stays_retryable_http_error() {
+    fn provider_rate_limit_is_structured_and_drops_response_body() {
         let error = classify_provider_error(
             reqwest::StatusCode::TOO_MANY_REQUESTS,
-            r#"{"error":{"message":"rate limited","code":"rate_limit"}}"#,
+            Some(42),
+            r#"{"error":{"message":"secret provider body","code":"rate_limit"}}"#,
         );
-        assert!(matches!(error, InfraError::LlmHttp { status: 429, .. }));
+        assert!(matches!(
+            error,
+            InfraError::RateLimited {
+                retry_after_secs: Some(42)
+            }
+        ));
+    }
+
+    #[test]
+    fn retry_after_supports_delta_seconds_http_date_and_invalid_values() {
+        let seconds = reqwest::header::HeaderValue::from_static("42");
+        assert_eq!(parse_retry_after(Some(&seconds)), Some(42));
+
+        let future = SystemTime::now() + std::time::Duration::from_secs(120);
+        let http_date =
+            reqwest::header::HeaderValue::from_str(&httpdate::fmt_http_date(future)).unwrap();
+        let parsed = parse_retry_after(Some(&http_date)).expect("HTTP-date should parse");
+        assert!((118..=120).contains(&parsed), "unexpected delay: {parsed}");
+
+        let past = SystemTime::now() - std::time::Duration::from_secs(60);
+        let past_date =
+            reqwest::header::HeaderValue::from_str(&httpdate::fmt_http_date(past)).unwrap();
+        assert_eq!(parse_retry_after(Some(&past_date)), Some(0));
+
+        let invalid = reqwest::header::HeaderValue::from_static("not-a-delay");
+        assert_eq!(parse_retry_after(Some(&invalid)), None);
+        assert_eq!(parse_retry_after(None), None);
+    }
+
+    #[tokio::test]
+    async fn concrete_clients_preserve_retry_after_from_provider_429() {
+        for provider in ["anthropic", "openai"] {
+            let base_url = spawn_single_response_server(
+                "429 Too Many Requests",
+                &[("Retry-After", "42")],
+                r#"{"error":{"message":"do not persist this body"}}"#,
+            );
+            let client: Box<dyn LlmClient> = match provider {
+                "anthropic" => Box::new(ClaudeClient::new("test-key").with_base_url(&base_url)),
+                "openai" => Box::new(OpenAIClient::new("test-key").with_base_url(&base_url)),
+                _ => unreachable!(),
+            };
+
+            let error = client
+                .complete("hello", Some("system"))
+                .await
+                .expect_err("provider 429 must fail");
+            assert!(
+                matches!(
+                    error,
+                    InfraError::RateLimited {
+                        retry_after_secs: Some(42)
+                    }
+                ),
+                "{provider} returned unexpected error: {error}"
+            );
+            assert!(!error.to_string().contains("do not persist this body"));
+        }
     }
 
     #[test]
     fn generic_moderation_message_from_5xx_is_not_quarantined() {
         let error = classify_provider_error(
             reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            None,
             r#"{"error":{"message":"moderation service unavailable"}}"#,
         );
         assert!(matches!(error, InfraError::LlmHttp { status: 503, .. }));
@@ -489,6 +581,7 @@ mod tests {
     fn openai_content_filter_code_is_quarantined() {
         let error = classify_provider_error(
             reqwest::StatusCode::BAD_REQUEST,
+            None,
             r#"{"error":{"message":"blocked","code":"content_filter"}}"#,
         );
         assert!(
@@ -505,6 +598,35 @@ mod tests {
         for secret in ["user", "secret", "token", "private-value"] {
             assert!(!identity.contains(secret));
         }
+    }
+
+    fn spawn_single_response_server(status: &str, headers: &[(&str, &str)], body: &str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let address = listener.local_addr().expect("test server address");
+        let status = status.to_string();
+        let headers = headers
+            .iter()
+            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .collect::<Vec<_>>();
+        let body = body.to_string();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept provider request");
+            let mut request = [0u8; 8192];
+            let _ = stream.read(&mut request).expect("read provider request");
+            let mut response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n",
+                body.len()
+            );
+            for (name, value) in headers {
+                response.push_str(&format!("{name}: {value}\r\n"));
+            }
+            response.push_str("\r\n");
+            response.push_str(&body);
+            stream
+                .write_all(response.as_bytes())
+                .expect("write provider response");
+        });
+        format!("http://{address}")
     }
 
     fn with_clean_llm_env(test: impl FnOnce()) {

--- a/packages/core/src/infra/quota_state.rs
+++ b/packages/core/src/infra/quota_state.rs
@@ -70,8 +70,7 @@ pub fn set_exhausted(retry_after_secs: Option<u64>) {
             .min(MAX_QUOTA_BACKOFF_SECS)
     });
 
-    let until = Utc::now() + Duration::from_secs(secs);
-    let timestamp = until.to_rfc3339_opts(SecondsFormat::Secs, true);
+    let timestamp = quota_deadline_timestamp(Utc::now(), secs);
 
     let path = quota_file_path();
     if let Some(parent) = path.parent() {
@@ -85,6 +84,10 @@ pub fn set_exhausted(retry_after_secs: Option<u64>) {
     if std::fs::write(&tmp, &timestamp).is_ok() {
         let _ = std::fs::rename(&tmp, &path);
     }
+}
+
+fn quota_deadline_timestamp(now: DateTime<Utc>, secs: u64) -> String {
+    (now + Duration::from_secs(secs)).to_rfc3339_opts(SecondsFormat::Nanos, true)
 }
 
 fn env_override_secs() -> Option<u64> {
@@ -154,6 +157,24 @@ mod tests {
         let contents = fs::read_to_string(&path).unwrap();
         let parsed: DateTime<Utc> = contents.trim().parse().expect("must be valid ISO-8601");
         assert!(parsed > before, "written timestamp must be in the future");
+    }
+
+    #[test]
+    fn set_exhausted_preserves_subsecond_deadline_precision() {
+        let now = DateTime::parse_from_rfc3339("2026-08-13T12:34:56.789123456Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let contents = quota_deadline_timestamp(now, 1);
+        assert!(
+            contents.contains('.'),
+            "quota marker should preserve subsecond precision: {contents}"
+        );
+        let parsed: DateTime<Utc> = contents.trim().parse().expect("valid marker timestamp");
+        assert_eq!(
+            parsed.signed_duration_since(now),
+            chrono::Duration::seconds(1)
+        );
+        assert_eq!(contents, "2026-08-13T12:34:57.789123456Z");
     }
 
     #[test]

--- a/scripts/daily-refresh.sh
+++ b/scripts/daily-refresh.sh
@@ -23,11 +23,19 @@ if [[ "${REFINE_RUNTIME_LOCK_ACTIVE:-}" != "1" ]]; then
   exit $?
 fi
 
+# shellcheck source=scripts/quota-time.sh
+source "${SCRIPT_DIR}/quota-time.sh"
+
 QUOTA_FILE="$HOME/.refine/quota_exhausted_until"
 if [ -f "$QUOTA_FILE" ]; then
   UNTIL=$(cat "$QUOTA_FILE")
   NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  if [[ "$UNTIL" > "$NOW" ]]; then
+  if ! UNTIL_KEY=$(quota_timestamp_sort_key "$UNTIL"); then
+    echo "WARN: ignoring malformed quota marker: $QUOTA_FILE" >&2
+  elif ! NOW_KEY=$(quota_timestamp_sort_key "$NOW"); then
+    echo "ERROR: failed to normalize current UTC time" >&2
+    exit 1
+  elif [[ "$UNTIL_KEY" > "$NOW_KEY" ]]; then
     echo "LLM quota exhausted until $UNTIL — skipping refresh"
     exit 0
   fi

--- a/scripts/quota-time.sh
+++ b/scripts/quota-time.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Normalize Refine's UTC RFC 3339 quota timestamps to a fixed-width key.
+# Accepts the legacy second-only form and the current 1-9 digit fractional form.
+quota_timestamp_sort_key() {
+  local value="$1"
+  if [[ ! "$value" =~ ^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2})(\.([0-9]{1,9}))?Z$ ]]; then
+    return 1
+  fi
+
+  local whole_seconds="${BASH_REMATCH[1]}"
+  local fraction="${BASH_REMATCH[3]:-}000000000"
+  local parsed=""
+  if date --version >/dev/null 2>&1; then
+    parsed=$(date -u -d "${whole_seconds}Z" +%Y-%m-%dT%H:%M:%S 2>/dev/null) || return 1
+  else
+    parsed=$(date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "${whole_seconds}Z" +%Y-%m-%dT%H:%M:%S 2>/dev/null) || return 1
+  fi
+  [[ "$parsed" == "$whole_seconds" ]] || return 1
+
+  printf '%s.%sZ\n' "$whole_seconds" "${fraction:0:9}"
+}

--- a/scripts/test-runtime-wrappers.sh
+++ b/scripts/test-runtime-wrappers.sh
@@ -10,6 +10,20 @@ fail() {
   exit 1
 }
 
+# Legacy second-only and precise markers must sort correctly within the same
+# whole second; this is the boundary that plain RFC 3339 string comparison gets wrong.
+# shellcheck source=scripts/quota-time.sh
+source "${SCRIPT_DIR}/quota-time.sh"
+second_key=$(quota_timestamp_sort_key '2026-08-13T12:34:57Z')
+precise_key=$(quota_timestamp_sort_key '2026-08-13T12:34:57.789123456Z')
+[[ "$precise_key" > "$second_key" ]] \
+  || fail 'precise quota marker did not sort after the same whole second'
+[[ "$second_key" == '2026-08-13T12:34:57.000000000Z' ]] \
+  || fail 'legacy quota marker did not normalize to fixed precision'
+if quota_timestamp_sort_key '2026-02-31T12:34:57Z' >/dev/null 2>&1; then
+  fail 'quota timestamp parser accepted an invalid calendar date'
+fi
+
 home="${TEST_ROOT}/home"
 mkdir -p "${home}/.refine"
 chmod 700 "${home}/.refine"
@@ -115,6 +129,9 @@ printf '%s\n' "export BASE_API_KEY='daily-secret'" > "${daily_home}/.refine/llm.
 chmod 600 "${daily_home}/.refine/llm.env"
 cat > "${daily_home}/.cargo/bin/refine" <<'EOF'
 #!/usr/bin/env bash
+if [[ -n "${FAKE_REFINE_LOG:-}" ]]; then
+  printf 'called\n' >> "$FAKE_REFINE_LOG"
+fi
 exit 0
 EOF
 cat > "${daily_home}/.cargo/bin/mirror" <<'EOF'
@@ -146,5 +163,40 @@ env -i HOME="$daily_home" PATH="/usr/bin:/bin" FAKE_MIRROR_EXIT=0 \
   || fail 'daily refresh did not succeed with all required steps healthy'
 [[ -f "${daily_home}/.refine/last-refresh-ok" ]] \
   || fail 'daily refresh omitted success marker after complete success'
+
+# Quota markers are written by Rust with optional nanosecond precision. The
+# wrapper must compare both legacy second-only and precise forms correctly.
+quota_refine_log="${TEST_ROOT}/quota-refine.log"
+future_year=$((10#$(date -u +%Y) + 1))
+printf '%04d-01-01T00:00:00.000000001Z\n' "$future_year" \
+  > "${daily_home}/.refine/quota_exhausted_until"
+output=$(env -i HOME="$daily_home" PATH="/usr/bin:/bin" \
+  FAKE_REFINE_LOG="$quota_refine_log" REFINE_RUNTIME_JOB_LOCK_WAIT_SECONDS=0 \
+  bash "${SCRIPT_DIR}/daily-refresh.sh" 2>&1) \
+  || fail 'daily refresh failed while honoring a precise future quota marker'
+[[ "$output" == *'skipping refresh'* ]] \
+  || fail 'daily refresh ignored a precise future quota marker'
+[[ ! -e "$quota_refine_log" ]] \
+  || fail 'daily refresh called refine despite a precise future quota marker'
+
+printf '%s\n' '2000-01-01T00:00:00Z' \
+  > "${daily_home}/.refine/quota_exhausted_until"
+env -i HOME="$daily_home" PATH="/usr/bin:/bin" \
+  FAKE_REFINE_LOG="$quota_refine_log" REFINE_RUNTIME_JOB_LOCK_WAIT_SECONDS=0 \
+  bash "${SCRIPT_DIR}/daily-refresh.sh" >/dev/null 2>&1 \
+  || fail 'daily refresh rejected a legacy expired quota marker'
+[[ -s "$quota_refine_log" ]] \
+  || fail 'daily refresh skipped work for a legacy expired quota marker'
+
+: > "$quota_refine_log"
+printf '%s\n' 'not-a-timestamp' > "${daily_home}/.refine/quota_exhausted_until"
+output=$(env -i HOME="$daily_home" PATH="/usr/bin:/bin" \
+  FAKE_REFINE_LOG="$quota_refine_log" REFINE_RUNTIME_JOB_LOCK_WAIT_SECONDS=0 \
+  bash "${SCRIPT_DIR}/daily-refresh.sh" 2>&1) \
+  || fail 'daily refresh did not fail open for a malformed quota marker'
+[[ "$output" == *'WARN: ignoring malformed quota marker'* ]] \
+  || fail 'daily refresh did not report a malformed quota marker'
+[[ -s "$quota_refine_log" ]] \
+  || fail 'daily refresh skipped work for a malformed quota marker'
 
 printf 'All runtime wrapper tests passed\n'


### PR DESCRIPTION
Closes #170

## Summary
- classify concrete Claude and OpenAI-compatible HTTP 429 responses as `InfraError::RateLimited`
- preserve valid `Retry-After` delta-seconds and HTTP-date values without retaining provider response bodies
- keep existing quota-state bounding/persistence and session-ingest early-stop behavior
- add concrete mock-server coverage for both providers and a CLI batch short-circuit regression

## Verification
- `cargo test -p refine-core --lib --locked --target-dir /tmp/refine-h07-target` (153 passed)
- `cargo test -p refine-cli --locked --target-dir /tmp/refine-h07-target` (59 passed)
- `cargo clippy -p refine-core -p refine-cli --locked --target-dir /tmp/refine-h07-target -- -D warnings`
- `git diff --check`