### PR TITLE
fix(server): recover extraction jobs after restart

### DIFF
--- a/apps/server/src/application/conversation.rs
+++ b/apps/server/src/application/conversation.rs
@@ -105,49 +105,56 @@ pub async fn create_conversation(
         last_error: None,
     };
 
-    // Atomically insert or, on idempotency-key conflict, fetch the existing row.
-    // Comparing returned id against the generated id reveals deduplication.
-    let persisted = state
-        .conversation_repo
-        .insert_or_fetch_conversation_by_idempotency(&conversation)
-        .await
-        .map_err(|err| CreateConversationError::Internal(err.to_string()))?;
-
-    if persisted.id != conversation_id {
+    if ingest_only {
+        let persisted = state
+            .conversation_repo
+            .insert_or_fetch_conversation_by_idempotency(&conversation)
+            .await
+            .map_err(|err| CreateConversationError::Internal(err.to_string()))?;
+        let deduplicated = persisted.id != conversation_id;
         return Ok(CreateConversationResult {
             conversation_id: persisted.id,
             status: persisted.status,
-            deduplicated: true,
+            deduplicated,
             job_id: None,
         });
     }
 
-    let mut job_id = None;
-    if !ingest_only {
-        let id = Uuid::new_v4().to_string();
-        let job = ExtractionJobRecord {
-            id: id.clone(),
-            conversation_id: conversation_id.clone(),
-            mode: mode.clone(),
-            status: JobStatus::Pending,
-            created_at: now.clone(),
-            updated_at: now,
-            error: None,
-        };
-        state
-            .job_repo
-            .upsert_job(&job)
-            .await
-            .map_err(|err| CreateConversationError::Internal(err.to_string()))?;
-        spawn_extraction(state, conversation_id.clone(), id.clone(), mode);
-        job_id = Some(id);
+    let job = ExtractionJobRecord {
+        id: Uuid::new_v4().to_string(),
+        conversation_id: conversation_id.clone(),
+        mode: mode.clone(),
+        status: JobStatus::Pending,
+        created_at: now.clone(),
+        updated_at: now,
+        error: None,
+        attempt_count: 0,
+        lease_owner: None,
+        lease_expires_at: None,
+    };
+    let (persisted, persisted_job) = state
+        .conversation_repo
+        .insert_or_fetch_conversation_with_job(&conversation, &job)
+        .await
+        .map_err(|err| CreateConversationError::Internal(err.to_string()))?;
+    let deduplicated = persisted.id != conversation_id;
+    if let Some(persisted_job) = persisted_job
+        .as_ref()
+        .filter(|job| job.status == JobStatus::Pending)
+    {
+        spawn_extraction(
+            state,
+            persisted.id.clone(),
+            persisted_job.id.clone(),
+            persisted_job.mode.clone(),
+        );
     }
 
     Ok(CreateConversationResult {
-        conversation_id,
-        status: conversation_status,
-        deduplicated: false,
-        job_id,
+        conversation_id: persisted.id,
+        status: persisted.status,
+        deduplicated,
+        job_id: persisted_job.map(|job| job.id),
     })
 }
 
@@ -191,20 +198,12 @@ pub async fn create_extraction_job(
             CreateExtractionJobError::BadRequest("conversation_id is required".to_string())
         })?;
 
-    let mut queued_conversation = state
+    let conversation = state
         .conversation_repo
         .find_conversation_by_id(&conversation_id)
         .await
         .map_err(|err| CreateExtractionJobError::Internal(err.to_string()))?
         .ok_or_else(|| CreateExtractionJobError::NotFound("Conversation not found".to_string()))?;
-    queued_conversation.status = ConversationStatus::Queued;
-    queued_conversation.last_error = None;
-    state
-        .conversation_repo
-        .upsert_conversation(&queued_conversation)
-        .await
-        .map_err(|err| CreateExtractionJobError::Internal(err.to_string()))?;
-
     let mode = ExtractionMode::from_option(payload.mode);
     let now = now_iso();
     let job_id = Uuid::new_v4().to_string();
@@ -216,19 +215,24 @@ pub async fn create_extraction_job(
         created_at: now.clone(),
         updated_at: now,
         error: None,
+        attempt_count: 0,
+        lease_owner: None,
+        lease_expires_at: None,
     };
 
-    state
+    let job = state
         .job_repo
-        .upsert_job(&job)
+        .enqueue_job(&job)
         .await
         .map_err(|err| CreateExtractionJobError::Internal(err.to_string()))?;
 
-    spawn_extraction(state, conversation_id, job_id.clone(), mode);
+    if job.status == JobStatus::Pending {
+        spawn_extraction(state, conversation.id, job.id.clone(), job.mode.clone());
+    }
 
     Ok(CreateExtractionJobResult {
-        job_id,
-        status: JobStatus::Pending,
+        job_id: job.id,
+        status: job.status,
     })
 }
 

--- a/apps/server/src/extraction.rs
+++ b/apps/server/src/extraction.rs
@@ -5,11 +5,13 @@ use refine_core::refinement::{
     extract_items_with_strict_defaults, ExtractionPolicy, ItemExtractionInput,
 };
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use tokio::sync::oneshot;
+use tokio::time::{interval, Duration};
+use uuid::Uuid;
 
-use crate::models::{
-    now_iso, ConversationRecord, ConversationStatus, ExtractionJobRecord, ExtractionMode, JobStatus,
-};
+use crate::models::{now_iso, ExtractionMode, JobStatus};
 use crate::state::AppState;
 
 pub fn spawn_extraction(
@@ -19,16 +21,53 @@ pub fn spawn_extraction(
     mode: ExtractionMode,
 ) {
     tokio::spawn(async move {
-        if let Err(err) = run_extraction(state.clone(), &conversation_id, &job_id, mode).await {
-            if let Err(persist_err) = set_conversation_failed(&state, &conversation_id, &err).await
-            {
-                tracing::warn!("persist failed conversation failed: {}", persist_err);
-            }
-            if let Err(persist_err) = set_job_failed(&state, &job_id, &err).await {
-                tracing::warn!("persist failed job failed: {}", persist_err);
+        if let Err(err) = run_extraction(state, &conversation_id, &job_id, mode).await {
+            tracing::warn!(job_id, conversation_id, error = %err, "extraction attempt ended");
+        }
+    });
+}
+
+pub async fn recover_extraction_jobs(state: Arc<AppState>) -> Result<usize, String> {
+    let jobs = state
+        .job_repo
+        .list_recoverable_jobs(&now_iso(), 10_000)
+        .await
+        .map_err(|err| format!("failed to list recoverable extraction jobs: {err}"))?;
+    let count = jobs.len();
+    for job in jobs {
+        spawn_extraction(state.clone(), job.conversation_id, job.id, job.mode);
+    }
+    Ok(count)
+}
+
+const LEASE_DURATION_SECS: i64 = 120;
+const HEARTBEAT_INTERVAL_SECS: u64 = 30;
+const RECOVERY_INTERVAL_SECS: u64 = 30;
+
+pub fn spawn_extraction_recovery(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        let mut ticker = interval(Duration::from_secs(RECOVERY_INTERVAL_SECS));
+        // The caller performs the startup sweep after binding the listener.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            match recover_extraction_jobs(state.clone()).await {
+                Ok(0) => {}
+                Ok(count) => tracing::info!(count, "scheduled recoverable extraction jobs"),
+                Err(err) => {
+                    tracing::warn!(error = %err, "failed to reconcile extraction jobs")
+                }
             }
         }
     });
