### PR TITLE
fix(cli): preserve failed session ingest retries

### DIFF
--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -126,9 +126,11 @@ fn session_captured_at(
     session_started_at.unwrap_or_else(|| DateTime::<Utc>::from(file_modified_at))
 }
 
-fn session_needs_refresh(existing_doc: &Document, file_modified_at: SystemTime) -> bool {
-    let file_modified_at = DateTime::<Utc>::from(file_modified_at);
-    file_modified_at > existing_doc.updated_at()
+fn session_needs_refresh(existing_doc: &Document, source_version: &str, raw_content: &str) -> bool {
+    match existing_doc.source_version() {
+        Some(existing_version) => existing_version != source_version,
+        None => existing_doc.raw_content() != raw_content,
+    }
 }
 
 fn content_source_version(provider: &str, raw_content: &str) -> String {
@@ -638,7 +640,7 @@ async fn handle_legacy_ingest_sessions(
             // document. If it is not a prefix/equal snapshot, keep it under
             // its local identity instead of replacing remem data.
             if let Some(existing_doc) = legacy_document.as_ref() {
-                if session_needs_refresh(existing_doc, ds.modified_at) {
+                if session_needs_refresh(existing_doc, &source_version, &raw_content) {
                     stale_refresh += 1;
                 } else {
                     skipped_dup += 1;
@@ -648,7 +650,7 @@ async fn handle_legacy_ingest_sessions(
             (legacy_url, ds.source.clone(), legacy_document)
         } else {
             if let Some(existing_doc) = legacy_document.as_ref() {
-                if session_needs_refresh(existing_doc, ds.modified_at) {
+                if session_needs_refresh(existing_doc, &source_version, &raw_content) {
                     stale_refresh += 1;
                 } else {
                     skipped_dup += 1;

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -10,6 +10,7 @@ use crate::remem_sessions::{
 };
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use fs2::FileExt;
 use refine_core::error::InfraError;
 use refine_core::infra::{
     llm_with_retry_policy, LlmClient, LlmRetryPolicy, DEFAULT_MAX_RETRIES,
@@ -25,6 +26,8 @@ use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fs::OpenOptions;
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -228,9 +231,11 @@ fn write_ingest_cursor_at(path: &Path, state: &IngestCursorState) -> Result<()> 
     let nonce = Utc::now().timestamp_nanos_opt().unwrap_or_default();
     let temp_path = path.with_extension(format!("tmp-{}-{nonce}", std::process::id()));
     let payload = serde_json::to_vec(state).context("failed to serialize ingest cursor")?;
-    let mut temp = OpenOptions::new()
-        .write(true)
-        .create_new(true)
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut temp = options
         .open(&temp_path)
         .with_context(|| format!("failed to create {}", temp_path.display()))?;
     temp.write_all(&payload)
@@ -240,7 +245,34 @@ fn write_ingest_cursor_at(path: &Path, state: &IngestCursorState) -> Result<()> 
     drop(temp);
     std::fs::rename(&temp_path, path)
         .with_context(|| format!("failed to replace {}", path.display()))?;
+    std::fs::File::open(dir)
+        .and_then(|directory| directory.sync_all())
+        .with_context(|| format!("failed to sync {}", dir.display()))?;
     Ok(())
+}
+
+fn lock_incremental_cursor(
+    source: Option<&SessionSource>,
+    db_path: &Path,
+) -> Result<std::fs::File> {
+    let home = dirs::home_dir().context("home directory is unavailable for ingest cursor")?;
+    let cursor_path = incremental_cursor_path(&home, source, db_path);
+    let parent = cursor_path
+        .parent()
+        .context("ingest cursor has no parent directory")?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create {}", parent.display()))?;
+    let lock_path = cursor_path.with_extension("lock");
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create(true).truncate(false);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let lock = options
+        .open(&lock_path)
+        .with_context(|| format!("failed to open {}", lock_path.display()))?;
+    lock.lock_exclusive()
+        .with_context(|| format!("failed to lock {}", lock_path.display()))?;
+    Ok(lock)
 }
 
 fn unix_seconds(t: SystemTime) -> u64 {
@@ -492,6 +524,13 @@ async fn handle_legacy_ingest_sessions(
     // 1-hour overlap on the cutoff absorbs clock skew and files modified near the boundary.
     let incremental = options.limit.is_none() && options.latest.is_none() && !options.dry_run;
     let source = options.source.clone();
+    // Serialize the complete read/scan/process/write cycle so an older,
+    // slower run cannot overwrite a newer safe watermark or failure set.
+    let _cursor_lock = if incremental {
+        Some(lock_incremental_cursor(source.as_ref(), db_path)?)
+    } else {
+        None
+    };
     let scan_start = SystemTime::now();
     let mtime_after = if incremental {
         read_last_ingest_mtime(source.as_ref(), db_path).map(|last| {

--- a/apps/cli/src/ingest_sessions.rs
+++ b/apps/cli/src/ingest_sessions.rs
@@ -20,12 +20,15 @@ use refine_core::session::{
     build_facet_prompt, chunk_session, discover_sessions, facets_to_items, needs_chunking,
     parse_facet_response, parse_session_file, FilterConfig, SessionSource, FACET_SYSTEM_PROMPT,
 };
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::Semaphore;
 
 mod legacy_migration;
@@ -34,6 +37,21 @@ mod quarantine;
 use quarantine::{record_key as quarantine_key, QuarantineStore};
 
 const DEFAULT_CONCURRENCY: usize = 1;
+const INGEST_CURSOR_VERSION: u8 = 2;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct IngestCursorFailure {
+    path_sha256: String,
+    modified_at_secs: u64,
+    reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct IngestCursorState {
+    version: u8,
+    watermark_secs: u64,
+    failures: Vec<IngestCursorFailure>,
+}
 
 fn concurrency() -> usize {
     std::env::var("REFINE_INGEST_CONCURRENCY")
@@ -156,23 +174,85 @@ fn encode_path_for_filename(path: &Path) -> String {
 fn read_last_ingest_mtime(source: Option<&SessionSource>, db_path: &Path) -> Option<SystemTime> {
     let home = dirs::home_dir()?;
     let path = incremental_cursor_path(&home, source, db_path);
-    let secs: u64 = std::fs::read_to_string(path).ok()?.trim().parse().ok()?;
+    let secs = parse_ingest_cursor(&std::fs::read_to_string(path).ok()?)?;
     Some(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
 }
 
+fn parse_ingest_cursor(raw: &str) -> Option<u64> {
+    let trimmed = raw.trim();
+    trimmed.parse::<u64>().ok().or_else(|| {
+        serde_json::from_str::<IngestCursorState>(trimmed)
+            .ok()
+            .filter(|state| state.version == INGEST_CURSOR_VERSION)
+            .map(|state| state.watermark_secs)
+    })
+}
+
 /// Persist the Unix-second timestamp to the scoped ingest cursor file.
-fn write_last_ingest_mtime(source: Option<&SessionSource>, db_path: &Path, t: SystemTime) {
-    let Some(home) = dirs::home_dir() else { return };
+fn write_last_ingest_mtime(
+    source: Option<&SessionSource>,
+    db_path: &Path,
+    t: SystemTime,
+    failures: Vec<IngestCursorFailure>,
+) -> Result<()> {
+    let home = dirs::home_dir().context("home directory is unavailable for ingest cursor")?;
     let path = incremental_cursor_path(&home, source, db_path);
-    let Some(dir) = path.parent() else { return };
-    if let Err(e) = std::fs::create_dir_all(dir) {
-        tracing::warn!("failed to create {}: {}", dir.display(), e);
-        return;
-    }
-    if let Ok(dur) = t.duration_since(SystemTime::UNIX_EPOCH) {
-        if let Err(e) = std::fs::write(&path, dur.as_secs().to_string()) {
-            tracing::warn!("failed to write {}: {}", path.display(), e);
-        }
+    write_ingest_cursor_at(
+        &path,
+        &IngestCursorState {
+            version: INGEST_CURSOR_VERSION,
+            watermark_secs: unix_seconds(t),
+            failures,
+        },
+    )
+}
+
+fn safe_cursor_watermark(scan_start: SystemTime, failed_mtimes: &[SystemTime]) -> SystemTime {
+    failed_mtimes
+        .iter()
+        .copied()
+        .min()
+        .map(|failed| {
+            failed
+                .checked_sub(Duration::from_secs(1))
+                .unwrap_or(UNIX_EPOCH)
+        })
+        .map_or(scan_start, |safe| safe.min(scan_start))
+}
+
+fn write_ingest_cursor_at(path: &Path, state: &IngestCursorState) -> Result<()> {
+    let dir = path
+        .parent()
+        .context("ingest cursor has no parent directory")?;
+    std::fs::create_dir_all(dir).with_context(|| format!("failed to create {}", dir.display()))?;
+    let nonce = Utc::now().timestamp_nanos_opt().unwrap_or_default();
+    let temp_path = path.with_extension(format!("tmp-{}-{nonce}", std::process::id()));
+    let payload = serde_json::to_vec(state).context("failed to serialize ingest cursor")?;
+    let mut temp = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+        .with_context(|| format!("failed to create {}", temp_path.display()))?;
+    temp.write_all(&payload)
+        .with_context(|| format!("failed to write {}", temp_path.display()))?;
+    temp.sync_all()
+        .with_context(|| format!("failed to sync {}", temp_path.display()))?;
+    drop(temp);
+    std::fs::rename(&temp_path, path)
+        .with_context(|| format!("failed to replace {}", path.display()))?;
+    Ok(())
+}
+
+fn unix_seconds(t: SystemTime) -> u64 {
+    t.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+fn cursor_failure(path: &Path, modified_at: SystemTime, reason: &str) -> IngestCursorFailure {
+    let digest = Sha256::digest(path.to_string_lossy().as_bytes());
+    IngestCursorFailure {
+        path_sha256: format!("{digest:x}"),
+        modified_at_secs: unix_seconds(modified_at),
+        reason: reason.to_string(),
     }
 }
 
@@ -450,6 +530,7 @@ async fn handle_legacy_ingest_sessions(
     let mut skipped_dup = 0usize;
     let mut skipped_filter = 0usize;
     let mut stale_refresh = 0usize;
+    let mut parse_failures = Vec::new();
 
     // 阶段 1: 串行做去重 + 过滤 + 解析（快，不需要 LLM）
     for (idx, ds) in sessions_to_process.iter().enumerate() {
@@ -460,9 +541,18 @@ async fn handle_legacy_ingest_sessions(
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!("解析失败 {}: {}", legacy_url, e);
+                parse_failures.push(cursor_failure(&ds.path, ds.modified_at, "parse_error"));
                 continue;
             }
         };
+        if session.meta.truncated_tail {
+            tracing::warn!(
+                path = %ds.path.display(),
+                "会话文件尾部仍在写入；本次不保存，下一轮重试"
+            );
+            parse_failures.push(cursor_failure(&ds.path, ds.modified_at, "truncated_tail"));
+            continue;
+        }
 
         let project = project_for_ingest(ds.project.as_deref(), session.meta.project.as_deref());
         let has_embedded_timestamp = session.meta.started_at.is_some();
@@ -568,7 +658,7 @@ async fn handle_legacy_ingest_sessions(
         });
     }
 
-    process_pending_sessions(
+    let process_result = process_pending_sessions(
         pending,
         total,
         skipped_dup,
@@ -579,11 +669,20 @@ async fn handle_legacy_ingest_sessions(
         doc_store,
         llm_client,
     )
-    .await?;
+    .await;
 
-    // Advance the incremental scan cursor so the next run only sees newer files.
-    if incremental && !options.dry_run {
-        write_last_ingest_mtime(source.as_ref(), db_path, scan_start);
+    if incremental && process_result.is_ok() {
+        let failed_mtimes = parse_failures
+            .iter()
+            .map(|failure| UNIX_EPOCH + Duration::from_secs(failure.modified_at_secs))
+            .collect::<Vec<_>>();
+        let watermark = safe_cursor_watermark(scan_start, &failed_mtimes);
+        write_last_ingest_mtime(source.as_ref(), db_path, watermark, parse_failures.clone())?;
+    }
+
+    process_result?;
+    if !parse_failures.is_empty() {
+        anyhow::bail!("{} 个会话文件解析失败或仍在写入", parse_failures.len());
     }
 
     Ok(())

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -263,6 +263,63 @@ fn cursor_is_partitioned_by_database_path() {
     );
 }
 
+#[test]
+fn safe_cursor_stays_before_oldest_failed_file() {
+    let scan_start = SystemTime::UNIX_EPOCH + Duration::from_secs(20_000);
+    let failures = [
+        SystemTime::UNIX_EPOCH + Duration::from_secs(15_000),
+        SystemTime::UNIX_EPOCH + Duration::from_secs(12_000),
+    ];
+    assert_eq!(
+        safe_cursor_watermark(scan_start, &failures),
+        SystemTime::UNIX_EPOCH + Duration::from_secs(11_999)
+    );
+    assert_eq!(safe_cursor_watermark(scan_start, &[]), scan_start);
+}
+
+#[test]
+fn cursor_write_atomically_replaces_previous_value() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("cursor/state");
+    let first = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let second = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+    let first = IngestCursorState {
+        version: INGEST_CURSOR_VERSION,
+        watermark_secs: unix_seconds(first),
+        failures: Vec::new(),
+    };
+    let second = IngestCursorState {
+        version: INGEST_CURSOR_VERSION,
+        watermark_secs: unix_seconds(second),
+        failures: vec![IngestCursorFailure {
+            path_sha256: "abc".to_string(),
+            modified_at_secs: 19,
+            reason: "parse_error".to_string(),
+        }],
+    };
+    write_ingest_cursor_at(&path, &first).expect("first cursor write");
+    write_ingest_cursor_at(&path, &second).expect("replace cursor");
+    let loaded: IngestCursorState =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(loaded, second);
+    assert_eq!(fs::read_dir(path.parent().unwrap()).unwrap().count(), 1);
+}
+
+#[test]
+fn cursor_reader_accepts_legacy_seconds_and_v2_state() {
+    assert_eq!(parse_ingest_cursor("42\n"), Some(42));
+    let state = IngestCursorState {
+        version: INGEST_CURSOR_VERSION,
+        watermark_secs: 84,
+        failures: Vec::new(),
+    };
+    assert_eq!(
+        parse_ingest_cursor(&serde_json::to_string(&state).unwrap()),
+        Some(84)
+    );
+    assert_eq!(parse_ingest_cursor("not a cursor"), None);
+}
+
 fn read_last_ingest_mtime_at(
     home: &Path,
     source: Option<&SessionSource>,

--- a/apps/cli/src/ingest_sessions/tests.rs
+++ b/apps/cli/src/ingest_sessions/tests.rs
@@ -44,6 +44,31 @@ struct SequenceLlmClient {
     calls: AtomicUsize,
 }
 
+struct AppendingLlmClient {
+    path: PathBuf,
+    record: String,
+    response: String,
+    appended: AtomicBool,
+}
+
+#[async_trait]
+impl LlmClient for AppendingLlmClient {
+    async fn complete(&self, _prompt: &str, _system: Option<&str>) -> InfraResult<String> {
+        if !self.appended.swap(true, Ordering::SeqCst) {
+            use std::io::Write as _;
+            let mut file = fs::OpenOptions::new()
+                .append(true)
+                .open(&self.path)
+                .expect("active transcript should remain appendable");
+            file.write_all(self.record.as_bytes())
+                .expect("active writer should append a complete JSONL record");
+            file.sync_all()
+                .expect("appended transcript record should reach the file");
+        }
+        Ok(self.response.clone())
+    }
+}
+
 impl SequenceLlmClient {
     fn new(responses: Vec<String>) -> Self {
         Self {
@@ -163,17 +188,136 @@ async fn facet_parse_error_retries_then_succeeds() {
 }
 
 #[test]
-fn session_needs_refresh_when_file_mtime_is_newer_than_saved_document() {
-    let mut doc = Document::new("codex-session", "raw");
+fn session_refresh_uses_source_content_instead_of_ingest_timestamp() {
+    let old_raw = "User: first message\n";
+    let old_version = content_source_version("local", old_raw);
+    let mut doc = Document::new("codex-session", old_raw);
     doc.set_url("file:///tmp/session.jsonl");
+    doc.set_source_version(Some(&old_version));
 
-    let old_mtime = SystemTime::now()
-        .checked_sub(Duration::from_secs(60))
-        .unwrap();
-    assert!(!session_needs_refresh(&doc, old_mtime));
+    assert!(!session_needs_refresh(&doc, &old_version, old_raw));
 
-    let new_mtime = SystemTime::now() + Duration::from_millis(200);
-    assert!(session_needs_refresh(&doc, new_mtime));
+    // Model a complete JSONL record appended while the previous snapshot is
+    // being processed. The database write can be newer than the append, so
+    // mtime compared with Document.updated_at is not a valid freshness check.
+    let appended_raw = "User: first message\nAssistant: appended while LLM was running\n";
+    let appended_version = content_source_version("local", appended_raw);
+    assert!(session_needs_refresh(&doc, &appended_version, appended_raw));
+
+    // Legacy documents without a source_version still use an exact content
+    // comparison, never the later database ingestion timestamp.
+    let legacy_doc = Document::new("codex-session", old_raw);
+    assert!(!session_needs_refresh(&legacy_doc, &old_version, old_raw));
+    assert!(session_needs_refresh(
+        &legacy_doc,
+        &appended_version,
+        appended_raw
+    ));
+}
+
+#[tokio::test]
+async fn complete_record_appended_during_llm_is_ingested_on_next_pass() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("active.jsonl");
+    fs::write(
+        &path,
+        "{\"type\":\"user\",\"message\":{\"content\":\"first\"}}\n",
+    )
+    .unwrap();
+
+    let first_session = parse_session_file(&path, SessionSource::ClaudeCode).unwrap();
+    assert!(!first_session.meta.truncated_tail);
+    let first_raw = first_session.to_document_content();
+    let first_version = content_source_version("local", &first_raw);
+    let url = path.to_string_lossy().to_string();
+    let store = Arc::new(SqliteStore::in_memory().unwrap());
+    let doc_store: Arc<dyn DocumentRepository> = store.clone();
+    let response = r#"{
+        "session_summary": "active snapshot",
+        "cognitive_level": "proficient",
+        "collaboration_mode": "pair_programming",
+        "decisions": [], "bugs_fixed": [], "patterns": [], "friction": [],
+        "project_progress": [], "questions": [], "knowledge_gained": [],
+        "tools_discovered": [], "architecture": [], "code_artifacts": []
+    }"#
+    .to_string();
+    let appending_client: Arc<dyn LlmClient> = Arc::new(AppendingLlmClient {
+        path: path.clone(),
+        record: concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[",
+            "{\"type\":\"text\",\"text\":\"appended\"}]}}\n"
+        )
+        .to_string(),
+        response: response.clone(),
+        appended: AtomicBool::new(false),
+    });
+    let first_pending = PendingSession {
+        idx: 0,
+        total: 1,
+        url: url.clone(),
+        source: SessionSource::ClaudeCode,
+        project: None,
+        captured_at: Utc::now(),
+        has_embedded_timestamp: false,
+        raw_content: first_raw.clone(),
+        source_version: Some(first_version.clone()),
+        needs_chunk: false,
+        chunks: Vec::new(),
+        existing_document: None,
+        legacy_documents_to_delete: Vec::new(),
+    };
+
+    process_single_session(
+        &first_pending,
+        &appending_client,
+        &doc_store,
+        &Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+    let first_saved = doc_store.find_by_url(&url).await.unwrap().unwrap();
+    assert_eq!(first_saved.raw_content(), first_raw);
+    assert_eq!(first_saved.source_version(), Some(first_version.as_str()));
+
+    let appended_session = parse_session_file(&path, SessionSource::ClaudeCode).unwrap();
+    assert!(!appended_session.meta.truncated_tail);
+    assert_eq!(appended_session.messages.len(), 2);
+    let appended_raw = appended_session.to_document_content();
+    let appended_version = content_source_version("local", &appended_raw);
+    assert!(session_needs_refresh(
+        &first_saved,
+        &appended_version,
+        &appended_raw
+    ));
+
+    let second_pending = PendingSession {
+        idx: 0,
+        total: 1,
+        url: url.clone(),
+        source: SessionSource::ClaudeCode,
+        project: None,
+        captured_at: Utc::now(),
+        has_embedded_timestamp: false,
+        raw_content: appended_raw.clone(),
+        source_version: Some(appended_version.clone()),
+        needs_chunk: false,
+        chunks: Vec::new(),
+        existing_document: Some(first_saved),
+        legacy_documents_to_delete: Vec::new(),
+    };
+    let static_client: Arc<dyn LlmClient> = Arc::new(StaticLlmClient { response });
+    process_single_session(
+        &second_pending,
+        &static_client,
+        &doc_store,
+        &Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let refreshed = doc_store.find_by_url(&url).await.unwrap().unwrap();
+    assert_eq!(refreshed.raw_content(), appended_raw);
+    assert_eq!(refreshed.source_version(), Some(appended_version.as_str()));
 }
 
 #[test]

--- a/apps/cli/src/remem_sessions.rs
+++ b/apps/cli/src/remem_sessions.rs
@@ -360,6 +360,7 @@ fn load_one_session<R: Runner>(runner: &R, summary: RememSessionSummary) -> Resu
                 project: None,
                 model: None,
                 started_at: Some(started_at),
+                truncated_tail: false,
             },
         },
     };

--- a/packages/core/src/session/parser.rs
+++ b/packages/core/src/session/parser.rs
@@ -2,11 +2,11 @@
 //!
 //! 支持 Claude Code 和 Codex 两种格式
 //!
-//! 解析策略：line-level error recovery。
+//! 解析策略：只容忍 append-only 文件的尾部截断。
 //! JSONL 是 append-only 流；当进程被 SIGKILL 或盘满时常见尾行被截断，
-//! 中途偶发损坏行不应该让整个会话被丢弃。每条 line 独立解析：
 //! - 解析成功 → 累积到 messages / meta
-//! - 解析失败 → 记 warn 日志（带 line index 与截断 snippet），继续下一行
+//! - 最后一个非空行在 EOF 截断 → 保留合法前缀并标记 `truncated_tail`
+//! - 中间损坏或完整写入的非法末行 → 整个文件失败，避免用缺行快照覆盖完整数据
 //!
 //! 同时从原始 JSONL 提取首个时间戳填充 `SessionMeta.started_at`，
 //! 弥补先前的 declaration-execution gap（字段定义但从未写入）。
@@ -15,9 +15,6 @@ use super::types::{MessageRole, Session, SessionMessage, SessionMeta, SessionSou
 use chrono::{DateTime, Utc};
 use std::path::Path;
 use tracing::warn;
-
-/// 单行 snippet 在日志里的最大长度，避免泄漏整条原始内容到日志后端。
-const SNIPPET_MAX: usize = 120;
 
 /// 单个 session 文件大小上限（200 MiB）。
 ///
@@ -50,8 +47,8 @@ pub fn parse_session_file(path: &Path, source: SessionSource) -> Result<Session,
 
 /// 解析 JSONL 字符串内容为 Session（可测试）
 ///
-/// 返回 `Err` 仅在调用方传入完全无法处理的输入时；单行 JSON 错误不会
-/// 中断整个文件解析，遵循 JSONL append-only 流的容错惯例。
+/// 中间 JSON 错误返回 `Err`。只有没有换行结尾且 serde 报告 EOF 的最后
+/// 一个非空记录会作为 append-in-progress 尾部截断被标记并容忍。
 pub fn parse_session_content(
     content: &str,
     path: &Path,
@@ -62,7 +59,12 @@ pub fn parse_session_content(
     }
     let mut messages = Vec::new();
     let mut meta = SessionMeta::default();
-    let mut malformed = 0usize;
+    let last_nonempty_line = content
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| !line.trim().is_empty())
+        .map(|(idx, _)| idx)
+        .last();
 
     for (idx, line) in content.lines().enumerate() {
         let line = line.trim();
@@ -72,15 +74,24 @@ pub fn parse_session_content(
         let value: serde_json::Value = match serde_json::from_str(line) {
             Ok(v) => v,
             Err(e) => {
-                malformed += 1;
-                warn!(
-                    path = %path.display(),
-                    line = idx + 1,
-                    error = %e,
-                    snippet = %truncate_snippet(line),
-                    "skipping malformed JSONL line"
-                );
-                continue;
+                let is_truncated_tail =
+                    Some(idx) == last_nonempty_line && !content.ends_with('\n') && e.is_eof();
+                if is_truncated_tail {
+                    meta.truncated_tail = true;
+                    warn!(
+                        path = %path.display(),
+                        line = idx + 1,
+                        error = %e,
+                        "session JSONL has a truncated tail; preserving parsed prefix"
+                    );
+                    break;
+                }
+                return Err(format!(
+                    "JSONL 解析失败 {}:{}: {}",
+                    path.display(),
+                    idx + 1,
+                    e
+                ));
             }
         };
 
@@ -97,37 +108,12 @@ pub fn parse_session_content(
         }
     }
 
-    if malformed > 0 {
-        warn!(
-            path = %path.display(),
-            malformed,
-            kept = messages.len(),
-            "JSONL parse completed with skipped lines"
-        );
-    }
-
     Ok(Session {
         source,
         file_path: path.to_path_buf(),
         messages,
         meta,
     })
-}
-
-/// 截断单行内容用于日志输出。
-fn truncate_snippet(line: &str) -> String {
-    if line.len() <= SNIPPET_MAX {
-        line.to_string()
-    } else {
-        // char_indices 避免在 UTF-8 字符中间切断。
-        let cut = line
-            .char_indices()
-            .take_while(|(i, _)| *i < SNIPPET_MAX)
-            .last()
-            .map(|(i, c)| i + c.len_utf8())
-            .unwrap_or(0);
-        format!("{}…", &line[..cut])
-    }
 }
 
 /// 解析 ISO-8601 字符串为 `DateTime<Utc>`。
@@ -525,25 +511,35 @@ mod tests {
         assert_eq!(session.messages.len(), 2);
         assert_eq!(session.messages[0].content, "hello");
         assert_eq!(session.messages[1].content, "hi");
+        assert!(session.meta.truncated_tail);
     }
 
-    /// 中段单行损坏：仅丢弃损坏行，前后行正常累积。
+    /// 中段单行损坏不能被当成完整 transcript。
     #[test]
     fn parse_recovers_from_midstream_corruption() {
         let jsonl = r#"{"type":"user","message":{"content":"first"}}
 {not even json
 {"type":"assistant","message":{"content":[{"type":"text","text":"after corruption"}]}}
 "#;
-        let session = parse_session_content(
+        let error = parse_session_content(
             jsonl,
             &PathBuf::from("/tmp/midcorrupt.jsonl"),
             SessionSource::ClaudeCode,
         )
-        .unwrap();
+        .expect_err("middle corruption must fail the entire session");
+        assert!(error.contains(":2:"), "unexpected error: {error}");
+    }
 
-        assert_eq!(session.messages.len(), 2);
-        assert_eq!(session.messages[0].content, "first");
-        assert_eq!(session.messages[1].content, "after corruption");
+    #[test]
+    fn invalid_final_record_with_newline_is_not_treated_as_in_progress() {
+        let jsonl = "{\"type\":\"user\",\"message\":{\"content\":\"first\"}}\n{bad}\n";
+        let error = parse_session_content(
+            jsonl,
+            &PathBuf::from("/tmp/invalid-final.jsonl"),
+            SessionSource::ClaudeCode,
+        )
+        .expect_err("fully written invalid tail must fail");
+        assert!(error.contains(":2:"), "unexpected error: {error}");
     }
 
     #[test]
@@ -633,21 +629,5 @@ mod tests {
             .expect("should fall through to next valid ts");
         assert_eq!(started.to_rfc3339(), "2026-04-21T05:00:00+00:00");
         assert_eq!(session.messages.len(), 2);
-    }
-
-    #[test]
-    fn truncate_snippet_handles_utf8_boundaries() {
-        // 多字节字符在 SNIPPET_MAX 边界附近时不应导致越界 panic。
-        let s: String = "中".repeat(80); // 240 bytes, well past SNIPPET_MAX
-        let out = truncate_snippet(&s);
-        assert!(out.ends_with('…'));
-        // 必须仍是合法 UTF-8（如果切坏 String 构造会 panic）
-        assert!(!out.is_empty());
-    }
-
-    #[test]
-    fn truncate_snippet_passthrough_for_short_lines() {
-        let out = truncate_snippet("short");
-        assert_eq!(out, "short");
     }
 }

--- a/packages/core/src/session/types.rs
+++ b/packages/core/src/session/types.rs
@@ -44,6 +44,10 @@ pub struct SessionMeta {
     pub project: Option<String>,
     pub model: Option<String>,
     pub started_at: Option<DateTime<Utc>>,
+    /// The final JSONL record ended at EOF before it became valid JSON. The
+    /// parsed prefix is useful for inspection, but must not replace a complete
+    /// persisted snapshot or advance an incremental ingest cursor.
+    pub truncated_tail: bool,
 }
 
 /// 统一会话结构


### PR DESCRIPTION
Closes #176

## Summary
- reject malformed middle JSONL records and distinguish an in-progress truncated tail
- prevent incomplete local transcripts from replacing persisted documents
- persist a backward-compatible cursor v2 with a safe watermark and hashed failure records
- advance the cursor only after successful extraction work and surface cursor write failures

## Verification
- `cargo test -p refine-core`
- `cargo test -p refine-cli`
- `cargo clippy -p refine-core -p refine-cli --lib --bins -- -D warnings`
- `cargo fmt --all -- --check`
- parser corruption/tail and cursor compatibility/watermark/atomic replacement tests