### PR TITLE
fix: serialize extension outbox mutations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
+      - run: bun run test
       - run: bun run typecheck
       - run: bun run build
 

--- a/apps/extension/bun.lock
+++ b/apps/extension/bun.lock
@@ -10,6 +10,7 @@
         "react-dom": "^18.3.1",
       },
       "devDependencies": {
+        "@types/bun": "^1.3.0",
         "@types/chrome": "^0.0.260",
         "@types/react": "^18.3.31",
         "@types/react-dom": "^18.3.7",
@@ -469,6 +470,8 @@
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@5.0.1", "", { "dependencies": { "defer-to-connect": "^2.0.1" } }, "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/chrome": ["@types/chrome@0.0.260", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-lX6QpgfsZRTDpNcCJ+3vzfFnFXq9bScFRTlfhbK5oecSAjamsno+ejFTCbNtc5O/TPnVK9Tja/PyecvWQe0F2w=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -480,6 +483,8 @@
     "@types/har-format": ["@types/har-format@1.2.16", "", {}, "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A=="],
 
     "@types/http-cache-semantics": ["@types/http-cache-semantics@4.2.0", "", {}, "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
@@ -556,6 +561,8 @@
     "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-require": ["bundle-require@4.2.1", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.17" } }, "sha512-7Q/6vkyYAwOmQNRw75x+4yRtZCZJXUDmHHlFdkiV0wgv/reNjtJwpu1jPJ0w2kbEpIM0uoKI3S4/f39dU7AjSA=="],
 
@@ -1084,6 +1091,8 @@
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unique-string": ["unique-string@3.0.0", "", { "dependencies": { "crypto-random-string": "^4.0.0" } }, "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ=="],
 

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -8,6 +8,7 @@
     "dev": "plasmo dev",
     "build": "plasmo build",
     "package": "plasmo package",
+    "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -16,6 +17,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.0",
     "@types/chrome": "^0.0.260",
     "@types/react": "^18.3.31",
     "@types/react-dom": "^18.3.7",

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -22,8 +22,7 @@ import {
   RETRY_BASE_DELAY_MS,
   RETRY_MAX_DELAY_MS,
 } from '../lib/config'
-import { createAsyncTaskQueue } from '../lib/async-queue'
-import { findLeasedItem } from '../lib/outbox-state'
+import { OutboxRuntime, type OutboxSnapshot } from '../lib/outbox-runtime'
 import type {
   ConversationPayload,
   ExtensionStats,
@@ -46,14 +45,6 @@ const DEFAULT_STATS: ExtensionStats = {
 const DEFAULT_SYNC_STATE: SyncState = {}
 
 let cloudStatusCache: CloudStatusCache | null = null
-const storageMutationQueue = createAsyncTaskQueue()
-const flushQueue = createAsyncTaskQueue()
-
-interface StorageSnapshot {
-  stats: ExtensionStats
-  outbox: OutboxItem[]
-  syncState: SyncState
-}
 
 interface CloudStatusCache {
   updatedAt: number
@@ -103,51 +94,7 @@ function formatQuotaExceededMessage(quota: QuotaStatusResponse): string {
   return '额度不足，请升级会员或提高服务端额度后重试。'
 }
 
-function backoffDelayMs(attemptCount: number): number {
-  const multiplier = Math.max(0, attemptCount - 1)
-  const delay = RETRY_BASE_DELAY_MS * 2 ** multiplier
-  return Math.min(delay, RETRY_MAX_DELAY_MS)
-}
-
-function createOutboxItem(payload: ConversationPayload): OutboxItem {
-  const now = Date.now()
-  return {
-    id: crypto.randomUUID(),
-    idempotencyKey: crypto.randomUUID(),
-    payload,
-    status: 'pending',
-    attemptCount: 0,
-    nextAttemptAt: now,
-    createdAt: now,
-    updatedAt: now,
-  }
-}
-
-function pruneOutbox(outbox: OutboxItem[]): OutboxItem[] {
-  const sentTtlMs = 24 * 60 * 60 * 1_000
-  const now = Date.now()
-  return outbox.filter((item) => item.status !== 'sent' || now - item.updatedAt <= sentTtlMs)
-}
-
-function recoverStuckSyncingItems(outbox: OutboxItem[], now = Date.now()): boolean {
-  let changed = false
-
-  for (const item of outbox) {
-    if (item.status !== 'syncing') continue
-    if (now - item.updatedAt < SYNCING_RECOVERY_STALE_MS) continue
-
-    item.status = 'failed'
-    item.syncLeaseId = undefined
-    item.lastError = item.lastError || 'Sync interrupted, retry scheduled'
-    item.nextAttemptAt = now
-    item.updatedAt = now
-    changed = true
-  }
-
-  return changed
-}
-
-async function buildSyncStatus(snapshot: StorageSnapshot): Promise<SyncStatus> {
+async function buildSyncStatus(snapshot: OutboxSnapshot): Promise<SyncStatus> {
   const counts = {
     pending: 0,
     syncing: 0,
@@ -167,7 +114,7 @@ async function buildSyncStatus(snapshot: StorageSnapshot): Promise<SyncStatus> {
   }
 }
 
-async function loadSnapshot(): Promise<StorageSnapshot> {
+async function loadSnapshot(): Promise<OutboxSnapshot> {
   const result = await chrome.storage.local.get([STATS_KEY, OUTBOX_KEY, SYNC_STATE_KEY])
   return {
     stats: (result[STATS_KEY] as ExtensionStats | undefined) || { ...DEFAULT_STATS },
@@ -176,7 +123,7 @@ async function loadSnapshot(): Promise<StorageSnapshot> {
   }
 }
 
-async function saveSnapshot(snapshot: StorageSnapshot): Promise<void> {
+async function saveSnapshot(snapshot: OutboxSnapshot): Promise<void> {
   await chrome.storage.local.set({
     [STATS_KEY]: snapshot.stats,
     [OUTBOX_KEY]: snapshot.outbox,
@@ -184,14 +131,29 @@ async function saveSnapshot(snapshot: StorageSnapshot): Promise<void> {
   })
 }
 
+const outboxRuntime = new OutboxRuntime({
+  storage: { load: loadSnapshot, save: saveSnapshot },
+  upload: uploadConversation,
+  retryBaseDelayMs: RETRY_BASE_DELAY_MS,
+  retryMaxDelayMs: RETRY_MAX_DELAY_MS,
+  syncingRecoveryStaleMs: SYNCING_RECOVERY_STALE_MS,
+  onSynced(item, result) {
+    void trackEvent({
+      event_name: 'conversation_synced',
+      source: item.payload.source,
+      properties: {
+        provider: item.payload.source,
+        outbox_item_id: item.id,
+        remote_conversation_id: result.conversationId || null,
+        attempt_count: item.attemptCount,
+      },
+      occurred_at: new Date().toISOString(),
+    })
+  },
+})
+
 async function initializeStorage(): Promise<void> {
-  await storageMutationQueue.run(async () => {
-    const snapshot = await loadSnapshot()
-    const now = Date.now()
-    recoverStuckSyncingItems(snapshot.outbox, now)
-    snapshot.outbox = pruneOutbox(snapshot.outbox)
-    await saveSnapshot(snapshot)
-  })
+  await outboxRuntime.initialize()
 }
 
 async function getCloudStatusWithCache(): Promise<{
@@ -233,11 +195,7 @@ async function getCloudStatusWithCache(): Promise<{
 }
 
 async function resetDailyStats(): Promise<void> {
-  await storageMutationQueue.run(async () => {
-    const snapshot = await loadSnapshot()
-    snapshot.stats.todayExtracted = 0
-    await saveSnapshot(snapshot)
-  })
+  await outboxRuntime.resetDailyStats()
 }
 
 async function enqueueConversation(payload: ConversationPayload): Promise<EnqueueConversationResult> {
@@ -249,13 +207,7 @@ async function enqueueConversation(payload: ConversationPayload): Promise<Enqueu
     }
   }
 
-  const item = createOutboxItem(payload)
-  await storageMutationQueue.run(async () => {
-    const snapshot = await loadSnapshot()
-    snapshot.outbox.push(item)
-    snapshot.stats.todayExtracted += 1
-    await saveSnapshot(snapshot)
-  })
+  const item = await outboxRuntime.enqueue(payload)
 
   void trackEvent({
     event_name: 'conversation_extracted',
@@ -277,99 +229,7 @@ async function enqueueConversation(payload: ConversationPayload): Promise<Enqueu
 }
 
 async function flushOutboxNow(): Promise<void> {
-  await flushOutboxWithOptions({ forceRetry: false })
-}
-
-async function flushOutboxWithOptions(options: { forceRetry: boolean }): Promise<void> {
-  const candidateIds = await listFlushCandidateIds(options.forceRetry)
-
-  for (const candidateId of candidateIds) {
-    const item = await claimOutboxItem(candidateId, options.forceRetry)
-    if (!item) continue
-
-    const result = await uploadConversation(item)
-    const committed = await finishOutboxUpload(item, result)
-    if (!committed || !result.success) continue
-
-    void trackEvent({
-      event_name: 'conversation_synced',
-      source: item.payload.source,
-      properties: {
-        provider: item.payload.source,
-        outbox_item_id: item.id,
-        remote_conversation_id: result.conversationId || null,
-        attempt_count: item.attemptCount,
-      },
-      occurred_at: new Date().toISOString(),
-    })
-  }
-}
-
-async function listFlushCandidateIds(forceRetry: boolean): Promise<string[]> {
-  return storageMutationQueue.run(async () => {
-    const snapshot = await loadSnapshot()
-    const now = Date.now()
-    const recovered = recoverStuckSyncingItems(snapshot.outbox, now)
-    if (recovered) await saveSnapshot(snapshot)
-
-    return snapshot.outbox
-      .filter((item) => {
-        if (item.status !== 'pending' && item.status !== 'failed') return false
-        return forceRetry || item.nextAttemptAt <= now
-      })
-      .map((item) => item.id)
-  })
-}
-
-async function claimOutboxItem(
-  itemId: string,
-  forceRetry: boolean,
-): Promise<OutboxItem | null> {
-  return storageMutationQueue.run(async () => {
-    const snapshot = await loadSnapshot()
-    const now = Date.now()
-    const item = snapshot.outbox.find((candidate) => candidate.id === itemId)
-    if (!item || (item.status !== 'pending' && item.status !== 'failed')) return null
-    if (!forceRetry && item.nextAttemptAt > now) return null
-
-    item.status = 'syncing'
-    item.syncLeaseId = crypto.randomUUID()
-    item.updatedAt = now
-    await saveSnapshot(snapshot)
-    return { ...item, payload: { ...item.payload } }
-  })
-}
-
-async function finishOutboxUpload(
-  claimedItem: OutboxItem,
-  result: Awaited<ReturnType<typeof uploadConversation>>,
-): Promise<boolean> {
-  return storageMutationQueue.run(async () => {
-    const snapshot = await loadSnapshot()
-    const item = findLeasedItem(snapshot.outbox, claimedItem)
-    if (!item) return false
-
-    item.syncLeaseId = undefined
-    item.updatedAt = Date.now()
-    if (result.success) {
-      item.status = 'sent'
-      item.lastError = undefined
-      item.remoteConversationId = result.conversationId
-      snapshot.stats.totalItems += 1
-      snapshot.syncState.lastSyncedAt = item.updatedAt
-      snapshot.syncState.lastError = undefined
-    } else {
-      item.status = 'failed'
-      item.attemptCount += 1
-      item.lastError = result.message || 'Unknown cloud sync error'
-      item.nextAttemptAt = item.updatedAt + backoffDelayMs(item.attemptCount)
-      snapshot.syncState.lastError = item.lastError
-    }
-
-    snapshot.outbox = pruneOutbox(snapshot.outbox)
-    await saveSnapshot(snapshot)
-    return true
-  })
+  await outboxRuntime.requestFlush(false)
 }
 
 async function flushOutbox(): Promise<void> {
@@ -377,7 +237,7 @@ async function flushOutbox(): Promise<void> {
 }
 
 async function flushOutboxWith(options: { forceRetry: boolean }): Promise<void> {
-  return flushQueue.run(() => flushOutboxWithOptions(options))
+  return outboxRuntime.requestFlush(options.forceRetry)
 }
 
 async function ensureAlarms(): Promise<void> {

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -22,6 +22,8 @@ import {
   RETRY_BASE_DELAY_MS,
   RETRY_MAX_DELAY_MS,
 } from '../lib/config'
+import { createAsyncTaskQueue } from '../lib/async-queue'
+import { findLeasedItem } from '../lib/outbox-state'
 import type {
   ConversationPayload,
   ExtensionStats,
@@ -43,8 +45,9 @@ const DEFAULT_STATS: ExtensionStats = {
 
 const DEFAULT_SYNC_STATE: SyncState = {}
 
-let flushPromise: Promise<void> | null = null
 let cloudStatusCache: CloudStatusCache | null = null
+const storageMutationQueue = createAsyncTaskQueue()
+const flushQueue = createAsyncTaskQueue()
 
 interface StorageSnapshot {
   stats: ExtensionStats
@@ -134,6 +137,7 @@ function recoverStuckSyncingItems(outbox: OutboxItem[], now = Date.now()): boole
     if (now - item.updatedAt < SYNCING_RECOVERY_STALE_MS) continue
 
     item.status = 'failed'
+    item.syncLeaseId = undefined
     item.lastError = item.lastError || 'Sync interrupted, retry scheduled'
     item.nextAttemptAt = now
     item.updatedAt = now
@@ -181,11 +185,13 @@ async function saveSnapshot(snapshot: StorageSnapshot): Promise<void> {
 }
 
 async function initializeStorage(): Promise<void> {
-  const snapshot = await loadSnapshot()
-  const now = Date.now()
-  recoverStuckSyncingItems(snapshot.outbox, now)
-  snapshot.outbox = pruneOutbox(snapshot.outbox)
-  await saveSnapshot(snapshot)
+  await storageMutationQueue.run(async () => {
+    const snapshot = await loadSnapshot()
+    const now = Date.now()
+    recoverStuckSyncingItems(snapshot.outbox, now)
+    snapshot.outbox = pruneOutbox(snapshot.outbox)
+    await saveSnapshot(snapshot)
+  })
 }
 
 async function getCloudStatusWithCache(): Promise<{
@@ -227,9 +233,11 @@ async function getCloudStatusWithCache(): Promise<{
 }
 
 async function resetDailyStats(): Promise<void> {
-  const snapshot = await loadSnapshot()
-  snapshot.stats.todayExtracted = 0
-  await saveSnapshot(snapshot)
+  await storageMutationQueue.run(async () => {
+    const snapshot = await loadSnapshot()
+    snapshot.stats.todayExtracted = 0
+    await saveSnapshot(snapshot)
+  })
 }
 
 async function enqueueConversation(payload: ConversationPayload): Promise<EnqueueConversationResult> {
@@ -241,11 +249,13 @@ async function enqueueConversation(payload: ConversationPayload): Promise<Enqueu
     }
   }
 
-  const snapshot = await loadSnapshot()
   const item = createOutboxItem(payload)
-  snapshot.outbox.push(item)
-  snapshot.stats.todayExtracted += 1
-  await saveSnapshot(snapshot)
+  await storageMutationQueue.run(async () => {
+    const snapshot = await loadSnapshot()
+    snapshot.outbox.push(item)
+    snapshot.stats.todayExtracted += 1
+    await saveSnapshot(snapshot)
+  })
 
   void trackEvent({
     event_name: 'conversation_extracted',
@@ -271,63 +281,95 @@ async function flushOutboxNow(): Promise<void> {
 }
 
 async function flushOutboxWithOptions(options: { forceRetry: boolean }): Promise<void> {
-  const snapshot = await loadSnapshot()
-  const now = Date.now()
-  const forceRetry = options.forceRetry
-  let changed = recoverStuckSyncingItems(snapshot.outbox, now)
+  const candidateIds = await listFlushCandidateIds(options.forceRetry)
 
-  for (const item of snapshot.outbox) {
-    if (item.status === 'sent') continue
-    if (item.status !== 'pending' && item.status !== 'failed') continue
-    if (!forceRetry && item.nextAttemptAt > now) continue
-    if (forceRetry && item.status === 'failed') {
-      item.nextAttemptAt = now
-    }
-
-    item.status = 'syncing'
-    item.updatedAt = Date.now()
-    changed = true
-    await saveSnapshot(snapshot)
+  for (const candidateId of candidateIds) {
+    const item = await claimOutboxItem(candidateId, options.forceRetry)
+    if (!item) continue
 
     const result = await uploadConversation(item)
+    const committed = await finishOutboxUpload(item, result)
+    if (!committed || !result.success) continue
 
+    void trackEvent({
+      event_name: 'conversation_synced',
+      source: item.payload.source,
+      properties: {
+        provider: item.payload.source,
+        outbox_item_id: item.id,
+        remote_conversation_id: result.conversationId || null,
+        attempt_count: item.attemptCount,
+      },
+      occurred_at: new Date().toISOString(),
+    })
+  }
+}
+
+async function listFlushCandidateIds(forceRetry: boolean): Promise<string[]> {
+  return storageMutationQueue.run(async () => {
+    const snapshot = await loadSnapshot()
+    const now = Date.now()
+    const recovered = recoverStuckSyncingItems(snapshot.outbox, now)
+    if (recovered) await saveSnapshot(snapshot)
+
+    return snapshot.outbox
+      .filter((item) => {
+        if (item.status !== 'pending' && item.status !== 'failed') return false
+        return forceRetry || item.nextAttemptAt <= now
+      })
+      .map((item) => item.id)
+  })
+}
+
+async function claimOutboxItem(
+  itemId: string,
+  forceRetry: boolean,
+): Promise<OutboxItem | null> {
+  return storageMutationQueue.run(async () => {
+    const snapshot = await loadSnapshot()
+    const now = Date.now()
+    const item = snapshot.outbox.find((candidate) => candidate.id === itemId)
+    if (!item || (item.status !== 'pending' && item.status !== 'failed')) return null
+    if (!forceRetry && item.nextAttemptAt > now) return null
+
+    item.status = 'syncing'
+    item.syncLeaseId = crypto.randomUUID()
+    item.updatedAt = now
+    await saveSnapshot(snapshot)
+    return { ...item, payload: { ...item.payload } }
+  })
+}
+
+async function finishOutboxUpload(
+  claimedItem: OutboxItem,
+  result: Awaited<ReturnType<typeof uploadConversation>>,
+): Promise<boolean> {
+  return storageMutationQueue.run(async () => {
+    const snapshot = await loadSnapshot()
+    const item = findLeasedItem(snapshot.outbox, claimedItem)
+    if (!item) return false
+
+    item.syncLeaseId = undefined
+    item.updatedAt = Date.now()
     if (result.success) {
       item.status = 'sent'
       item.lastError = undefined
       item.remoteConversationId = result.conversationId
-      item.updatedAt = Date.now()
       snapshot.stats.totalItems += 1
-      snapshot.syncState.lastSyncedAt = Date.now()
+      snapshot.syncState.lastSyncedAt = item.updatedAt
       snapshot.syncState.lastError = undefined
-      changed = true
-
-      void trackEvent({
-        event_name: 'conversation_synced',
-        source: item.payload.source,
-        properties: {
-          provider: item.payload.source,
-          outbox_item_id: item.id,
-          remote_conversation_id: result.conversationId || null,
-          attempt_count: item.attemptCount,
-        },
-        occurred_at: new Date().toISOString(),
-      })
-      continue
+    } else {
+      item.status = 'failed'
+      item.attemptCount += 1
+      item.lastError = result.message || 'Unknown cloud sync error'
+      item.nextAttemptAt = item.updatedAt + backoffDelayMs(item.attemptCount)
+      snapshot.syncState.lastError = item.lastError
     }
 
-    item.status = 'failed'
-    item.attemptCount += 1
-    item.lastError = result.message || 'Unknown cloud sync error'
-    item.nextAttemptAt = Date.now() + backoffDelayMs(item.attemptCount)
-    item.updatedAt = Date.now()
-    snapshot.syncState.lastError = item.lastError
-    changed = true
-  }
-
-  if (changed) {
     snapshot.outbox = pruneOutbox(snapshot.outbox)
     await saveSnapshot(snapshot)
-  }
+    return true
+  })
 }
 
 async function flushOutbox(): Promise<void> {
@@ -335,16 +377,7 @@ async function flushOutbox(): Promise<void> {
 }
 
 async function flushOutboxWith(options: { forceRetry: boolean }): Promise<void> {
-  if (flushPromise) {
-    await flushPromise
-    if (!options.forceRetry) return
-  }
-
-  flushPromise = flushOutboxWithOptions(options).finally(() => {
-    flushPromise = null
-  })
-
-  return flushPromise
+  return flushQueue.run(() => flushOutboxWithOptions(options))
 }
 
 async function ensureAlarms(): Promise<void> {

--- a/apps/extension/src/lib/async-queue.test.ts
+++ b/apps/extension/src/lib/async-queue.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createAsyncTaskQueue } from './async-queue'
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('createAsyncTaskQueue', () => {
+  test('serializes a read-await-write interleaving without losing either update', async () => {
+    const queue = createAsyncTaskQueue()
+    const firstRead = deferred()
+    const releaseFirstWrite = deferred()
+    let persisted: string[] = []
+    const reads: string[][] = []
+
+    const mutate = (value: string, pause = false) =>
+      queue.run(async () => {
+        const snapshot = [...persisted]
+        reads.push([...snapshot])
+        if (pause) {
+          firstRead.resolve()
+          await releaseFirstWrite.promise
+        }
+        snapshot.push(value)
+        persisted = snapshot
+      })
+
+    const first = mutate('first', true)
+    await firstRead.promise
+    const second = mutate('second')
+    await Promise.resolve()
+
+    expect(reads).toEqual([[]])
+    releaseFirstWrite.resolve()
+    await Promise.all([first, second])
+
+    expect(reads).toEqual([[], ['first']])
+    expect(persisted).toEqual(['first', 'second'])
+  })
+
+  test('continues after a rejected task', async () => {
+    const queue = createAsyncTaskQueue()
+    const failed = queue.run(async () => {
+      throw new Error('storage write failed')
+    })
+    const recovered = queue.run(async () => 'next task completed')
+
+    await expect(failed).rejects.toThrow('storage write failed')
+    await expect(recovered).resolves.toBe('next task completed')
+  })
+})

--- a/apps/extension/src/lib/async-queue.ts
+++ b/apps/extension/src/lib/async-queue.ts
@@ -1,0 +1,18 @@
+export interface AsyncTaskQueue {
+  run<T>(task: () => Promise<T>): Promise<T>
+}
+
+export function createAsyncTaskQueue(): AsyncTaskQueue {
+  let tail: Promise<void> = Promise.resolve()
+
+  return {
+    run<T>(task: () => Promise<T>): Promise<T> {
+      const result = tail.then(task)
+      tail = result.then(
+        () => undefined,
+        () => undefined,
+      )
+      return result
+    },
+  }
+}

--- a/apps/extension/src/lib/outbox-runtime.test.ts
+++ b/apps/extension/src/lib/outbox-runtime.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test'
+
+import { OutboxRuntime, type OutboxSnapshot, type OutboxStorage } from './outbox-runtime'
+import type { ConversationPayload, OutboxItem } from './types'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function memoryStorage(initial?: Partial<OutboxSnapshot>): OutboxStorage & {
+  current(): OutboxSnapshot
+  readonly loads: number
+} {
+  let snapshot: OutboxSnapshot = {
+    stats: { totalItems: 0, todayExtracted: 0 },
+    outbox: [],
+    syncState: {},
+    ...initial,
+  }
+  let loads = 0
+  return {
+    async load() {
+      loads += 1
+      return structuredClone(snapshot)
+    },
+    async save(next) {
+      snapshot = structuredClone(next)
+    },
+    current() {
+      return structuredClone(snapshot)
+    },
+    get loads() {
+      return loads
+    },
+  }
+}
+
+function payload(content: string): ConversationPayload {
+  return {
+    content,
+    url: `https://example.test/${content}`,
+    source: 'chatgpt',
+    capturedAt: 1,
+  }
+}
+
+function runtime(
+  storage: OutboxStorage,
+  upload: (item: OutboxItem) => Promise<{ success: boolean; conversationId?: string }>,
+  counters?: { uploadCalls: number },
+) {
+  let sequence = 0
+  return new OutboxRuntime({
+    storage,
+    async upload(item) {
+      if (counters) counters.uploadCalls += 1
+      return upload(item)
+    },
+    now: () => 10_000,
+    randomUUID: () => `uuid-${++sequence}`,
+    retryBaseDelayMs: 1,
+    retryMaxDelayMs: 10,
+    syncingRecoveryStaleMs: 60_000,
+  })
+}
+
+describe('OutboxRuntime', () => {
+  test('preserves an enqueue while an older upload is paused and counts success once', async () => {
+    const storage = memoryStorage()
+    const uploadStarted = deferred<void>()
+    const releaseUpload = deferred<void>()
+    const service = runtime(storage, async () => {
+      uploadStarted.resolve()
+      await releaseUpload.promise
+      return { success: true, conversationId: 'remote-1' }
+    })
+
+    const first = await service.enqueue(payload('first'))
+    const flushing = service.requestFlush(false)
+    await uploadStarted.promise
+    const second = await service.enqueue(payload('second'))
+
+    let snapshot = storage.current()
+    expect(snapshot.outbox.map((item) => item.id)).toEqual([first.id, second.id])
+    expect(snapshot.outbox[0]?.status).toBe('syncing')
+    expect(snapshot.outbox[1]?.status).toBe('pending')
+
+    releaseUpload.resolve()
+    await flushing
+    snapshot = storage.current()
+    expect(snapshot.outbox.map((item) => item.id)).toEqual([first.id, second.id])
+    expect(snapshot.outbox.map((item) => item.status)).toEqual(['sent', 'pending'])
+    expect(snapshot.stats).toEqual({ totalItems: 1, todayExtracted: 2 })
+  })
+
+  test('stale lease result cannot change status or double-count success', async () => {
+    const storage = memoryStorage()
+    const oldUploadStarted = deferred<void>()
+    const releaseOldUpload = deferred<void>()
+    const oldWorker = runtime(storage, async () => {
+      oldUploadStarted.resolve()
+      await releaseOldUpload.promise
+      return { success: true, conversationId: 'remote-old' }
+    })
+    await oldWorker.enqueue(payload('first'))
+    const oldFlush = oldWorker.requestFlush(false)
+    await oldUploadStarted.promise
+
+    const persisted = storage.current()
+    persisted.outbox[0]!.updatedAt = -60_001
+    await storage.save(persisted)
+    const newWorker = runtime(storage, async () => ({ success: true, conversationId: 'remote-new' }))
+    await newWorker.initialize()
+    await newWorker.requestFlush(false)
+
+    releaseOldUpload.resolve()
+    await oldFlush
+    const snapshot = storage.current()
+    expect(snapshot.outbox[0]?.remoteConversationId).toBe('remote-new')
+    expect(snapshot.stats.totalItems).toBe(1)
+  })
+
+  test('coalesces many normal flush requests into one trailing pass', async () => {
+    const storage = memoryStorage()
+    const firstUploadStarted = deferred<void>()
+    const releaseFirstUpload = deferred<void>()
+    const counters = { uploadCalls: 0 }
+    const service = runtime(
+      storage,
+      async (item) => {
+        if (item.payload.content === 'first') {
+          firstUploadStarted.resolve()
+          await releaseFirstUpload.promise
+        }
+        return { success: true }
+      },
+      counters,
+    )
+
+    await service.enqueue(payload('first'))
+    const firstFlush = service.requestFlush(false)
+    await firstUploadStarted.promise
+    await service.enqueue(payload('second'))
+    const requests = Array.from({ length: 20 }, () => service.requestFlush(false))
+    releaseFirstUpload.resolve()
+    await Promise.all([firstFlush, ...requests])
+
+    expect(counters.uploadCalls).toBe(2)
+    expect(storage.loads).toBe(8)
+    expect(storage.current().outbox.map((item) => item.status)).toEqual(['sent', 'sent'])
+  })
+
+  test('keeps force flush ordered behind an active normal flush without duplicate upload', async () => {
+    const storage = memoryStorage()
+    const uploadStarted = deferred<void>()
+    const releaseUpload = deferred<void>()
+    const counters = { uploadCalls: 0 }
+    const service = runtime(
+      storage,
+      async () => {
+        uploadStarted.resolve()
+        await releaseUpload.promise
+        return { success: true }
+      },
+      counters,
+    )
+
+    await service.enqueue(payload('first'))
+    const normal = service.requestFlush(false)
+    await uploadStarted.promise
+    const forced = service.requestFlush(true)
+    releaseUpload.resolve()
+    await Promise.all([normal, forced])
+
+    expect(counters.uploadCalls).toBe(1)
+    expect(storage.current().outbox[0]?.status).toBe('sent')
+  })
+})

--- a/apps/extension/src/lib/outbox-runtime.ts
+++ b/apps/extension/src/lib/outbox-runtime.ts
@@ -1,0 +1,215 @@
+import type { CloudUploadResult } from './cloud-contract'
+import { createAsyncTaskQueue } from './async-queue'
+import { findLeasedItem } from './outbox-state'
+import type {
+  ConversationPayload,
+  ExtensionStats,
+  OutboxItem,
+  SyncState,
+} from './types'
+
+export interface OutboxSnapshot {
+  stats: ExtensionStats
+  outbox: OutboxItem[]
+  syncState: SyncState
+}
+
+export interface OutboxStorage {
+  load(): Promise<OutboxSnapshot>
+  save(snapshot: OutboxSnapshot): Promise<void>
+}
+
+export interface OutboxRuntimeOptions {
+  storage: OutboxStorage
+  upload(item: OutboxItem): Promise<CloudUploadResult>
+  onSynced?(item: OutboxItem, result: CloudUploadResult): void
+  now?: () => number
+  randomUUID?: () => string
+  retryBaseDelayMs: number
+  retryMaxDelayMs: number
+  syncingRecoveryStaleMs: number
+  sentTtlMs?: number
+}
+
+export class OutboxRuntime {
+  private readonly mutationQueue = createAsyncTaskQueue()
+  private readonly flushQueue = createAsyncTaskQueue()
+  private normalFlushDirty = false
+  private normalFlushPromise: Promise<void> | null = null
+
+  constructor(private readonly options: OutboxRuntimeOptions) {}
+
+  readSnapshot(): Promise<OutboxSnapshot> {
+    return this.options.storage.load()
+  }
+
+  initialize(): Promise<void> {
+    return this.mutationQueue.run(async () => {
+      const snapshot = await this.options.storage.load()
+      this.recoverStuckItems(snapshot.outbox)
+      snapshot.outbox = this.prune(snapshot.outbox)
+      await this.options.storage.save(snapshot)
+    })
+  }
+
+  resetDailyStats(): Promise<void> {
+    return this.mutationQueue.run(async () => {
+      const snapshot = await this.options.storage.load()
+      snapshot.stats.todayExtracted = 0
+      await this.options.storage.save(snapshot)
+    })
+  }
+
+  enqueue(payload: ConversationPayload): Promise<OutboxItem> {
+    const now = this.now()
+    const item: OutboxItem = {
+      id: this.uuid(),
+      idempotencyKey: this.uuid(),
+      payload,
+      status: 'pending',
+      attemptCount: 0,
+      nextAttemptAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    return this.mutationQueue.run(async () => {
+      const snapshot = await this.options.storage.load()
+      snapshot.outbox.push(item)
+      snapshot.stats.todayExtracted += 1
+      await this.options.storage.save(snapshot)
+      return item
+    })
+  }
+
+  requestFlush(forceRetry: boolean): Promise<void> {
+    if (forceRetry) {
+      return this.flushQueue.run(() => this.flushPass(true))
+    }
+
+    this.normalFlushDirty = true
+    if (this.normalFlushPromise) return this.normalFlushPromise
+
+    const run = this.flushQueue.run(async () => {
+      while (this.normalFlushDirty) {
+        this.normalFlushDirty = false
+        await this.flushPass(false)
+      }
+    })
+    this.normalFlushPromise = run.finally(() => {
+      this.normalFlushPromise = null
+      if (this.normalFlushDirty) void this.requestFlush(false)
+    })
+    return this.normalFlushPromise
+  }
+
+  private async flushPass(forceRetry: boolean): Promise<void> {
+    const candidateIds = await this.listCandidateIds(forceRetry)
+    for (const candidateId of candidateIds) {
+      const item = await this.claim(candidateId, forceRetry)
+      if (!item) continue
+
+      const result = await this.options.upload(item)
+      const committed = await this.finish(item, result)
+      if (committed && result.success) this.options.onSynced?.(item, result)
+    }
+  }
+
+  private listCandidateIds(forceRetry: boolean): Promise<string[]> {
+    return this.mutationQueue.run(async () => {
+      const snapshot = await this.options.storage.load()
+      const recovered = this.recoverStuckItems(snapshot.outbox)
+      if (recovered) await this.options.storage.save(snapshot)
+      const now = this.now()
+      return snapshot.outbox
+        .filter((item) => {
+          if (item.status !== 'pending' && item.status !== 'failed') return false
+          return forceRetry || item.nextAttemptAt <= now
+        })
+        .map((item) => item.id)
+    })
+  }
+
+  private claim(itemId: string, forceRetry: boolean): Promise<OutboxItem | null> {
+    return this.mutationQueue.run(async () => {
+      const snapshot = await this.options.storage.load()
+      const now = this.now()
+      const item = snapshot.outbox.find((candidate) => candidate.id === itemId)
+      if (!item || (item.status !== 'pending' && item.status !== 'failed')) return null
+      if (!forceRetry && item.nextAttemptAt > now) return null
+
+      item.status = 'syncing'
+      item.syncLeaseId = this.uuid()
+      item.updatedAt = now
+      await this.options.storage.save(snapshot)
+      return structuredClone(item)
+    })
+  }
+
+  private finish(claimedItem: OutboxItem, result: CloudUploadResult): Promise<boolean> {
+    return this.mutationQueue.run(async () => {
+      const snapshot = await this.options.storage.load()
+      const item = findLeasedItem(snapshot.outbox, claimedItem)
+      if (!item) return false
+
+      item.syncLeaseId = undefined
+      item.updatedAt = this.now()
+      if (result.success) {
+        item.status = 'sent'
+        item.lastError = undefined
+        item.remoteConversationId = result.conversationId
+        snapshot.stats.totalItems += 1
+        snapshot.syncState.lastSyncedAt = item.updatedAt
+        snapshot.syncState.lastError = undefined
+      } else {
+        item.status = 'failed'
+        item.attemptCount += 1
+        item.lastError = result.message || 'Unknown cloud sync error'
+        item.nextAttemptAt = item.updatedAt + this.backoffDelayMs(item.attemptCount)
+        snapshot.syncState.lastError = item.lastError
+      }
+
+      snapshot.outbox = this.prune(snapshot.outbox)
+      await this.options.storage.save(snapshot)
+      return true
+    })
+  }
+
+  private recoverStuckItems(outbox: OutboxItem[]): boolean {
+    const now = this.now()
+    let changed = false
+    for (const item of outbox) {
+      if (item.status !== 'syncing') continue
+      if (now - item.updatedAt < this.options.syncingRecoveryStaleMs) continue
+      item.status = 'failed'
+      item.syncLeaseId = undefined
+      item.lastError = item.lastError || 'Sync interrupted, retry scheduled'
+      item.nextAttemptAt = now
+      item.updatedAt = now
+      changed = true
+    }
+    return changed
+  }
+
+  private prune(outbox: OutboxItem[]): OutboxItem[] {
+    const ttl = this.options.sentTtlMs ?? 24 * 60 * 60 * 1_000
+    const now = this.now()
+    return outbox.filter((item) => item.status !== 'sent' || now - item.updatedAt <= ttl)
+  }
+
+  private backoffDelayMs(attemptCount: number): number {
+    const multiplier = Math.max(0, attemptCount - 1)
+    return Math.min(
+      this.options.retryBaseDelayMs * 2 ** multiplier,
+      this.options.retryMaxDelayMs,
+    )
+  }
+
+  private now(): number {
+    return (this.options.now ?? Date.now)()
+  }
+
+  private uuid(): string {
+    return (this.options.randomUUID ?? (() => crypto.randomUUID()))()
+  }
+}

--- a/apps/extension/src/lib/outbox-state.test.ts
+++ b/apps/extension/src/lib/outbox-state.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+
+import { findLeasedItem, type LeasedOutboxItem } from './outbox-state'
+
+function item(overrides: Partial<LeasedOutboxItem> = {}): LeasedOutboxItem {
+  return {
+    id: 'item-1',
+    idempotencyKey: 'key-1',
+    status: 'syncing',
+    syncLeaseId: 'lease-new',
+    ...overrides,
+  }
+}
+
+describe('findLeasedItem', () => {
+  test('allows only the current upload lease to commit', () => {
+    const persisted = item()
+    expect(findLeasedItem([persisted], item())).toBe(persisted)
+    expect(findLeasedItem([persisted], item({ syncLeaseId: 'lease-old' }))).toBeUndefined()
+  })
+
+  test('rejects replaced identities and terminal items', () => {
+    const claim = item()
+    expect(findLeasedItem([item({ idempotencyKey: 'key-replaced' })], claim)).toBeUndefined()
+    expect(findLeasedItem([item({ status: 'sent' })], claim)).toBeUndefined()
+  })
+})

--- a/apps/extension/src/lib/outbox-state.ts
+++ b/apps/extension/src/lib/outbox-state.ts
@@ -1,0 +1,19 @@
+export interface LeasedOutboxItem {
+  id: string
+  idempotencyKey: string
+  status: 'pending' | 'syncing' | 'failed' | 'sent'
+  syncLeaseId?: string
+}
+
+export function findLeasedItem<T extends LeasedOutboxItem>(
+  outbox: T[],
+  claimedItem: LeasedOutboxItem,
+): T | undefined {
+  return outbox.find(
+    (candidate) =>
+      candidate.id === claimedItem.id &&
+      candidate.idempotencyKey === claimedItem.idempotencyKey &&
+      candidate.status === 'syncing' &&
+      candidate.syncLeaseId === claimedItem.syncLeaseId,
+  )
+}

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -17,6 +17,7 @@ export interface OutboxItem {
   nextAttemptAt: number
   lastError?: string
   remoteConversationId?: string
+  syncLeaseId?: string
   createdAt: number
   updatedAt: number
 }


### PR DESCRIPTION
Closes #172

## Summary
- serialize every background storage read-modify-write through a failure-resilient async queue
- keep network upload outside the storage critical section so enqueue remains responsive
- protect upload completion with a persisted per-attempt lease, preventing stale service-worker results from overwriting newer state
- bound each flush to its starting candidate set while preserving idempotency keys and legacy outbox compatibility
- add deterministic Bun tests for the former lost-update interleaving, queue recovery after failure, and stale lease rejection
- run extension tests in CI before typecheck/build

## Verification
- `bun install --frozen-lockfile`
- `bun run test` (4 passed)
- `bun run typecheck`
- `bun run build`
- `git diff --check`