+}
+
+fn lease_times() -> (String, String) {
+    let now = chrono::Utc::now();
+    (
+        now.to_rfc3339(),
+        (now + chrono::Duration::seconds(LEASE_DURATION_SECS)).to_rfc3339(),
+    )
 }
 
 async fn run_extraction(
@@ -37,9 +76,95 @@ async fn run_extraction(
     job_id: &str,
     mode: ExtractionMode,
 ) -> Result<(), String> {
-    set_job_running(&state, job_id).await?;
-    set_conversation_status(&state, conversation_id, ConversationStatus::Processing).await?;
+    let owner = Uuid::new_v4().to_string();
+    let (now, lease_expires_at) = lease_times();
+    let claimed = state
+        .job_repo
+        .claim_job(job_id, &owner, &now, &lease_expires_at)
+        .await
+        .map_err(|err| format!("failed to claim extraction job: {err}"))?;
+    if claimed.is_none() {
+        return Err("extraction job is already claimed or terminal".to_string());
+    }
 
+    let lease_valid = Arc::new(AtomicBool::new(true));
+    let (stop_tx, stop_rx) = oneshot::channel();
+    let heartbeat = tokio::spawn(heartbeat_job_lease(
+        state.clone(),
+        job_id.to_string(),
+        owner.clone(),
+        lease_valid.clone(),
+        stop_rx,
+    ));
+    let result = run_claimed_extraction(
+        state.clone(),
+        conversation_id,
+        job_id,
+        mode,
+        &owner,
+        lease_valid,
+    )
+    .await;
+    let _ = stop_tx.send(());
+    let _ = heartbeat.await;
+
+    if let Err(error) = &result {
+        let finished = state
+            .job_repo
+            .finish_job_claim(
+                job_id,
+                &owner,
+                JobStatus::Failed,
+                &[],
+                Some(error),
+                &now_iso(),
+            )
+            .await
+            .map_err(|err| format!("failed to finish extraction claim: {err}"))?;
+        if !finished {
+            return Err("extraction claim was lost before failure was persisted".to_string());
+        }
+    }
+    result
+}
+
+async fn heartbeat_job_lease(
+    state: Arc<AppState>,
+    job_id: String,
+    owner: String,
+    lease_valid: Arc<AtomicBool>,
+    mut stop: oneshot::Receiver<()>,
+) {
+    let mut ticker = interval(Duration::from_secs(HEARTBEAT_INTERVAL_SECS));
+    ticker.tick().await;
+    loop {
+        tokio::select! {
+            _ = &mut stop => return,
+            _ = ticker.tick() => {
+                let (now, expires_at) = lease_times();
+                match state.job_repo.renew_job_lease(&job_id, &owner, &now, &expires_at).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        lease_valid.store(false, Ordering::Release);
+                        return;
+                    }
+                    Err(err) => {
+                        tracing::warn!(job_id, error = %err, "failed to renew extraction lease");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn run_claimed_extraction(
+    state: Arc<AppState>,
+    conversation_id: &str,
+    job_id: &str,
+    mode: ExtractionMode,
+    owner: &str,
+    lease_valid: Arc<AtomicBool>,
+) -> Result<(), String> {
     let conversation = state
         .conversation_repo
         .find_conversation_by_id(conversation_id)
@@ -76,19 +201,29 @@ async fn run_extraction(
         .await
         .map_err(|e| e.to_string())?;
 
-    let item_ids = save_document_items_and_index(&state, &doc, &items).await?;
+    if !lease_valid.load(Ordering::Acquire) {
+        return Err("extraction lease was lost while awaiting the provider".to_string());
+    }
+    let (now, expires_at) = lease_times();
+    let renewed = state
+        .job_repo
+        .renew_job_lease(job_id, owner, &now, &expires_at)
+        .await
+        .map_err(|err| format!("failed to verify extraction lease: {err}"))?;
+    if !renewed {
+        return Err("extraction lease was lost before persistence".to_string());
+    }
 
-    set_conversation_processed(&state, conversation_id, item_ids).await?;
-    set_job_succeeded(&state, job_id).await?;
-
-    Ok(())
+    save_claimed_results_and_index(&state, job_id, owner, &doc, &items).await
 }
 
-async fn save_document_items_and_index(
+async fn save_claimed_results_and_index(
     state: &Arc<AppState>,
+    job_id: &str,
+    owner: &str,
     doc: &Document,
     items: &[Item],
-) -> Result<Vec<String>, String> {
+) -> Result<(), String> {
     let existing_item_ids = state
         .store
         .find_by_document_id(doc.id())
@@ -119,17 +254,31 @@ async fn save_document_items_and_index(
         indexed_ids.push(item.id().clone());
     }
 
-    if let Err(err) = state.doc_store.save_with_replaced_items(doc, items).await {
+    let finished = match state
+        .job_repo
+        .finish_job_claim_with_results(job_id, owner, doc, items, &now_iso())
+        .await
+    {
+        Ok(finished) => finished,
+        Err(err) => {
+            let cleanup_error = cleanup_indexed_items(state, &indexed_ids).await;
+            return Err(with_cleanup_error(
+                format!("failed to save claimed extraction results: {}", err),
+                cleanup_error,
+            ));
+        }
+    };
+    if !finished {
         let cleanup_error = cleanup_indexed_items(state, &indexed_ids).await;
         return Err(with_cleanup_error(
-            format!("failed to save document items transaction: {}", err),
+            "extraction claim was lost before result persistence".to_string(),
             cleanup_error,
         ));
     }
 
     remove_obsolete_indexes(state, &existing_item_ids, &new_item_ids).await;
 
-    Ok(new_item_ids.iter().map(ToString::to_string).collect())
+    Ok(())
 }
 
 async fn canonicalize_document(
@@ -220,153 +369,9 @@ fn mode_to_policy(mode: ExtractionMode) -> ExtractionPolicy {
     }
 }
 
-async fn set_job_running(state: &Arc<AppState>, job_id: &str) -> Result<(), String> {
-    update_job(
-        state,
-        job_id,
-        |job| {
-            job.status = JobStatus::Running;
-            job.updated_at = now_iso();
-            job.error = None;
-        },
-        "running",
-    )
-    .await
-}
-
-async fn set_job_succeeded(state: &Arc<AppState>, job_id: &str) -> Result<(), String> {
-    update_job(
-        state,
-        job_id,
-        |job| {
-            job.status = JobStatus::Succeeded;
-            job.updated_at = now_iso();
-            job.error = None;
-        },
-        "succeeded",
-    )
-    .await
-}
-
-async fn set_job_failed(state: &Arc<AppState>, job_id: &str, error: &str) -> Result<(), String> {
-    update_job(
-        state,
-        job_id,
-        |job| {
-            job.status = JobStatus::Failed;
-            job.updated_at = now_iso();
-            job.error = Some(error.to_string());
-        },
-        "failed",
-    )
-    .await
-}
-
-async fn set_conversation_status(
-    state: &Arc<AppState>,
-    conversation_id: &str,
-    status: ConversationStatus,
-) -> Result<(), String> {
-    update_conversation(
-        state,
-        conversation_id,
-        move |conversation| {
-            conversation.status = status;
-        },
-        "status",
-    )
-    .await
-}
-
-async fn set_conversation_processed(
-    state: &Arc<AppState>,
-    conversation_id: &str,
-    item_ids: Vec<String>,
-) -> Result<(), String> {
-    update_conversation(
-        state,
-        conversation_id,
-        move |conversation| {
-            conversation.status = ConversationStatus::Processed;
-            conversation.item_ids = item_ids;
-            conversation.last_error = None;
-        },
-        "processed",
-    )
-    .await
-}
-
-async fn set_conversation_failed(
-    state: &Arc<AppState>,
-    conversation_id: &str,
-    error: &str,
-) -> Result<(), String> {
-    update_conversation(
-        state,
-        conversation_id,
-        |conversation| {
-            conversation.status = ConversationStatus::Failed;
-            conversation.last_error = Some(error.to_string());
-        },
-        "failed",
-    )
-    .await
-}
-
-async fn update_job<F>(
-    state: &Arc<AppState>,
-    job_id: &str,
-    mutate: F,
-    phase: &str,
-) -> Result<(), String>
-where
-    F: FnOnce(&mut ExtractionJobRecord),
-{
-    let mut job = state
-        .job_repo
-        .find_job_by_id(job_id)
-        .await
-        .map_err(|err| format!("persist {} job skipped: load error {}", phase, err))?
-        .ok_or_else(|| format!("persist {} job skipped: not found {}", phase, job_id))?;
-    mutate(&mut job);
-    state
-        .job_repo
-        .upsert_job(&job)
-        .await
-        .map_err(|err| format!("persist {} job failed: {}", phase, err))
-}
-
-async fn update_conversation<F>(
-    state: &Arc<AppState>,
-    conversation_id: &str,
-    mutate: F,
-    phase: &str,
-) -> Result<(), String>
-where
-    F: FnOnce(&mut ConversationRecord),
-{
-    let mut conversation = state
-        .conversation_repo
-        .find_conversation_by_id(conversation_id)
-        .await
-        .map_err(|err| format!("persist {} conversation skipped: load error {}", phase, err))?
-        .ok_or_else(|| {
-            format!(
-                "persist {} conversation skipped: not found {}",
-                phase, conversation_id
-            )
-        })?;
-    mutate(&mut conversation);
-    state
-        .conversation_repo
-        .upsert_conversation(&conversation)
-        .await
-        .map_err(|err| format!("persist {} conversation failed: {}", phase, err))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{run_extraction, spawn_extraction};
+    use super::{recover_extraction_jobs, run_extraction, spawn_extraction};
     use crate::models::{
         now_iso, ConversationRecord, ConversationStatus, ExtractionJobRecord, ExtractionMode,
         JobStatus,
@@ -540,7 +545,7 @@ mod tests {
         .await
         .expect_err("succeeded job must not restart extraction");
         assert!(
-            err.contains("invalid job status transition"),
+            err.contains("already claimed or terminal"),
             "unexpected error: {}",
             err
         );
@@ -551,6 +556,20 @@ mod tests {
             "aborted extraction saved items: {:?}",
             saved_items
         );
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_schedules_pending_jobs() {
+        let (_tmp, state, persistence, _conversation_id, job_id) = build_state_with_failing_index()
+            .await
+            .expect("build test state");
+
+        let scheduled = recover_extraction_jobs(state)
+            .await
+            .expect("schedule recovery");
+        assert_eq!(scheduled, 1);
+        let job = wait_for_failed_job(&persistence, &job_id).await;
+        assert_eq!(job.attempt_count, 1);
     }
 
     async fn build_state_with_failing_index(
@@ -597,6 +616,9 @@ mod tests {
                 created_at: now.clone(),
                 updated_at: now,
                 error: None,
+                attempt_count: 0,
+                lease_owner: None,
+                lease_expires_at: None,
             })
             .await
             .map_err(|e| e.to_string())?;

--- a/apps/server/src/extraction.rs
+++ b/apps/server/src/extraction.rs
@@ -6,8 +6,8 @@ use refine_core::refinement::{
 };
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use tokio::sync::oneshot;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::{oneshot, Semaphore};
 use tokio::time::{interval, Duration};
 use uuid::Uuid;
 
@@ -20,7 +20,16 @@ pub fn spawn_extraction(
     job_id: String,
     mode: ExtractionMode,
 ) {
+    let permit = match extraction_semaphore().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            // The durable pending job will be picked up by the reconciliation
+            // loop when capacity becomes available.
+            return;
+        }
+    };
     tokio::spawn(async move {
+        let _permit = permit;
         if let Err(err) = run_extraction(state, &conversation_id, &job_id, mode).await {
             tracing::warn!(job_id, conversation_id, error = %err, "extraction attempt ended");
         }
@@ -28,9 +37,21 @@ pub fn spawn_extraction(
 }
 
 pub async fn recover_extraction_jobs(state: Arc<AppState>) -> Result<usize, String> {
+    let now = now_iso();
+    let reconciled = state
+        .job_repo
+        .reconcile_processed_jobs(&now)
+        .await
+        .map_err(|err| format!("failed to reconcile processed extraction jobs: {err}"))?;
+    if reconciled > 0 {
+        tracing::info!(reconciled, "reconciled already processed extraction jobs");
+    }
+    if state.llm_client.is_none() {
+        return Ok(0);
+    }
     let jobs = state
         .job_repo
-        .list_recoverable_jobs(&now_iso(), 10_000)
+        .list_recoverable_jobs(&now, MAX_CONCURRENT_EXTRACTIONS)
         .await
         .map_err(|err| format!("failed to list recoverable extraction jobs: {err}"))?;
     let count = jobs.len();
@@ -43,6 +64,14 @@ pub async fn recover_extraction_jobs(state: Arc<AppState>) -> Result<usize, Stri
 const LEASE_DURATION_SECS: i64 = 120;
 const HEARTBEAT_INTERVAL_SECS: u64 = 30;
 const RECOVERY_INTERVAL_SECS: u64 = 30;
+const MAX_CONCURRENT_EXTRACTIONS: usize = 4;
+
+fn extraction_semaphore() -> Arc<Semaphore> {
+    static SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    SEMAPHORE
+        .get_or_init(|| Arc::new(Semaphore::new(MAX_CONCURRENT_EXTRACTIONS)))
+        .clone()
+}
 
 pub fn spawn_extraction_recovery(state: Arc<AppState>) {
     tokio::spawn(async move {
@@ -386,6 +415,7 @@ mod tests {
     use serde_json::json;
     use std::sync::Arc;
     use tempfile::TempDir;
+    use tokio::sync::Semaphore;
     use tokio::time::{sleep, Duration, Instant};
     use uuid::Uuid;
 
@@ -570,6 +600,53 @@ mod tests {
         assert_eq!(scheduled, 1);
         let job = wait_for_failed_job(&persistence, &job_id).await;
         assert_eq!(job.attempt_count, 1);
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_without_llm_keeps_job_pending() {
+        let (_tmp, state, persistence, _conversation_id, job_id) = build_state_with_failing_index()
+            .await
+            .expect("build test state");
+        let state = Arc::new(AppState {
+            llm_client: None,
+            store: state.store.clone(),
+            doc_store: state.doc_store.clone(),
+            engine: state.engine.clone(),
+            semantic_search_enabled: state.semantic_search_enabled,
+            free_quota_items: state.free_quota_items,
+            premium_users: state.premium_users.clone(),
+            api_token: state.api_token.clone(),
+            dev_anon: state.dev_anon,
+            conversation_repo: state.conversation_repo.clone(),
+            job_repo: state.job_repo.clone(),
+            event_repo: state.event_repo.clone(),
+        });
+
+        assert_eq!(recover_extraction_jobs(state).await.expect("recovery"), 0);
+        let job = persistence
+            .find_job_by_id(&job_id)
+            .await
+            .expect("load job")
+            .expect("job exists");
+        assert_eq!(job.status, JobStatus::Pending);
+        assert_eq!(job.attempt_count, 0);
+    }
+
+    #[tokio::test]
+    async fn extraction_scheduler_enforces_provider_concurrency_limit() {
+        let semaphore = Semaphore::new(super::MAX_CONCURRENT_EXTRACTIONS);
+        let mut permits = Vec::new();
+        for _ in 0..super::MAX_CONCURRENT_EXTRACTIONS {
+            permits.push(
+                semaphore
+                    .try_acquire()
+                    .expect("configured extraction slot should be available"),
+            );
+        }
+        assert!(
+            semaphore.try_acquire().is_err(),
+            "scheduler admitted more than the configured extraction concurrency"
+        );
     }
 
     async fn build_state_with_failing_index(

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -76,6 +76,12 @@ async fn main() {
             std::process::exit(1);
         }
     };
+    match extraction::recover_extraction_jobs(state.clone()).await {
+        Ok(0) => {}
+        Ok(count) => tracing::info!(count, "scheduled recoverable extraction jobs"),
+        Err(err) => tracing::warn!(error = %err, "failed to recover extraction jobs"),
+    }
+    extraction::spawn_extraction_recovery(state.clone());
     axum::serve(listener, app).await.expect("server exited");
 }
 

--- a/apps/server/src/models.rs
+++ b/apps/server/src/models.rs
@@ -183,11 +183,15 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".to_string(),
             updated_at: "2026-01-01T00:00:01Z".to_string(),
             error: None,
+            attempt_count: 0,
+            lease_owner: None,
+            lease_expires_at: None,
         };
         let get_value = serde_json::to_value(GetExtractionJobResponse { job: job_record })
             .expect("serialize get response");
         assert_eq!(get_value["job"]["id"], "j1");
         assert_eq!(get_value["job"]["status"], "running");
+        assert!(get_value["job"].get("lease_owner").is_none());
     }
 
     #[test]

--- a/packages/core/src/conversation/record.rs
+++ b/packages/core/src/conversation/record.rs
@@ -95,6 +95,10 @@ pub struct ExtractionJobRecord {
     pub created_at: String,
     pub updated_at: String,
     pub error: Option<String>,
+    pub attempt_count: u32,
+    #[serde(skip_serializing)]
+    pub lease_owner: Option<String>,
+    pub lease_expires_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/packages/core/src/conversation/repository.rs
+++ b/packages/core/src/conversation/repository.rs
@@ -41,6 +41,9 @@ pub trait JobRepository: Send + Sync {
     /// Atomically queues the parent conversation and inserts `job`. If the
     /// conversation already has a pending or running job, returns that job.
     async fn enqueue_job(&self, job: &ExtractionJobRecord) -> InfraResult<ExtractionJobRecord>;
+    /// Converges legacy crash states where the conversation was already
+    /// committed as processed before its active job reached succeeded.
+    async fn reconcile_processed_jobs(&self, now: &str) -> InfraResult<usize>;
     async fn list_recoverable_jobs(
         &self,
         now: &str,

--- a/packages/core/src/conversation/repository.rs
+++ b/packages/core/src/conversation/repository.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use crate::error::InfraResult;
+use crate::knowledge::{Document, Item};
 
 use super::record::{ConversationRecord, EventRecord, ExtractionJobRecord};
 
@@ -22,12 +23,62 @@ pub trait ConversationRepository: Send + Sync {
         &self,
         record: &ConversationRecord,
     ) -> InfraResult<ConversationRecord>;
+    /// Atomically inserts a conversation and its initial extraction job. On an
+    /// idempotency conflict, returns the existing conversation and its newest
+    /// recoverable job, creating the supplied job for that conversation when
+    /// an earlier partial write left it without one.
+    async fn insert_or_fetch_conversation_with_job(
+        &self,
+        record: &ConversationRecord,
+        job: &ExtractionJobRecord,
+    ) -> InfraResult<(ConversationRecord, Option<ExtractionJobRecord>)>;
 }
 
 #[async_trait]
 pub trait JobRepository: Send + Sync {
     async fn find_job_by_id(&self, id: &str) -> InfraResult<Option<ExtractionJobRecord>>;
     async fn upsert_job(&self, job: &ExtractionJobRecord) -> InfraResult<()>;
+    /// Atomically queues the parent conversation and inserts `job`. If the
+    /// conversation already has a pending or running job, returns that job.
+    async fn enqueue_job(&self, job: &ExtractionJobRecord) -> InfraResult<ExtractionJobRecord>;
+    async fn list_recoverable_jobs(
+        &self,
+        now: &str,
+        limit: usize,
+    ) -> InfraResult<Vec<ExtractionJobRecord>>;
+    async fn claim_job(
+        &self,
+        id: &str,
+        owner: &str,
+        now: &str,
+        lease_expires_at: &str,
+    ) -> InfraResult<Option<ExtractionJobRecord>>;
+    async fn renew_job_lease(
+        &self,
+        id: &str,
+        owner: &str,
+        now: &str,
+        lease_expires_at: &str,
+    ) -> InfraResult<bool>;
+    async fn finish_job_claim(
+        &self,
+        id: &str,
+        owner: &str,
+        status: super::record::JobStatus,
+        item_ids: &[String],
+        error: Option<&str>,
+        now: &str,
+    ) -> InfraResult<bool>;
+    /// Atomically verifies the active lease, replaces the extracted document
+    /// items, and marks both job and conversation successful.
+    async fn finish_job_claim_with_results(
+        &self,
+        id: &str,
+        owner: &str,
+        document: &Document,
+        items: &[Item],
+        now: &str,
+    ) -> InfraResult<bool>;
 }
 
 #[async_trait]

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -411,6 +411,20 @@ fn migrate_extraction_jobs_add_lease_columns(conn: &Connection) -> InfraResult<(
     }
     conn.execute_batch(
         r#"
+        UPDATE extraction_jobs
+        SET status = 'failed',
+            error = COALESCE(error, 'superseded by a newer active extraction job'),
+            lease_owner = NULL,
+            lease_expires_at = NULL
+        WHERE status IN ('pending', 'running')
+          AND EXISTS (
+            SELECT 1 FROM extraction_jobs newer
+            WHERE newer.conversation_id = extraction_jobs.conversation_id
+              AND newer.status IN ('pending', 'running')
+              AND (newer.created_at > extraction_jobs.created_at
+                   OR (newer.created_at = extraction_jobs.created_at
+                       AND newer.id > extraction_jobs.id))
+          );
         CREATE INDEX IF NOT EXISTS idx_extraction_jobs_recovery
         ON extraction_jobs(status, lease_expires_at, created_at);
         "#,

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -18,7 +18,7 @@ pub mod quota_state;
 mod sqlite;
 
 const FTS_BOOTSTRAP_USER_VERSION: i64 = 1;
-const ALLOWED_COLUMN_EXISTS_TABLES: &[&str] = &["items", "documents"];
+const ALLOWED_COLUMN_EXISTS_TABLES: &[&str] = &["items", "documents", "extraction_jobs"];
 const ALLOWED_FOREIGN_KEY_TABLES: &[&str] = &["items", "extraction_jobs"];
 
 pub fn prepare_sqlite_db(conn: &Connection) -> InfraResult<()> {
@@ -32,6 +32,7 @@ pub fn prepare_sqlite_db(conn: &Connection) -> InfraResult<()> {
     migrate_documents_add_source_version(&tx)?;
     migrate_documents_url_unique(&tx)?;
     migrate_items_document_fk(&tx)?;
+    migrate_extraction_jobs_add_lease_columns(&tx)?;
     migrate_extraction_jobs_conversation_fk(&tx)?;
     maybe_rebuild_fts_index(&tx)?;
     tx.commit()
@@ -365,11 +366,16 @@ fn migrate_extraction_jobs_conversation_fk(conn: &Connection) -> InfraResult<()>
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             error TEXT,
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            lease_owner TEXT,
+            lease_expires_at TEXT,
             FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
         );
         INSERT INTO extraction_jobs
-          (id, conversation_id, mode, status, created_at, updated_at, error)
-        SELECT id, conversation_id, mode, status, created_at, updated_at, error
+          (id, conversation_id, mode, status, created_at, updated_at, error,
+           attempt_count, lease_owner, lease_expires_at)
+        SELECT id, conversation_id, mode, status, created_at, updated_at, error,
+               attempt_count, lease_owner, lease_expires_at
         FROM extraction_jobs_without_conversation_fk
         WHERE EXISTS (
             SELECT 1
@@ -379,10 +385,37 @@ fn migrate_extraction_jobs_conversation_fk(conn: &Connection) -> InfraResult<()>
         DROP TABLE extraction_jobs_without_conversation_fk;
         CREATE INDEX IF NOT EXISTS idx_extraction_jobs_conversation
         ON extraction_jobs(conversation_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_extraction_jobs_recovery
+        ON extraction_jobs(status, lease_expires_at, created_at);
         "#,
     )
     .map_err(|e| InfraError::Database(e.to_string()))?;
 
+    Ok(())
+}
+
+fn migrate_extraction_jobs_add_lease_columns(conn: &Connection) -> InfraResult<()> {
+    if !column_exists(conn, "extraction_jobs", "attempt_count")? {
+        conn.execute_batch(
+            "ALTER TABLE extraction_jobs ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0",
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    }
+    if !column_exists(conn, "extraction_jobs", "lease_owner")? {
+        conn.execute_batch("ALTER TABLE extraction_jobs ADD COLUMN lease_owner TEXT")
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+    }
+    if !column_exists(conn, "extraction_jobs", "lease_expires_at")? {
+        conn.execute_batch("ALTER TABLE extraction_jobs ADD COLUMN lease_expires_at TEXT")
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+    }
+    conn.execute_batch(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_extraction_jobs_recovery
+        ON extraction_jobs(status, lease_expires_at, created_at);
+        "#,
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))?;
     Ok(())
 }
 

--- a/packages/core/src/infra/schema.sql
+++ b/packages/core/src/infra/schema.sql
@@ -118,6 +118,9 @@ CREATE TABLE IF NOT EXISTS extraction_jobs (
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     error TEXT,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    lease_owner TEXT,
+    lease_expires_at TEXT,
     FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
 );
 

--- a/packages/core/src/infra/sqlite/conversation_ops.rs
+++ b/packages/core/src/infra/sqlite/conversation_ops.rs
@@ -467,11 +467,17 @@ pub(super) fn list_recoverable_jobs(
             SELECT id, conversation_id, mode, status, created_at, updated_at, error,
                    attempt_count, lease_owner, lease_expires_at
             FROM extraction_jobs
-            WHERE status = 'pending'
+            WHERE EXISTS (
+                SELECT 1 FROM conversations
+                WHERE conversations.id = extraction_jobs.conversation_id
+                  AND conversations.status IN ('queued', 'processing', 'failed')
+            ) AND (
+               status = 'pending'
                OR (status = 'running' AND (
                     lease_expires_at IS NULL
                     OR julianday(lease_expires_at) <= julianday(?1)
                ))
+            )
             ORDER BY created_at ASC, id ASC
             LIMIT ?2
             "#,
@@ -485,6 +491,24 @@ pub(super) fn list_recoverable_jobs(
         .map_err(|e| InfraError::Database(e.to_string()))?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
         .map_err(|e| InfraError::Database(e.to_string()))
+}
+
+pub(super) fn reconcile_processed_jobs(conn: &Connection, now: &str) -> InfraResult<usize> {
+    conn.execute(
+        r#"
+        UPDATE extraction_jobs
+        SET status = 'succeeded', updated_at = ?1, error = NULL,
+            lease_owner = NULL, lease_expires_at = NULL
+        WHERE status IN ('pending', 'running')
+          AND EXISTS (
+            SELECT 1 FROM conversations
+            WHERE conversations.id = extraction_jobs.conversation_id
+              AND conversations.status = 'processed'
+          )
+        "#,
+        [now],
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))
 }
 
 pub(super) fn claim_job(
@@ -504,7 +528,11 @@ pub(super) fn claim_job(
             SET status = 'running', updated_at = ?3, error = NULL,
                 attempt_count = attempt_count + 1,
                 lease_owner = ?2, lease_expires_at = ?4
-            WHERE id = ?1 AND (
+            WHERE id = ?1 AND EXISTS (
+                SELECT 1 FROM conversations
+                WHERE conversations.id = extraction_jobs.conversation_id
+                  AND conversations.status IN ('queued', 'processing', 'failed')
+            ) AND (
                 status = 'pending'
                 OR (status = 'running' AND (
                     lease_expires_at IS NULL
@@ -608,26 +636,38 @@ pub(super) fn finish_job_claim_in_transaction(
         serde_json::to_string(item_ids).map_err(|e| InfraError::Database(e.to_string()))?;
     match status {
         JobStatus::Succeeded => {
-            conn.execute(
-                r#"
+            let changed = conn
+                .execute(
+                    r#"
                 UPDATE conversations
                 SET status = 'processed', item_ids = ?2, last_error = NULL
                 WHERE id = ?1 AND status IN ('queued', 'processing')
                 "#,
-                params![conversation_id, item_ids],
-            )
-            .map_err(|e| InfraError::Database(e.to_string()))?;
+                    params![conversation_id, item_ids],
+                )
+                .map_err(|e| InfraError::Database(e.to_string()))?;
+            if changed != 1 {
+                return Err(InfraError::Database(format!(
+                    "claimed job {id} could not finish its conversation successfully"
+                )));
+            }
         }
         JobStatus::Failed => {
-            conn.execute(
-                r#"
+            let changed = conn
+                .execute(
+                    r#"
                 UPDATE conversations
                 SET status = 'failed', last_error = ?2
                 WHERE id = ?1 AND status IN ('queued', 'processing')
                 "#,
-                params![conversation_id, error],
-            )
-            .map_err(|e| InfraError::Database(e.to_string()))?;
+                    params![conversation_id, error],
+                )
+                .map_err(|e| InfraError::Database(e.to_string()))?;
+            if changed != 1 {
+                return Err(InfraError::Database(format!(
+                    "claimed job {id} could not fail its conversation"
+                )));
+            }
         }
         _ => unreachable!(),
     }
@@ -1306,6 +1346,79 @@ mod tests {
             .expect("conversation exists");
         assert_eq!(conversation.status, ConversationStatus::Processed);
         assert_eq!(conversation.item_ids, vec!["item-1"]);
+        cleanup(&path);
+    }
+
+    #[tokio::test]
+    async fn processed_parent_is_not_recovered_or_reclaimed() {
+        let path = temp_db_path();
+        let store = Arc::new(SqliteStore::open(&path).expect("store init"));
+        let mut conversation =
+            build_conversation(ConversationStatus::Queued, "processed-running-parent");
+        store
+            .upsert_conversation(&conversation)
+            .await
+            .expect("insert conversation");
+        let now = now_iso();
+        let job = ExtractionJobRecord {
+            id: Uuid::new_v4().to_string(),
+            conversation_id: conversation.id.clone(),
+            mode: ExtractionMode::Auto,
+            status: JobStatus::Pending,
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            error: None,
+            attempt_count: 0,
+            lease_owner: None,
+            lease_expires_at: None,
+        };
+        store.upsert_job(&job).await.expect("insert job");
+        store
+            .claim_job(&job.id, "legacy-worker", &now, "2020-01-01T00:00:00Z")
+            .await
+            .expect("claim")
+            .expect("claimed");
+        conversation.status = ConversationStatus::Processing;
+        store
+            .upsert_conversation(&conversation)
+            .await
+            .expect("processing");
+        conversation.status = ConversationStatus::Processed;
+        conversation.item_ids = vec!["old-item".to_string()];
+        store
+            .upsert_conversation(&conversation)
+            .await
+            .expect("processed");
+
+        assert!(store
+            .list_recoverable_jobs(&now_iso(), 10)
+            .await
+            .expect("recoverable")
+            .is_empty());
+        assert!(store
+            .claim_job(&job.id, "new-worker", &now_iso(), "2099-01-01T00:00:00Z",)
+            .await
+            .expect("claim processed")
+            .is_none());
+        assert_eq!(
+            store
+                .reconcile_processed_jobs(&now_iso())
+                .await
+                .expect("reconcile processed"),
+            1
+        );
+        let reconciled = store
+            .find_job_by_id(&job.id)
+            .await
+            .expect("load reconciled job")
+            .expect("job exists");
+        assert_eq!(reconciled.status, JobStatus::Succeeded);
+        let parent = store
+            .find_conversation_by_id(&conversation.id)
+            .await
+            .expect("load parent")
+            .expect("parent exists");
+        assert_eq!(parent.item_ids, vec!["old-item"]);
         cleanup(&path);
     }
 

--- a/packages/core/src/infra/sqlite/conversation_ops.rs
+++ b/packages/core/src/infra/sqlite/conversation_ops.rs
@@ -2,7 +2,7 @@
 //!
 //! 全部在 worker 单线程内调用，假定 connection 已经过 `configure_connection`。
 
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
 
 use crate::conversation::{
     ConversationRecord, ConversationStatus, EventRecord, ExtractionJobRecord, ExtractionMode,
@@ -224,13 +224,156 @@ pub(super) fn insert_or_fetch_conversation_by_idempotency(
     .map_err(|e| InfraError::Database(e.to_string()))
 }
 
+pub(super) fn insert_or_fetch_conversation_with_job(
+    conn: &Connection,
+    record: &ConversationRecord,
+    job: &ExtractionJobRecord,
+) -> InfraResult<(ConversationRecord, Option<ExtractionJobRecord>)> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let mut persisted = insert_or_fetch_conversation_by_idempotency(&tx, record)?;
+    if persisted.status == ConversationStatus::Processed {
+        tx.commit()
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+        return Ok((persisted, None));
+    }
+
+    let existing = tx
+        .query_row(
+            r#"
+            SELECT id, conversation_id, mode, status, created_at, updated_at, error,
+                   attempt_count, lease_owner, lease_expires_at
+            FROM extraction_jobs
+            WHERE conversation_id = ?1 AND status IN ('pending', 'running')
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            "#,
+            [persisted.id.as_str()],
+            row_to_job,
+        )
+        .optional()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+
+    let persisted_job = match existing {
+        Some(existing) => Some(existing),
+        None => {
+            let mut initial_job = job.clone();
+            initial_job.conversation_id = persisted.id.clone();
+            upsert_job(&tx, &initial_job)?;
+            Some(initial_job)
+        }
+    };
+    if matches!(
+        persisted.status,
+        ConversationStatus::Captured | ConversationStatus::Failed
+    ) {
+        tx.execute(
+            "UPDATE conversations SET status = 'queued', last_error = NULL WHERE id = ?1",
+            [persisted.id.as_str()],
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+        persisted.status = ConversationStatus::Queued;
+        persisted.last_error = None;
+    }
+    tx.commit()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok((persisted, persisted_job))
+}
+
+pub(super) fn enqueue_job(
+    conn: &Connection,
+    job: &ExtractionJobRecord,
+) -> InfraResult<ExtractionJobRecord> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let existing = tx
+        .query_row(
+            r#"
+            SELECT id, conversation_id, mode, status, created_at, updated_at, error,
+                   attempt_count, lease_owner, lease_expires_at
+            FROM extraction_jobs
+            WHERE conversation_id = ?1 AND status IN ('pending', 'running')
+            ORDER BY created_at DESC, id DESC LIMIT 1
+            "#,
+            [job.conversation_id.as_str()],
+            row_to_job,
+        )
+        .optional()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    if let Some(existing) = existing {
+        tx.commit()
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+        return Ok(existing);
+    }
+    let changed = tx
+        .execute(
+            r#"
+            UPDATE conversations SET status = 'queued', last_error = NULL
+            WHERE id = ?1 AND status IN ('captured', 'failed')
+            "#,
+            [job.conversation_id.as_str()],
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    if changed == 0 {
+        let status = tx
+            .query_row(
+                "SELECT status FROM conversations WHERE id = ?1",
+                [job.conversation_id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+        if status.as_deref() != Some("queued") {
+            return Err(InfraError::Database(format!(
+                "conversation {} cannot be queued from {}",
+                job.conversation_id,
+                status.as_deref().unwrap_or("<missing>")
+            )));
+        }
+    }
+    tx.execute(
+        r#"
+        INSERT OR IGNORE INTO extraction_jobs
+          (id, conversation_id, mode, status, created_at, updated_at, error,
+           attempt_count, lease_owner, lease_expires_at)
+        VALUES (?1, ?2, ?3, 'pending', ?4, ?5, ?6, 0, NULL, NULL)
+        "#,
+        params![
+            job.id,
+            job.conversation_id,
+            extraction_mode_to_db(&job.mode),
+            job.created_at,
+            job.updated_at,
+            job.error,
+        ],
+    )
+    .map_err(|e| InfraError::Database(e.to_string()))?;
+    let persisted = tx
+        .query_row(
+            r#"
+            SELECT id, conversation_id, mode, status, created_at, updated_at, error,
+                   attempt_count, lease_owner, lease_expires_at
+            FROM extraction_jobs
+            WHERE conversation_id = ?1 AND status IN ('pending', 'running')
+            ORDER BY created_at DESC, id DESC LIMIT 1
+            "#,
+            [job.conversation_id.as_str()],
+            row_to_job,
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    tx.commit()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(persisted)
+}
+
 pub(super) fn find_job_by_id(
     conn: &Connection,
     id: &str,
 ) -> InfraResult<Option<ExtractionJobRecord>> {
     conn.query_row(
         r#"
-        SELECT id, conversation_id, mode, status, created_at, updated_at, error
+        SELECT id, conversation_id, mode, status, created_at, updated_at, error,
+               attempt_count, lease_owner, lease_expires_at
         FROM extraction_jobs
         WHERE id = ?1
         "#,
@@ -246,16 +389,20 @@ pub(super) fn upsert_job(conn: &Connection, job: &ExtractionJobRecord) -> InfraR
         .execute(
             r#"
         INSERT INTO extraction_jobs
-          (id, conversation_id, mode, status, created_at, updated_at, error)
+          (id, conversation_id, mode, status, created_at, updated_at, error,
+           attempt_count, lease_owner, lease_expires_at)
         VALUES
-          (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+          (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
         ON CONFLICT(id) DO UPDATE SET
           conversation_id=excluded.conversation_id,
           mode=excluded.mode,
           status=excluded.status,
           created_at=excluded.created_at,
           updated_at=excluded.updated_at,
-          error=excluded.error
+          error=excluded.error,
+          attempt_count=excluded.attempt_count,
+          lease_owner=excluded.lease_owner,
+          lease_expires_at=excluded.lease_expires_at
         WHERE extraction_jobs.status = excluded.status
            OR (extraction_jobs.status = 'pending' AND excluded.status = 'running')
            OR (extraction_jobs.status = 'pending' AND excluded.status = 'failed')
@@ -269,6 +416,9 @@ pub(super) fn upsert_job(conn: &Connection, job: &ExtractionJobRecord) -> InfraR
                 job.created_at,
                 job.updated_at,
                 job.error,
+                job.attempt_count,
+                job.lease_owner,
+                job.lease_expires_at,
             ],
         )
         .map_err(|e| InfraError::Database(e.to_string()))?;
@@ -304,6 +454,184 @@ pub(super) fn upsert_job(conn: &Connection, job: &ExtractionJobRecord) -> InfraR
     }
 
     Ok(())
+}
+
+pub(super) fn list_recoverable_jobs(
+    conn: &Connection,
+    now: &str,
+    limit: usize,
+) -> InfraResult<Vec<ExtractionJobRecord>> {
+    let mut stmt = conn
+        .prepare(
+            r#"
+            SELECT id, conversation_id, mode, status, created_at, updated_at, error,
+                   attempt_count, lease_owner, lease_expires_at
+            FROM extraction_jobs
+            WHERE status = 'pending'
+               OR (status = 'running' AND (
+                    lease_expires_at IS NULL
+                    OR julianday(lease_expires_at) <= julianday(?1)
+               ))
+            ORDER BY created_at ASC, id ASC
+            LIMIT ?2
+            "#,
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let rows = stmt
+        .query_map(
+            params![now, std::cmp::min(limit, i64::MAX as usize) as i64],
+            row_to_job,
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| InfraError::Database(e.to_string()))
+}
+
+pub(super) fn claim_job(
+    conn: &Connection,
+    id: &str,
+    owner: &str,
+    now: &str,
+    lease_expires_at: &str,
+) -> InfraResult<Option<ExtractionJobRecord>> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let claimed = tx
+        .query_row(
+            r#"
+            UPDATE extraction_jobs
+            SET status = 'running', updated_at = ?3, error = NULL,
+                attempt_count = attempt_count + 1,
+                lease_owner = ?2, lease_expires_at = ?4
+            WHERE id = ?1 AND (
+                status = 'pending'
+                OR (status = 'running' AND (
+                    lease_expires_at IS NULL
+                    OR julianday(lease_expires_at) <= julianday(?3)
+                ))
+            )
+            RETURNING id, conversation_id, mode, status, created_at, updated_at, error,
+                      attempt_count, lease_owner, lease_expires_at
+            "#,
+            params![id, owner, now, lease_expires_at],
+            row_to_job,
+        )
+        .optional()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    if let Some(job) = &claimed {
+        tx.execute(
+            r#"
+            UPDATE conversations
+            SET status = 'processing', last_error = NULL
+            WHERE id = ?1 AND status IN ('queued', 'processing', 'failed')
+            "#,
+            [job.conversation_id.as_str()],
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    }
+    tx.commit()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(claimed)
+}
+
+pub(super) fn renew_job_lease(
+    conn: &Connection,
+    id: &str,
+    owner: &str,
+    now: &str,
+    lease_expires_at: &str,
+) -> InfraResult<bool> {
+    conn.execute(
+        r#"
+        UPDATE extraction_jobs
+        SET updated_at = ?3, lease_expires_at = ?4
+        WHERE id = ?1 AND status = 'running' AND lease_owner = ?2
+        "#,
+        params![id, owner, now, lease_expires_at],
+    )
+    .map(|affected| affected == 1)
+    .map_err(|e| InfraError::Database(e.to_string()))
+}
+
+pub(super) fn finish_job_claim(
+    conn: &Connection,
+    id: &str,
+    owner: &str,
+    status: JobStatus,
+    item_ids: &[String],
+    error: Option<&str>,
+    now: &str,
+) -> InfraResult<bool> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let finished = finish_job_claim_in_transaction(&tx, id, owner, status, item_ids, error, now)?;
+    tx.commit()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(finished)
+}
+
+pub(super) fn finish_job_claim_in_transaction(
+    conn: &Connection,
+    id: &str,
+    owner: &str,
+    status: JobStatus,
+    item_ids: &[String],
+    error: Option<&str>,
+    now: &str,
+) -> InfraResult<bool> {
+    if !matches!(status, JobStatus::Succeeded | JobStatus::Failed) {
+        return Err(InfraError::Database(
+            "claimed job can only finish as succeeded or failed".to_string(),
+        ));
+    }
+    let conversation_id = conn
+        .query_row(
+            r#"
+            UPDATE extraction_jobs
+            SET status = ?3, updated_at = ?4, error = ?5,
+                lease_owner = NULL, lease_expires_at = NULL
+            WHERE id = ?1 AND status = 'running' AND lease_owner = ?2
+            RETURNING conversation_id
+            "#,
+            params![id, owner, job_status_to_db(&status), now, error],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let Some(conversation_id) = conversation_id else {
+        return Ok(false);
+    };
+
+    let item_ids =
+        serde_json::to_string(item_ids).map_err(|e| InfraError::Database(e.to_string()))?;
+    match status {
+        JobStatus::Succeeded => {
+            conn.execute(
+                r#"
+                UPDATE conversations
+                SET status = 'processed', item_ids = ?2, last_error = NULL
+                WHERE id = ?1 AND status IN ('queued', 'processing')
+                "#,
+                params![conversation_id, item_ids],
+            )
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+        }
+        JobStatus::Failed => {
+            conn.execute(
+                r#"
+                UPDATE conversations
+                SET status = 'failed', last_error = ?2
+                WHERE id = ?1 AND status IN ('queued', 'processing')
+                "#,
+                params![conversation_id, error],
+            )
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+        }
+        _ => unreachable!(),
+    }
+    Ok(true)
 }
 
 fn invalid_transition_error(kind: &str, id: &str, from: &str, to: &str) -> InfraError {
@@ -452,6 +780,9 @@ fn row_to_job(row: &rusqlite::Row<'_>) -> rusqlite::Result<ExtractionJobRecord> 
         created_at: row.get(4)?,
         updated_at: row.get(5)?,
         error: row.get(6)?,
+        attempt_count: row.get(7)?,
+        lease_owner: row.get(8)?,
+        lease_expires_at: row.get(9)?,
     })
 }
 
@@ -699,6 +1030,9 @@ mod tests {
             created_at: now.clone(),
             updated_at: now,
             error: None,
+            attempt_count: 0,
+            lease_owner: None,
+            lease_expires_at: None,
         };
         store.upsert_job(&job).await.expect("upsert job");
         let loaded = store
@@ -731,6 +1065,9 @@ mod tests {
             created_at: now.clone(),
             updated_at: now,
             error: None,
+            attempt_count: 0,
+            lease_owner: None,
+            lease_expires_at: None,
         };
 
         store.upsert_job(&job).await.expect("insert pending job");
@@ -756,6 +1093,219 @@ mod tests {
             .expect("find job")
             .expect("job should exist");
         assert_eq!(loaded.status, JobStatus::Succeeded);
+        cleanup(&path);
+    }
+
+    #[tokio::test]
+    async fn conversation_and_initial_job_are_created_atomically_and_idempotently() {
+        let path = temp_db_path();
+        let store = Arc::new(SqliteStore::open(&path).expect("store init"));
+        let conversation = build_conversation(ConversationStatus::Queued, "atomic-job-key");
+        let now = now_iso();
+        let job = ExtractionJobRecord {
+            id: Uuid::new_v4().to_string(),
+            conversation_id: conversation.id.clone(),
+            mode: ExtractionMode::Auto,
+            status: JobStatus::Pending,
+            created_at: now.clone(),
+            updated_at: now,
+            error: None,
+            attempt_count: 0,
+            lease_owner: None,
+            lease_expires_at: None,
+        };
+
+        let (first_conversation, first_job) = store
+            .insert_or_fetch_conversation_with_job(&conversation, &job)
+            .await
+            .expect("insert conversation and job");
+        let mut duplicate = conversation.clone();
+        duplicate.id = Uuid::new_v4().to_string();
+        let mut duplicate_job = job.clone();
+        duplicate_job.id = Uuid::new_v4().to_string();
+        duplicate_job.conversation_id = duplicate.id.clone();
+        let (second_conversation, second_job) = store
+            .insert_or_fetch_conversation_with_job(&duplicate, &duplicate_job)
+            .await
+            .expect("fetch conversation and active job");
+
+        assert_eq!(first_conversation.id, second_conversation.id);
+        assert_eq!(
+            first_job.expect("first job").id,
+            second_job.expect("second job").id
+        );
+        cleanup(&path);
+    }
+
+    #[tokio::test]
+    async fn processed_idempotent_replay_does_not_restart_terminal_job() {
+        let path = temp_db_path();
+        let store = Arc::new(SqliteStore::open(&path).expect("store init"));
+        let conversation = build_conversation(ConversationStatus::Queued, "processed-replay-key");
+        let now = now_iso();
+        let job = ExtractionJobRecord {
+            id: Uuid::new_v4().to_string(),
+            conversation_id: conversation.id.clone(),
+            mode: ExtractionMode::Auto,
+            status: JobStatus::Pending,
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            error: None,
+            attempt_count: 0,
+            lease_owner: None,
+            lease_expires_at: None,
+        };
+        let (_, initial_job) = store
+            .insert_or_fetch_conversation_with_job(&conversation, &job)
+            .await
+            .expect("insert conversation and job");
+        let claimed = store
+            .claim_job(
+                &initial_job.expect("initial job").id,
+                "worker",
+                &now,
+                "2099-01-01T00:00:00Z",
+            )
+            .await
+            .expect("claim job")
+            .expect("claimed job");
+        store
+            .finish_job_claim(
+                &claimed.id,
+                "worker",
+                JobStatus::Succeeded,
+                &[],
+                None,
+                &now_iso(),
+            )
+            .await
+            .expect("finish job");
+
+        let mut replay = conversation.clone();
+        replay.id = Uuid::new_v4().to_string();
+        let mut replay_job = job;
+        replay_job.id = Uuid::new_v4().to_string();
+        replay_job.conversation_id = replay.id.clone();
+        let (persisted, replayed_job) = store
+            .insert_or_fetch_conversation_with_job(&replay, &replay_job)
+            .await
+            .expect("replay processed conversation");
+        assert_eq!(persisted.status, ConversationStatus::Processed);
+        assert!(replayed_job.is_none());
+        cleanup(&path);
+    }
+
+    #[tokio::test]
+    async fn only_one_worker_can_claim_a_pending_job() {
+        let path = temp_db_path();
+        let store = Arc::new(SqliteStore::open(&path).expect("store init"));
+        let conversation = build_conversation(ConversationStatus::Queued, "claim-parent");
+        store
+            .upsert_conversation(&conversation)
+            .await
+            .expect("insert conversation");
+        let now = now_iso();
+        let job = ExtractionJobRecord {
+            id: Uuid::new_v4().to_string(),
+            conversation_id: conversation.id.clone(),
+            mode: ExtractionMode::Auto,
+            status: JobStatus::Pending,
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            error: None,
+            attempt_count: 0,
+            lease_owner: None,
+            lease_expires_at: None,
+        };
+        store.upsert_job(&job).await.expect("insert job");
+        let expires = (chrono::Utc::now() + chrono::Duration::minutes(2)).to_rfc3339();
+
+        let first = store
+            .claim_job(&job.id, "worker-a", &now, &expires)
+            .await
+            .expect("claim a");
+        let second = store
+            .claim_job(&job.id, "worker-b", &now, &expires)
+            .await
+            .expect("claim b");
+        assert!(first.is_some());
+        assert!(second.is_none());
+        assert_eq!(first.expect("claimed").attempt_count, 1);
+        cleanup(&path);
+    }
+
+    #[tokio::test]
+    async fn stale_lease_is_recoverable_and_old_owner_cannot_finish() {
+        let path = temp_db_path();
+        let store = Arc::new(SqliteStore::open(&path).expect("store init"));
+        let conversation = build_conversation(ConversationStatus::Queued, "stale-parent");
+        store
+            .upsert_conversation(&conversation)
+            .await
+            .expect("insert conversation");
+        let now = now_iso();
+        let job = ExtractionJobRecord {
+            id: Uuid::new_v4().to_string(),
+            conversation_id: conversation.id.clone(),
+            mode: ExtractionMode::Knowledge,
+            status: JobStatus::Pending,
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            error: None,
+            attempt_count: 0,
+            lease_owner: None,
+            lease_expires_at: None,
+        };
+        store.upsert_job(&job).await.expect("insert job");
+        let expired = (chrono::Utc::now() - chrono::Duration::minutes(1)).to_rfc3339();
+        store
+            .claim_job(&job.id, "crashed-worker", &now, &expired)
+            .await
+            .expect("initial claim")
+            .expect("claimed");
+
+        let recoverable = store
+            .list_recoverable_jobs(&now_iso(), 10)
+            .await
+            .expect("list recoverable");
+        assert_eq!(recoverable.len(), 1);
+        let expires = (chrono::Utc::now() + chrono::Duration::minutes(2)).to_rfc3339();
+        let reclaimed = store
+            .claim_job(&job.id, "recovery-worker", &now_iso(), &expires)
+            .await
+            .expect("reclaim")
+            .expect("reclaimed");
+        assert_eq!(reclaimed.attempt_count, 2);
+
+        assert!(!store
+            .finish_job_claim(
+                &job.id,
+                "crashed-worker",
+                JobStatus::Failed,
+                &[],
+                Some("late failure"),
+                &now_iso(),
+            )
+            .await
+            .expect("stale finish"));
+        assert!(store
+            .finish_job_claim(
+                &job.id,
+                "recovery-worker",
+                JobStatus::Succeeded,
+                &["item-1".to_string()],
+                None,
+                &now_iso(),
+            )
+            .await
+            .expect("current finish"));
+        let conversation = store
+            .find_conversation_by_id(&conversation.id)
+            .await
+            .expect("load conversation")
+            .expect("conversation exists");
+        assert_eq!(conversation.status, ConversationStatus::Processed);
+        assert_eq!(conversation.item_ids, vec!["item-1"]);
         cleanup(&path);
     }
 

--- a/packages/core/src/infra/sqlite/mod.rs
+++ b/packages/core/src/infra/sqlite/mod.rs
@@ -326,6 +326,17 @@ impl ConversationRepository for SqliteStore {
         self.request(|resp| SqliteCommand::ConversationInsertOrFetchByIdempotency { record, resp })
             .await
     }
+
+    async fn insert_or_fetch_conversation_with_job(
+        &self,
+        record: &ConversationRecord,
+        job: &ExtractionJobRecord,
+    ) -> InfraResult<(ConversationRecord, Option<ExtractionJobRecord>)> {
+        let record = record.clone();
+        let job = job.clone();
+        self.request(|resp| SqliteCommand::ConversationInsertOrFetchWithJob { record, job, resp })
+            .await
+    }
 }
 
 #[async_trait]
@@ -340,6 +351,114 @@ impl JobRepository for SqliteStore {
         let job = job.clone();
         self.request(|resp| SqliteCommand::JobUpsert { job, resp })
             .await
+    }
+
+    async fn enqueue_job(&self, job: &ExtractionJobRecord) -> InfraResult<ExtractionJobRecord> {
+        let job = job.clone();
+        self.request(|resp| SqliteCommand::JobEnqueue { job, resp })
+            .await
+    }
+
+    async fn list_recoverable_jobs(
+        &self,
+        now: &str,
+        limit: usize,
+    ) -> InfraResult<Vec<ExtractionJobRecord>> {
+        let now = now.to_string();
+        self.request(|resp| SqliteCommand::JobListRecoverable { now, limit, resp })
+            .await
+    }
+
+    async fn claim_job(
+        &self,
+        id: &str,
+        owner: &str,
+        now: &str,
+        lease_expires_at: &str,
+    ) -> InfraResult<Option<ExtractionJobRecord>> {
+        let id = id.to_string();
+        let owner = owner.to_string();
+        let now = now.to_string();
+        let lease_expires_at = lease_expires_at.to_string();
+        self.request(|resp| SqliteCommand::JobClaim {
+            id,
+            owner,
+            now,
+            lease_expires_at,
+            resp,
+        })
+        .await
+    }
+
+    async fn renew_job_lease(
+        &self,
+        id: &str,
+        owner: &str,
+        now: &str,
+        lease_expires_at: &str,
+    ) -> InfraResult<bool> {
+        let id = id.to_string();
+        let owner = owner.to_string();
+        let now = now.to_string();
+        let lease_expires_at = lease_expires_at.to_string();
+        self.request(|resp| SqliteCommand::JobRenewLease {
+            id,
+            owner,
+            now,
+            lease_expires_at,
+            resp,
+        })
+        .await
+    }
+
+    async fn finish_job_claim(
+        &self,
+        id: &str,
+        owner: &str,
+        status: crate::conversation::JobStatus,
+        item_ids: &[String],
+        error: Option<&str>,
+        now: &str,
+    ) -> InfraResult<bool> {
+        let id = id.to_string();
+        let owner = owner.to_string();
+        let item_ids = item_ids.to_vec();
+        let error = error.map(ToString::to_string);
+        let now = now.to_string();
+        self.request(|resp| SqliteCommand::JobFinishClaim {
+            id,
+            owner,
+            status,
+            item_ids,
+            error,
+            now,
+            resp,
+        })
+        .await
+    }
+
+    async fn finish_job_claim_with_results(
+        &self,
+        id: &str,
+        owner: &str,
+        document: &Document,
+        items: &[Item],
+        now: &str,
+    ) -> InfraResult<bool> {
+        let id = id.to_string();
+        let owner = owner.to_string();
+        let document = document.clone();
+        let items = items.to_vec();
+        let now = now.to_string();
+        self.request(|resp| SqliteCommand::JobFinishClaimWithResults {
+            id,
+            owner,
+            document,
+            items,
+            now,
+            resp,
+        })
+        .await
     }
 }
 

--- a/packages/core/src/infra/sqlite/mod.rs
+++ b/packages/core/src/infra/sqlite/mod.rs
@@ -369,6 +369,12 @@ impl JobRepository for SqliteStore {
             .await
     }
 
+    async fn reconcile_processed_jobs(&self, now: &str) -> InfraResult<usize> {
+        let now = now.to_string();
+        self.request(|resp| SqliteCommand::JobReconcileProcessed { now, resp })
+            .await
+    }
+
     async fn claim_job(
         &self,
         id: &str,

--- a/packages/core/src/infra/sqlite/worker.rs
+++ b/packages/core/src/infra/sqlite/worker.rs
@@ -178,6 +178,10 @@ pub(super) enum SqliteCommand {
         limit: usize,
         resp: oneshot::Sender<InfraResult<Vec<ExtractionJobRecord>>>,
     },
+    JobReconcileProcessed {
+        now: String,
+        resp: oneshot::Sender<InfraResult<usize>>,
+    },
     JobClaim {
         id: String,
         owner: String,
@@ -552,6 +556,13 @@ fn handle_command(conn: &Connection, command: SqliteCommand) {
                 "JobListRecoverable",
                 resp,
                 conversation_ops::list_recoverable_jobs(conn, &now, limit),
+            );
+        }
+        SqliteCommand::JobReconcileProcessed { now, resp } => {
+            send_response(
+                "JobReconcileProcessed",
+                resp,
+                conversation_ops::reconcile_processed_jobs(conn, &now),
             );
         }
         SqliteCommand::JobClaim {

--- a/packages/core/src/infra/sqlite/worker.rs
+++ b/packages/core/src/infra/sqlite/worker.rs
@@ -155,6 +155,11 @@ pub(super) enum SqliteCommand {
         record: ConversationRecord,
         resp: oneshot::Sender<InfraResult<ConversationRecord>>,
     },
+    ConversationInsertOrFetchWithJob {
+        record: ConversationRecord,
+        job: ExtractionJobRecord,
+        resp: oneshot::Sender<InfraResult<(ConversationRecord, Option<ExtractionJobRecord>)>>,
+    },
     // Extraction job 操作
     JobFindById {
         id: String,
@@ -163,6 +168,46 @@ pub(super) enum SqliteCommand {
     JobUpsert {
         job: ExtractionJobRecord,
         resp: oneshot::Sender<InfraResult<()>>,
+    },
+    JobEnqueue {
+        job: ExtractionJobRecord,
+        resp: oneshot::Sender<InfraResult<ExtractionJobRecord>>,
+    },
+    JobListRecoverable {
+        now: String,
+        limit: usize,
+        resp: oneshot::Sender<InfraResult<Vec<ExtractionJobRecord>>>,
+    },
+    JobClaim {
+        id: String,
+        owner: String,
+        now: String,
+        lease_expires_at: String,
+        resp: oneshot::Sender<InfraResult<Option<ExtractionJobRecord>>>,
+    },
+    JobRenewLease {
+        id: String,
+        owner: String,
+        now: String,
+        lease_expires_at: String,
+        resp: oneshot::Sender<InfraResult<bool>>,
+    },
+    JobFinishClaim {
+        id: String,
+        owner: String,
+        status: crate::conversation::JobStatus,
+        item_ids: Vec<String>,
+        error: Option<String>,
+        now: String,
+        resp: oneshot::Sender<InfraResult<bool>>,
+    },
+    JobFinishClaimWithResults {
+        id: String,
+        owner: String,
+        document: Document,
+        items: Vec<Item>,
+        now: String,
+        resp: oneshot::Sender<InfraResult<bool>>,
     },
     // Event 操作
     EventInsert {
@@ -478,6 +523,13 @@ fn handle_command(conn: &Connection, command: SqliteCommand) {
                 conversation_ops::insert_or_fetch_conversation_by_idempotency(conn, &record),
             );
         }
+        SqliteCommand::ConversationInsertOrFetchWithJob { record, job, resp } => {
+            send_response(
+                "ConversationInsertOrFetchWithJob",
+                resp,
+                conversation_ops::insert_or_fetch_conversation_with_job(conn, &record, &job),
+            );
+        }
         SqliteCommand::JobFindById { id, resp } => {
             send_response(
                 "JobFindById",
@@ -487,6 +539,83 @@ fn handle_command(conn: &Connection, command: SqliteCommand) {
         }
         SqliteCommand::JobUpsert { job, resp } => {
             send_response("JobUpsert", resp, conversation_ops::upsert_job(conn, &job));
+        }
+        SqliteCommand::JobEnqueue { job, resp } => {
+            send_response(
+                "JobEnqueue",
+                resp,
+                conversation_ops::enqueue_job(conn, &job),
+            );
+        }
+        SqliteCommand::JobListRecoverable { now, limit, resp } => {
+            send_response(
+                "JobListRecoverable",
+                resp,
+                conversation_ops::list_recoverable_jobs(conn, &now, limit),
+            );
+        }
+        SqliteCommand::JobClaim {
+            id,
+            owner,
+            now,
+            lease_expires_at,
+            resp,
+        } => {
+            send_response(
+                "JobClaim",
+                resp,
+                conversation_ops::claim_job(conn, &id, &owner, &now, &lease_expires_at),
+            );
+        }
+        SqliteCommand::JobRenewLease {
+            id,
+            owner,
+            now,
+            lease_expires_at,
+            resp,
+        } => {
+            send_response(
+                "JobRenewLease",
+                resp,
+                conversation_ops::renew_job_lease(conn, &id, &owner, &now, &lease_expires_at),
+            );
+        }
+        SqliteCommand::JobFinishClaim {
+            id,
+            owner,
+            status,
+            item_ids,
+            error,
+            now,
+            resp,
+        } => {
+            send_response(
+                "JobFinishClaim",
+                resp,
+                conversation_ops::finish_job_claim(
+                    conn,
+                    &id,
+                    &owner,
+                    status,
+                    &item_ids,
+                    error.as_deref(),
+                    &now,
+                ),
+            );
+        }
+        SqliteCommand::JobFinishClaimWithResults {
+            id,
+            owner,
+            document,
+            items,
+            now,
+            resp,
+        } => {
+            send_response(
+                "JobFinishClaimWithResults",
+                resp,
+                finish_job_claim_with_results(conn, &id, &owner, &document, &items, &now),
+            );
         }
         SqliteCommand::EventInsert { event, resp } => {
             send_response(
@@ -521,6 +650,59 @@ fn save_document_with_replaced_items(
     tx.commit()
         .map_err(|e| InfraError::Database(e.to_string()))?;
     Ok(())
+}
+
+fn finish_job_claim_with_results(
+    conn: &Connection,
+    id: &str,
+    owner: &str,
+    document: &Document,
+    items: &[Item],
+    now: &str,
+) -> InfraResult<bool> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    let owns_claim: bool = tx
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM extraction_jobs \
+             WHERE id = ?1 AND status = 'running' AND lease_owner = ?2)",
+            rusqlite::params![id, owner],
+            |row| row.get(0),
+        )
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    if !owns_claim {
+        tx.commit()
+            .map_err(|e| InfraError::Database(e.to_string()))?;
+        return Ok(false);
+    }
+
+    let (document, items) = canonicalize_document_items(&tx, document, items)?;
+    doc_ops::save(&tx, &document)?;
+    ops::delete_by_document_id(&tx, document.id().as_str())?;
+    for item in &items {
+        ops::save(&tx, item)?;
+    }
+    let item_ids = items
+        .iter()
+        .map(|item| item.id().to_string())
+        .collect::<Vec<_>>();
+    let finished = conversation_ops::finish_job_claim_in_transaction(
+        &tx,
+        id,
+        owner,
+        crate::conversation::JobStatus::Succeeded,
+        &item_ids,
+        None,
+        now,
+    )?;
+    if !finished {
+        return Err(InfraError::Database(
+            "extraction lease changed during result transaction".to_string(),
+        ));
+    }
+    tx.commit()
+        .map_err(|e| InfraError::Database(e.to_string()))?;
+    Ok(true)
 }
 
 fn save_document_with_replaced_items_and_delete_documents(

--- a/packages/core/tests/sqlite_roundtrip.rs
+++ b/packages/core/tests/sqlite_roundtrip.rs
@@ -528,6 +528,9 @@ async fn pending_job_can_record_startup_failure_without_regressing_terminal_stat
         created_at: now.clone(),
         updated_at: now,
         error: None,
+        attempt_count: 0,
+        lease_owner: None,
+        lease_expires_at: None,
     };
 
     store.upsert_job(&job).await.expect("insert pending job");


### PR DESCRIPTION
Closes #174

## Summary
- atomically persist conversations with their initial extraction job and coalesce repeated enqueue requests
- claim persisted jobs with expiring leases, heartbeat active work, and reject stale worker completion
- recover pending and expired-running jobs at startup and through periodic reconciliation
- commit extracted document/items together with job and conversation success state

## Verification
- `cargo clippy -p refine-core -p refine-server --lib --bins -- -D warnings`
- `cargo test -p refine-core`
- `cargo test -p refine-server`
- focused claim, stale lease, idempotent replay, startup recovery, and FK migration tests